### PR TITLE
修复Timeline组件PDF导出样式和颜色问题

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -237,9 +237,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
-      "version": "18.19.111",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.111.tgz",
-      "integrity": "sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==",
+      "version": "18.19.115",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.115.tgz",
+      "integrity": "sha512-kNrFiTgG4a9JAn1LMQeLOv3MvXIPokzXziohMrMsvpYgLpdEt/mMiVYc4sGKtDfyxM5gIDF4VgrPRyCw4fHOYg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -252,33 +252,6 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
     },
     "node_modules/@babel/runtime": {
       "version": "7.27.6",
@@ -306,9 +279,9 @@
       }
     },
     "node_modules/@browserbasehq/sdk/node_modules/@types/node": {
-      "version": "18.19.111",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.111.tgz",
-      "integrity": "sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==",
+      "version": "18.19.115",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.115.tgz",
+      "integrity": "sha512-kNrFiTgG4a9JAn1LMQeLOv3MvXIPokzXziohMrMsvpYgLpdEt/mMiVYc4sGKtDfyxM5gIDF4VgrPRyCw4fHOYg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -349,15 +322,16 @@
       "license": "MIT"
     },
     "node_modules/@clerk/backend": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/@clerk/backend/-/backend-2.1.0.tgz",
-      "integrity": "sha512-Ltb3IzdGeahM1Jr+u0UAVnVjEIYXUsq9/mTb1adolsOc9oR2LCKHE7rTRnmkwY8y+IwCzXVuywIYW+zLTk47+Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.4.0.tgz",
+      "integrity": "sha512-CTnd6Ut7lQDSvfEBtD+JHbGE4wIbKIp2zbeYkeGN9IP6wA6gZ++T7FQPGItLzGQmipCX3GPQ6mvEFf/ch39BwA==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.9.7",
-        "@clerk/types": "^4.60.1",
+        "@clerk/shared": "^3.10.2",
+        "@clerk/types": "^4.63.0",
         "cookie": "1.0.2",
         "snakecase-keys": "8.0.1",
+        "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -365,13 +339,13 @@
       }
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "5.32.0",
-      "resolved": "https://registry.npmmirror.com/@clerk/clerk-react/-/clerk-react-5.32.0.tgz",
-      "integrity": "sha512-RdipOVBdbUbFaDb8kF3EzhJw0eh5LPxSWWRTu4k+pOdRB1gzETiToLchj5nDWFkl8qW/uL4gQbZH+Pfc7izO0A==",
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.32.4.tgz",
+      "integrity": "sha512-+tGhLXkmf5XmuetT7oYPwASw3sa1bQcV25VAnb3Vn0k3DqbTcD2blAxTd3Ks98E0VbeACSR3oJkmF5TnzOquEQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.9.7",
-        "@clerk/types": "^4.60.1",
+        "@clerk/shared": "^3.10.2",
+        "@clerk/types": "^4.63.0",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -383,15 +357,15 @@
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmmirror.com/@clerk/nextjs/-/nextjs-6.22.0.tgz",
-      "integrity": "sha512-Lh+hq4iuvuSgiWSDHDM9BAM8+YZU/wtADGo2TAU7FBVEZ6I3SwyXo5JEY4F7s30TpH3kS9qC/Ye3YA6VIOOu7Q==",
+      "version": "6.23.3",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.23.3.tgz",
+      "integrity": "sha512-N7pJI23UAzenz4Auz73vlUYjKtRYnsAIUeI+m4DwsaxQfmFXeQLvi0Nlq5aZ6JlFyara8jxAzhvW2aBPdPbVvw==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^2.1.0",
-        "@clerk/clerk-react": "^5.32.0",
-        "@clerk/shared": "^3.9.7",
-        "@clerk/types": "^4.60.1",
+        "@clerk/backend": "^2.4.0",
+        "@clerk/clerk-react": "^5.32.4",
+        "@clerk/shared": "^3.10.2",
+        "@clerk/types": "^4.63.0",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
@@ -405,13 +379,13 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmmirror.com/@clerk/shared/-/shared-3.9.7.tgz",
-      "integrity": "sha512-D3iuzuDoadK6BKb7qFZEH332z4Sl5mxLuHMf8rKdIMHuOu1RQK0RqFJtKPcFvDxq0RvJ9MC+rK24P2Sa2tOoNA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.10.2.tgz",
+      "integrity": "sha512-4bp080EPX9Z/qLSdf9V22NNATC5GFjfEOtlfAOw2Xq24IAIxve3ePd92TcAsMHYThn3Pmwcj7upnvUB24IXKQw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@clerk/types": "^4.60.1",
+        "@clerk/types": "^4.63.0",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.5",
@@ -435,9 +409,9 @@
       }
     },
     "node_modules/@clerk/types": {
-      "version": "4.60.1",
-      "resolved": "https://registry.npmmirror.com/@clerk/types/-/types-4.60.1.tgz",
-      "integrity": "sha512-Lbt0/Q9W9BJtGz1IITdmeqal7y1zp9EaxOEMvsTEDhOxKf/0F/M1d0gJmHEU0puQzYPp9zJsIWC2yJjbgy3Y3Q==",
+      "version": "4.63.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.63.0.tgz",
+      "integrity": "sha512-U3FTDzKx8uGve8gtaRv/QpfhEjK/dg9m9BuzIhYEowZ56jNimXDaXuijAcCZEeKwf+DDQmAPaNOinev6D2qtiQ==",
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.3"
@@ -742,9 +716,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
-      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -757,9 +731,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
-      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -804,9 +778,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
-      "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
+      "integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -827,45 +801,58 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
-      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.14.0",
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.1.tgz",
-      "integrity": "sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
+      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.1.tgz",
-      "integrity": "sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
+      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.1",
-        "@floating-ui/utils": "^0.2.9"
+        "@floating-ui/core": "^1.7.2",
+        "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.3.tgz",
-      "integrity": "sha512-huMBfiU9UnQ2oBwIhgzyIiSpVgvlDstU8CX0AF+wS+KzmYMs0J2a3GwuFHV1Lz+jlrQGeC1fF+Nv0QoumyV0bA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.4.tgz",
+      "integrity": "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
+        "@floating-ui/dom": "^1.7.2"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -873,9 +860,9 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
     "node_modules/@google/generative-ai": {
@@ -994,9 +981,9 @@
       }
     },
     "node_modules/@ibm-cloud/watsonx-ai": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.6.7.tgz",
-      "integrity": "sha512-lyHG5pjIINc+3fVbodD+ui0kvs7xk6TRAPJasK+8d8+j/FXS6TNsNGjvP79nfQJPTTYYy9IXxFc/3Z4jAqfD7w==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@ibm-cloud/watsonx-ai/-/watsonx-ai-1.6.8.tgz",
+      "integrity": "sha512-Ip5bLDM40rQRYauRmmIIpxLO57wI3+F59Njmp0hexnVr+uKroV+O9+eAGQkdE2c9d17R16Q77ueAGheZrzqgWA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -1009,9 +996,9 @@
       }
     },
     "node_modules/@ibm-cloud/watsonx-ai/node_modules/@types/node": {
-      "version": "18.19.111",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.111.tgz",
-      "integrity": "sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==",
+      "version": "18.19.115",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.115.tgz",
+      "integrity": "sha512-kNrFiTgG4a9JAn1LMQeLOv3MvXIPokzXziohMrMsvpYgLpdEt/mMiVYc4sGKtDfyxM5gIDF4VgrPRyCw4fHOYg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1435,18 +1422,14 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+      "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -1459,27 +1442,17 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
+      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1498,57 +1471,34 @@
       }
     },
     "node_modules/@langchain/anthropic": {
-      "version": "0.3.21",
-      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-0.3.21.tgz",
-      "integrity": "sha512-iyVZ9PHcNbABVzWFWtolcDUqHYCEkl1yypRYXE98tTPiNhGo6g/MgKky96TEcOnJ0VNHD6qlzo9LhQl87OplvA==",
+      "version": "0.3.24",
+      "resolved": "https://registry.npmjs.org/@langchain/anthropic/-/anthropic-0.3.24.tgz",
+      "integrity": "sha512-Gi1TwXu5vkCxUMToiXaiwTTWq9v3WMyU3ldB/VEWjzbkr3nKF5kcp+HLqhvV7WWOFVTTNgG+pzfq8JALecq5MA==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.39.0",
-        "fast-xml-parser": "^4.4.1",
-        "zod": "^3.22.4",
-        "zod-to-json-schema": "^3.22.4"
+        "@anthropic-ai/sdk": "^0.56.0",
+        "fast-xml-parser": "^4.4.1"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": ">=0.3.48 <0.4.0"
+        "@langchain/core": ">=0.3.58 <0.4.0"
       }
     },
     "node_modules/@langchain/anthropic/node_modules/@anthropic-ai/sdk": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
-      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
+      "version": "0.56.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.56.0.tgz",
+      "integrity": "sha512-SLCB8M8+VMg1cpCucnA1XWHGWqVSZtIWzmOdDOEu3eTFZMB+A0sGZ1ESO5MHDnqrNTXz3safMrWx9x4rMZSOqA==",
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
       }
-    },
-    "node_modules/@langchain/anthropic/node_modules/@types/node": {
-      "version": "18.19.111",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.111.tgz",
-      "integrity": "sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@langchain/anthropic/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
     },
     "node_modules/@langchain/community": {
-      "version": "0.3.46",
-      "resolved": "https://registry.npmjs.org/@langchain/community/-/community-0.3.46.tgz",
-      "integrity": "sha512-loix9LkoNcn1gQlVCopmrJW9TmgZb+YpZw7nkFzXT6ozR8ZDh1XlFq1ymR5gTFtdNzF0neK2oJtE9iEl1lm7Dw==",
+      "version": "0.3.48",
+      "resolved": "https://registry.npmjs.org/@langchain/community/-/community-0.3.48.tgz",
+      "integrity": "sha512-0KceBKSx34lL5cnbKybWIMQAFTgkZJMOzcZ1YdcagIwgoDa5a4MsJdtTABxaY0gu+87Uo3KqMj+GXx2wQqnZWA==",
       "license": "MIT",
       "dependencies": {
         "@langchain/openai": ">=0.2.0 <0.6.0",
@@ -1558,7 +1508,7 @@
         "flat": "^5.0.2",
         "js-yaml": "^4.1.0",
         "langchain": ">=0.2.3 <0.3.0 || >=0.3.4 <0.4.0",
-        "langsmith": "^0.3.29",
+        "langsmith": "^0.3.33",
         "uuid": "^10.0.0",
         "zod": "^3.25.32"
       },
@@ -1593,8 +1543,8 @@
         "@google-ai/generativelanguage": "*",
         "@google-cloud/storage": "^6.10.1 || ^7.7.0",
         "@gradientai/nodejs-sdk": "^1.2.0",
-        "@huggingface/inference": "^2.6.4",
-        "@huggingface/transformers": "^3.2.3",
+        "@huggingface/inference": "^4.0.5",
+        "@huggingface/transformers": "^3.5.2",
         "@ibm-cloud/watsonx-ai": "*",
         "@lancedb/lancedb": "^0.12.0",
         "@langchain/core": ">=0.3.58 <0.4.0",
@@ -1667,7 +1617,7 @@
         "mammoth": "^1.6.0",
         "mariadb": "^3.4.0",
         "mem0ai": "^2.1.8",
-        "mongodb": ">=5.2.0",
+        "mongodb": "^6.17.0",
         "mysql2": "^3.9.8",
         "neo4j-driver": "*",
         "notion-to-md": "^3.1.0",
@@ -2071,9 +2021,9 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "0.3.58",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.58.tgz",
-      "integrity": "sha512-HLkOtVofgBHefaUae/+2fLNkpMLzEjHSavTmUF0YC7bDa5NPIZGlP80CGrSFXAeJ+WCPd8rIK8K/p6AW94inUQ==",
+      "version": "0.3.62",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.62.tgz",
+      "integrity": "sha512-GqRTcoUPnozGRMUcA6QkP7LHL/OvanGdB51Jgb0w7IIPDI3wFugxMHZ4gphnGDtxsD1tQY5ykyEpYNxFK8kl1w==",
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -2081,7 +2031,7 @@
         "camelcase": "6",
         "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.3.29",
+        "langsmith": "^0.3.33",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
         "p-retry": "4",
@@ -2094,20 +2044,19 @@
       }
     },
     "node_modules/@langchain/google-genai": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-0.2.10.tgz",
-      "integrity": "sha512-kIy0qhu7FAsShNTvuOx8uV+hf7mWk8OzJP5W9mjs1ovAIT1C9WqG1epkhexBfj4DAQfQ6E+m/oGtJ+CVsalspw==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@langchain/google-genai/-/google-genai-0.2.14.tgz",
+      "integrity": "sha512-gKe/T2LNh8wSSMJOaFmYd8cwQnDSXKtVtC6a7CFoq5nWuh0bKzhItM/7bue1aMN8mlKfB2G1HCwxhaZoSpS/DA==",
       "license": "MIT",
       "dependencies": {
         "@google/generative-ai": "^0.24.0",
-        "uuid": "^11.1.0",
-        "zod-to-json-schema": "^3.22.4"
+        "uuid": "^11.1.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": ">=0.3.55 <0.4.0"
+        "@langchain/core": ">=0.3.58 <0.4.0"
       }
     },
     "node_modules/@langchain/google-genai/node_modules/uuid": {
@@ -2124,9 +2073,9 @@
       }
     },
     "node_modules/@langchain/langgraph": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-0.3.3.tgz",
-      "integrity": "sha512-dB1HFTe2sY96ep8eHilEo7EH+j+9Zn/X2juZK5NyPWEJLoG1+t2N6MzKo1bkwwzRHaGpbMNDJUWpR2bZ9nWUcA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph/-/langgraph-0.3.6.tgz",
+      "integrity": "sha512-TMRUEPb/eC5mS8XdY6gwLGX2druwFDxSWUQDXHHNsbrqhIrL3BPlw+UumjcKBQ8wvhk3gEspg4aHXGq8mAqbRA==",
       "license": "MIT",
       "dependencies": {
         "@langchain/langgraph-checkpoint": "~0.0.18",
@@ -2163,9 +2112,9 @@
       }
     },
     "node_modules/@langchain/langgraph-sdk": {
-      "version": "0.0.84",
-      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-0.0.84.tgz",
-      "integrity": "sha512-l0PFQyJ+6m6aclORNPPWlcRwgKcXVXsPaJCbCUYFABR3yf4cOpsjhUNR0cJ7+2cS400oieHjGRdGGyO/hbSjhg==",
+      "version": "0.0.89",
+      "resolved": "https://registry.npmjs.org/@langchain/langgraph-sdk/-/langgraph-sdk-0.0.89.tgz",
+      "integrity": "sha512-TFNFfhVxAljV4dFJa53otnT3Ox0uN24ZdW7AfV1rTPe4QTnonxlRGEUl3SSky1CaaVxYaHN9dJyn9zyhxr2jVQ==",
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.15",
@@ -2200,27 +2149,47 @@
       }
     },
     "node_modules/@langchain/openai": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.5.12.tgz",
-      "integrity": "sha512-k7rxBY3ed/HIiMLd6HBqFibsfB0+L6c82H8JgXDqKeyUoACJIi1JaKHXmofmCeF2SBXBU9dog4gEGpHfcUDGUA==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.5.16.tgz",
+      "integrity": "sha512-TqzPE3PM0bMkQi53qs8vCFkwaEp3VgwGw+s1e8Nas5ICCZZtc2XqcDPz4hf2gpo1k7/AZd6HuPlAsDy6wye9Qw==",
       "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.12",
-        "openai": "^4.96.0",
-        "zod": "^3.22.4",
-        "zod-to-json-schema": "^3.22.3"
+        "openai": "^5.3.0",
+        "zod": "^3.25.32"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": ">=0.3.48 <0.4.0"
+        "@langchain/core": ">=0.3.58 <0.4.0"
+      }
+    },
+    "node_modules/@langchain/openai/node_modules/openai": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.8.2.tgz",
+      "integrity": "sha512-8C+nzoHYgyYOXhHGN6r0fcb4SznuEn1R7YZMvlqDbnCuE0FM2mm3T1HiYW6WIcMS/F1Of2up/cSPjLPaWt0X9Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@langchain/tavily": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@langchain/tavily/-/tavily-0.1.3.tgz",
-      "integrity": "sha512-lEbhhhGuAxkrbWYXWXsBN+8r2K7+aNeNP/bCGfhUoi5RdCQpCfqpsnXOx4f7du8FirFlwgUgNoW+bZbKRF5Pzg==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@langchain/tavily/-/tavily-0.1.4.tgz",
+      "integrity": "sha512-8hlZYMmqZ7oVsH9G8eq6hXq8UTgwmrXAUP6MZXNN+31SPCkFn31dK8JyEA1OI9paC6Rcgc2XMT36oy7tARKOwA==",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.25.32"
@@ -2248,9 +2217,9 @@
       }
     },
     "node_modules/@langchain/weaviate": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@langchain/weaviate/-/weaviate-0.2.0.tgz",
-      "integrity": "sha512-gAtTCxSllR8Z92qAuRn2ir0cop241VmftQHQN+UYtTeoLge8hvZT5k0j55PDVaXTVpjx0ecx6DKv5I/wLRQI+A==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@langchain/weaviate/-/weaviate-0.2.1.tgz",
+      "integrity": "sha512-rlfAKF+GB0A5MUrol34oDrBkl4q6AefARk9KDW+LfzhV/74pZZLZyIPYPxvE4XwI3gvpwp024DNsDxK/4UW0/g==",
       "license": "MIT",
       "dependencies": {
         "uuid": "^10.0.0",
@@ -2336,9 +2305,9 @@
       }
     },
     "node_modules/@next/bundle-analyzer": {
-      "version": "15.3.4",
-      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-15.3.4.tgz",
-      "integrity": "sha512-AN9H9S+4WaIIahyJBGe6arLj5kopvVZPLffAJsDhkbQPGqirYqaHhwO6vheytXtdq3xNjwJLpbmYNa5ZQnitSw==",
+      "version": "15.3.5",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-15.3.5.tgz",
+      "integrity": "sha512-r1tlg7N4IUWpdqdy8/6bf7pvo2yeN9Oc6OHEiMsMfIooJ5k37Odi9HC1qBS4soULNE7FiQ18JP/TdmQKiaIkoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2598,7 +2567,7 @@
     },
     "node_modules/@panva/hkdf": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmmirror.com/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
       "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
       "license": "MIT",
       "funding": {
@@ -2930,13 +2899,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.0.tgz",
-      "integrity": "sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==",
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.2.tgz",
+      "integrity": "sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "playwright": "1.53.0"
+        "playwright": "1.53.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4631,12 +4600,6 @@
         "yoga-layout": "^3.2.1"
       }
     },
-    "node_modules/@react-pdf/layout/node_modules/emoji-regex": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-      "license": "MIT"
-    },
     "node_modules/@react-pdf/pdfkit": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-4.0.3.tgz",
@@ -4680,12 +4643,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
-      "version": "0.25.0-rc-603e6108-20241029",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
-      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
-      "license": "MIT"
     },
     "node_modules/@react-pdf/render": {
       "version": "4.3.0",
@@ -4767,9 +4724,9 @@
       }
     },
     "node_modules/@react-three/drei": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.2.0.tgz",
-      "integrity": "sha512-zd65A1f4Wy6rPt1kro0ZVNXl0D4CMzmwb8TU0yNOrnGquHB41hZcncRMPf9G4D4ue8mmIrYNv//8Gjexl2T8Kg==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.4.2.tgz",
+      "integrity": "sha512-DbZXdqXL47MvFoI5mnYZkN7FJqVcekavj1bJMLFTvS161iLtFWoawe5NdcvgTG62D38DIfvaJJ244Fhu7QxbEA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
@@ -4807,9 +4764,9 @@
       }
     },
     "node_modules/@react-three/fiber": {
-      "version": "9.1.2",
-      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.1.2.tgz",
-      "integrity": "sha512-k8FR9yVHV9kIF3iuOD0ds5hVymXYXfgdKklqziBVod9ZEJ8uk05Zjw29J/omU3IKeUfLNAIHfxneN3TUYM4I2w==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.2.0.tgz",
+      "integrity": "sha512-esZe+E9T/aYEM4HlBkirr/yRE8qWTp9WUsLISyHHMCHKlJv85uc5N4wwKw+Ay0QeTSITw6T9Q3Svpu383Q+CSQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.8",
@@ -4876,9 +4833,9 @@
       "license": "MIT"
     },
     "node_modules/@rushstack/eslint-patch": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.11.0.tgz",
-      "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
+      "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
       "license": "MIT"
     },
@@ -4908,6 +4865,12 @@
         "node": ">=20.11.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -4915,18 +4878,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.9.tgz",
-      "integrity": "sha512-ZFsgw6lbtcZKYPWvf6zAuCVSuer7UQ2Z5P8BETHcpA4x/3NwOjAIXmRnYfG77F14f9bPeuR4GaNz3ji1JkQMeQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.11.tgz",
+      "integrity": "sha512-yzhzuGRmv5QyU9qLNg4GTlYI6STedBWRE7NjxP45CsFYYq9taI0zJXZBMqIC/c8fViNLhmrbpSFS57EoxUmD6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4936,13 +4899,13 @@
         "lightningcss": "1.30.1",
         "magic-string": "^0.30.17",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.1.9"
+        "tailwindcss": "4.1.11"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.9.tgz",
-      "integrity": "sha512-oqjNxOBt1iNRAywjiH+VFsfovx/hVt4mxe0kOkRMAbbcCwbJg5e2AweFqyGN7gtmE1TJXnvnyX7RWTR1l72ciQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.11.tgz",
+      "integrity": "sha512-Q69XzrtAhuyfHo+5/HMgr1lAiPP/G40OMFAnws7xcFEYqcypZmdW8eGXaOUIeOl1dzPJBPENXgbjsOyhg2nkrg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4954,24 +4917,24 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.1.9",
-        "@tailwindcss/oxide-darwin-arm64": "4.1.9",
-        "@tailwindcss/oxide-darwin-x64": "4.1.9",
-        "@tailwindcss/oxide-freebsd-x64": "4.1.9",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.9",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.9",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.1.9",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.1.9",
-        "@tailwindcss/oxide-linux-x64-musl": "4.1.9",
-        "@tailwindcss/oxide-wasm32-wasi": "4.1.9",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.9",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.1.9"
+        "@tailwindcss/oxide-android-arm64": "4.1.11",
+        "@tailwindcss/oxide-darwin-arm64": "4.1.11",
+        "@tailwindcss/oxide-darwin-x64": "4.1.11",
+        "@tailwindcss/oxide-freebsd-x64": "4.1.11",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.11",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.1.11",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.1.11",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.1.11",
+        "@tailwindcss/oxide-linux-x64-musl": "4.1.11",
+        "@tailwindcss/oxide-wasm32-wasi": "4.1.11",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.1.11",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.1.11"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.9.tgz",
-      "integrity": "sha512-X4mBUUJ3DPqODhtdT5Ju55feJwBN+hP855Z7c0t11Jzece9KRtdM41ljMrCcureKMh96mcOh2gxahkp1yE+BOQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.1.11.tgz",
+      "integrity": "sha512-3IfFuATVRUMZZprEIx9OGDjG3Ou3jG4xQzNTvjDoKmU9JdmoCohQJ83MYd0GPnQIu89YoJqvMM0G3uqLRFtetg==",
       "cpu": [
         "arm64"
       ],
@@ -4986,9 +4949,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.9.tgz",
-      "integrity": "sha512-jnWnqz71ZLXUbJLW53m9dSQakLBfaWxAd9TAibimrNdQfZKyie+xGppdDCZExtYwUdflt3kOT9y1JUgYXVEQmw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.1.11.tgz",
+      "integrity": "sha512-ESgStEOEsyg8J5YcMb1xl8WFOXfeBmrhAwGsFxxB2CxY9evy63+AtpbDLAyRkJnxLy2WsD1qF13E97uQyP1lfQ==",
       "cpu": [
         "arm64"
       ],
@@ -5003,9 +4966,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.9.tgz",
-      "integrity": "sha512-+Ui6LlvZ6aCPvSwv3l16nYb6gu1N6RamFz7hSu5aqaiPrDQqD1LPT/e8r2/laSVwFjRyOZxQQ/gvGxP3ihA2rw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.1.11.tgz",
+      "integrity": "sha512-EgnK8kRchgmgzG6jE10UQNaH9Mwi2n+yw1jWmof9Vyg2lpKNX2ioe7CJdf9M5f8V9uaQxInenZkOxnTVL3fhAw==",
       "cpu": [
         "x64"
       ],
@@ -5020,9 +4983,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.9.tgz",
-      "integrity": "sha512-BWqCh0uoXMprwWfG7+oyPW53VCh6G08pxY0IIN/i5DQTpPnCJ4zm2W8neH9kW1v1f6RXP3b2qQjAzrAcnQ5e9w==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.1.11.tgz",
+      "integrity": "sha512-xdqKtbpHs7pQhIKmqVpxStnY1skuNh4CtbcyOHeX1YBE0hArj2romsFGb6yUmzkq/6M24nkxDqU8GYrKrz+UcA==",
       "cpu": [
         "x64"
       ],
@@ -5037,9 +5000,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.9.tgz",
-      "integrity": "sha512-U8itjQb5TVc80aV5Yo+JtKo+qS95CV4XLrKEtSLQFoTD/c9j3jk4WZipYT+9Jxqem29qCMRPxjEZ3s+wTT4XCw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.1.11.tgz",
+      "integrity": "sha512-ryHQK2eyDYYMwB5wZL46uoxz2zzDZsFBwfjssgB7pzytAeCCa6glsiJGjhTEddq/4OsIjsLNMAiMlHNYnkEEeg==",
       "cpu": [
         "arm"
       ],
@@ -5054,9 +5017,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.9.tgz",
-      "integrity": "sha512-dKlGraoNvyTrR7ovLw3Id9yTwc+l0NYg8bwOkYqk+zltvGns8bPvVr6PH5jATdc75kCGd6kDRmP4p1LwqCnPJQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.1.11.tgz",
+      "integrity": "sha512-mYwqheq4BXF83j/w75ewkPJmPZIqqP1nhoghS9D57CLjsh3Nfq0m4ftTotRYtGnZd3eCztgbSPJ9QhfC91gDZQ==",
       "cpu": [
         "arm64"
       ],
@@ -5071,9 +5034,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.9.tgz",
-      "integrity": "sha512-qCZ4QTrZaBEgNM13pGjvakdmid1Kw3CUCEQzgVAn64Iud7zSxOGwK1usg+hrwrOfFH7vXZZr8OhzC8fJTRq5NA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.1.11.tgz",
+      "integrity": "sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==",
       "cpu": [
         "arm64"
       ],
@@ -5088,9 +5051,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.9.tgz",
-      "integrity": "sha512-bmzkAWQjRlY9udmg/a1bOtZpV14ZCdrB74PZrd7Oz/wK62Rk+m9+UV3BsgGfOghyO5Qu5ZDciADzDMZbi9n1+g==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.1.11.tgz",
+      "integrity": "sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==",
       "cpu": [
         "x64"
       ],
@@ -5105,9 +5068,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.9.tgz",
-      "integrity": "sha512-NpvPQsXj1raDHhd+g2SUvZQoTPWfYAsyYo9h4ZqV7EOmR+aj7LCAE5hnXNnrJ5Egy/NiO3Hs7BNpSbsPEOpORg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.1.11.tgz",
+      "integrity": "sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==",
       "cpu": [
         "x64"
       ],
@@ -5122,9 +5085,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.9.tgz",
-      "integrity": "sha512-G93Yuf3xrpTxDUCSh685d1dvOkqOB0Gy+Bchv9Zy3k+lNw/9SEgsHit50xdvp1/p9yRH2TeDHJeDLUiV4mlTkA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.1.11.tgz",
+      "integrity": "sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -5143,7 +5106,7 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@emnapi/wasi-threads": "^1.0.2",
-        "@napi-rs/wasm-runtime": "^0.2.10",
+        "@napi-rs/wasm-runtime": "^0.2.11",
         "@tybys/wasm-util": "^0.9.0",
         "tslib": "^2.8.0"
       },
@@ -5152,9 +5115,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.9.tgz",
-      "integrity": "sha512-Eq9FZzZe/NPkUiSMY+eY7r5l7msuFlm6wC6lnV11m8885z0vs9zx48AKTfw0UbVecTRV5wMxKb3Kmzx2LoUIWg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.11.tgz",
+      "integrity": "sha512-UgKYx5PwEKrac3GPNPf6HVMNhUIGuUh4wlDFR2jYYdkX6pL/rn73zTq/4pzUm8fOjAn5L8zDeHp9iXmUGOXZ+w==",
       "cpu": [
         "arm64"
       ],
@@ -5169,9 +5132,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.9.tgz",
-      "integrity": "sha512-oZ4zkthMXMJN2w/vu3jEfuqWTW7n8giGYDV/SfhBGRNehNMOBqh3YUAEv+8fv2YDJEzL4JpXTNTiSXW3UiUwBw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.1.11.tgz",
+      "integrity": "sha512-YfHoggn1j0LK7wR82TOucWc5LDCguHnoS879idHekmmiR7g9HUtMw9MI0NHatS28u/Xlkfi9w5RJWgz2Dl+5Qg==",
       "cpu": [
         "x64"
       ],
@@ -5186,23 +5149,23 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.9.tgz",
-      "integrity": "sha512-v3DKzHibZO8ioVDmuVHCW1PR0XSM7nS40EjZFJEA1xPuvTuQPaR5flE1LyikU3hu2u1KNWBtEaSe8qsQjX3tyg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.11.tgz",
+      "integrity": "sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.1.9",
-        "@tailwindcss/oxide": "4.1.9",
+        "@tailwindcss/node": "4.1.11",
+        "@tailwindcss/oxide": "4.1.11",
         "postcss": "^8.4.41",
-        "tailwindcss": "4.1.9"
+        "tailwindcss": "4.1.11"
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.14.0.tgz",
-      "integrity": "sha512-MBSMzGYRFlwYCocvx3dU7zpCBSDQ0qWByNtStaEzuBUgzCJ6wn2DP/xG0cMcLmE3Ia0VLM4nwbLOAAvBXOtylA==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.24.2.tgz",
+      "integrity": "sha512-RZ0+RdU9i88WqJF3ca1MWWDC08Ad2y9F2pytCfgohKHswNzhz0qeacoWZU/44yI15D+r320Peu6ucsy0uV+u4w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5213,9 +5176,9 @@
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.14.0.tgz",
-      "integrity": "sha512-AwqPP0jLYNioKxakiVw0vlfH/ceGFbV+SGoqBbPSGFPRdSbHhxHDNBlTtiThmT3N2PiVwXAD9xislJV+WY4GUA==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.24.2.tgz",
+      "integrity": "sha512-q8FZL34eLYXBGt2tDggEHMqNghvYmc5miTDNQUB7peb1DN5mPqY9HJT6qB+bxucZIJpqD83REX/a632x1bbk/w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5226,9 +5189,9 @@
       }
     },
     "node_modules/@tiptap/extension-bold": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.14.0.tgz",
-      "integrity": "sha512-8DWwelH55H8KtLECSIv0wh8x/F/6lpagV/pMvT+Azujad0oqK+1iAPKU/kLgjXbFSkisrpV6KSwQts5neCtfRQ==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.24.2.tgz",
+      "integrity": "sha512-gg9bQCvN/DC/cfDMwjJVrVzaO9LI7h3Y+2FgGGiCweHptJVCGcmOCPwhN+rC01FlDGJSXUm6XDY28xBaM3z/Jw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5239,9 +5202,9 @@
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.14.0.tgz",
-      "integrity": "sha512-sN15n0RjPh+2Asvxs7l47hVEvX6c0aPempU8QQWcPUlHoGf1D/XkyHXy6GWVPSxZ5Rj5uAwgKvhHsG/FJ/YGKQ==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-2.24.2.tgz",
+      "integrity": "sha512-iU/FvuPjhB06UMzziYVhU+dasCOuCY3P5uVMPuE9i4PxHACx9z20IPISeGCNoeo9LxoIfMS/9sUVLArB5WzGMA==",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
@@ -5256,9 +5219,9 @@
       }
     },
     "node_modules/@tiptap/extension-bullet-list": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.14.0.tgz",
-      "integrity": "sha512-SWnL4bP8Mm/mWN42AMQNoqYE0V6LgSBTVsHwwAki2wIUQdr9HyoAnohvHy3IME56NMwoyZyo+Mzl45wOqUxziA==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.24.2.tgz",
+      "integrity": "sha512-cIIKJauziWlhMemftWlzfWaFzgdPaRat1iSdklVfRJD+Fu710oLdL0FEIGf9MzkW8LGx5H4pASyI1fgt9NBsog==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5269,9 +5232,9 @@
       }
     },
     "node_modules/@tiptap/extension-code": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.14.0.tgz",
-      "integrity": "sha512-kyo02mnzqgwXayMcyRA/fHQgb+nMmQQpIt1irZwjtEoFZshA7NnY/6b5SJmRcxQ4/X4r2Y2Ha2sWmOcEkLmt4A==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.24.2.tgz",
+      "integrity": "sha512-dK1jOm0Xe0h8SUXVUJPj3AxWb1N4zeBkdPZFoz+iUHacpymMinH1CuukN9UpwmSi0YPfrIMKkCaw5WOEzjV8RA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5282,9 +5245,9 @@
       }
     },
     "node_modules/@tiptap/extension-code-block": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.14.0.tgz",
-      "integrity": "sha512-LRYYZeh8U2XgfTsJ4houB9s9cVRt7PRfVa4MaCeOYKfowVOKQh67yV5oom8Azk9XrMPkPxDmMmdPAEPxeVYFvw==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.24.2.tgz",
+      "integrity": "sha512-zM3skKOZyS9bhnABaSD4dgACNpXm6IjfWdhyIsIE9EcO2p6sMdyFefz0AmMDdoyJq0oSmm+JD6sblEisJOQZ9w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5296,9 +5259,9 @@
       }
     },
     "node_modules/@tiptap/extension-color": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-2.14.0.tgz",
-      "integrity": "sha512-sY+eWIbkCMAwOGH7pQ1ZuNqkqMaaHE+TsJwA7bQ6VhI2gGhhqGjT/DfmJMUen8FSdzuPoWlgtuXXCeOO6FOduw==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-2.24.2.tgz",
+      "integrity": "sha512-HngspYM6fTNM87v5rJ6tdpM0LPk59zqfRZIgZkZbfdKGLUmglh9ZdKMtiwU3rwwTEHS61OSaUpPmI8404AszAQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5310,9 +5273,9 @@
       }
     },
     "node_modules/@tiptap/extension-document": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.14.0.tgz",
-      "integrity": "sha512-qwEgpPIJ3AgXdEtRTr88hODbXRdt14VAwLj27PTSqexB5V7Ra1Jy7iQDhqRwBCoUomVywBsWYxkSuDisSRG+9w==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.24.2.tgz",
+      "integrity": "sha512-w3q1JaWZlwK8aHmF4lrFqalLssNkZoS3rjL/iS0v69q/fTI9t0WmCx5Jx427eUlNITZ5XoCL8zguKmnSPbFovg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5323,9 +5286,9 @@
       }
     },
     "node_modules/@tiptap/extension-dropcursor": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.14.0.tgz",
-      "integrity": "sha512-FIh5cdPuoPKvZ0GqSKhzMZGixm05ac3hSgqhMNCBZmXX459qBUI9CvDl/uzSnY9koBDeLVV3HYMthWQQLSXl9A==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.24.2.tgz",
+      "integrity": "sha512-yJyQeM05LBVG54ShyzJ0M9I2zALcjMrg9Kc/b6O73EWSIGLlYPhGBY/VujZFZ4OIC5i+yrKRr3nzoj68iIzwcw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5337,9 +5300,9 @@
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.14.0.tgz",
-      "integrity": "sha512-Khx7M7RfZlD1/T/PUlpJmao6FtEBa2L6td2hhaW1USflwGJGk0U/ud4UEqh+aZoJZrkot/EMhEvzmORF3nq+xw==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-2.24.2.tgz",
+      "integrity": "sha512-BSYGFW/wr5PvOu20nd7mPY8bdjlDwXmUU2xsA6NkDAVBPqVvAprr9ZDnz5Hnc74qjsIa6gWZb85ZwRxZ1MxRjw==",
       "license": "MIT",
       "dependencies": {
         "tippy.js": "^6.3.7"
@@ -5354,9 +5317,9 @@
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.14.0.tgz",
-      "integrity": "sha512-as+SqC39FRshw4Fm1XVlrdSXveiusf5xiC4nuefLmXsUxO7Yx67x8jS0/VQbxWTLHZ6R1YEW8prLtnxGmVLCAQ==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.24.2.tgz",
+      "integrity": "sha512-bp0BBw4pzjHnbjWSFaeYcffXL6Bvs8bSLRDz56qP9j/6WH6ngLBQQMmRKsJeYnzb895MZj767tB4EtgC6kzwMg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5368,9 +5331,9 @@
       }
     },
     "node_modules/@tiptap/extension-hard-break": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.14.0.tgz",
-      "integrity": "sha512-A8c8n8881iBq3AusNqibh6Hloybr+FgYdg4Lg4jNxbbEaL0WhyLFge1bWlGVpbHXFqdv5YldMUAu6Rop3FhNvw==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.24.2.tgz",
+      "integrity": "sha512-6TB9GBUTp3DIOptQubEVvL6BVKhxfLzAJwWYXjw0EkZHrK8TQPB3QIjLV/uZy29Ruji2k97ytxuxfrGoQXoXtA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5381,9 +5344,9 @@
       }
     },
     "node_modules/@tiptap/extension-heading": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.14.0.tgz",
-      "integrity": "sha512-vM//6G3Ox3mxPv9eilhrDqylELCc8kEP1aQ4xUuOw7vCidjNtGggOa1ERnnpV2dCa2A9E8y4FHtN4Xh29stXQg==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.24.2.tgz",
+      "integrity": "sha512-riUjAhiiSmdJupgRJFuHrDoXZrDpqjZYklsAcO/VyGRmp9z2Oz0LLlPTMotndCujYzGkH3jw2cz6bNo94jVoRQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5394,9 +5357,9 @@
       }
     },
     "node_modules/@tiptap/extension-history": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.14.0.tgz",
-      "integrity": "sha512-/qnOHQFCEPfkb3caykqd+sqzEC2gx30EQB/mM7+5kIG7CQy7XXaGjFAEaqzE1xJ783Q2E7GVk4JxWM+3NhYSLw==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.24.2.tgz",
+      "integrity": "sha512-D2nom9y/X62wdP0XQluo58QIPzGjEag8mI/KXiJumLOiXCBXGsubBsZWdOMi5K+4YHfsLrZnCfEDE773Y5Pgng==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5408,9 +5371,9 @@
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.14.0.tgz",
-      "integrity": "sha512-OrKWgHOhmJtVHjPYaEJetNLiNEvrI85lTrGxzeQa+a8ACb93h4svyHe9J+LHs5pKkXDQFcpYEXJntu0LVLLiDw==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.24.2.tgz",
+      "integrity": "sha512-gE0CsdOxy0zpfFtD4kTeqTEONB7EscE5zwGecuBZyrLEqk2R2b3cTM/IMDC95aknQ5YcqphlUGfVGhWiw3/USg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5422,9 +5385,9 @@
       }
     },
     "node_modules/@tiptap/extension-italic": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.14.0.tgz",
-      "integrity": "sha512-yEw2S+smoVR8DMYQMAWckVW2Sstf7z5+GBZ8zm8NMGhMKb1JFCPZUv5KTTIPnq7ZrKuuZHvjN9+Ef1dRYD8T2A==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.24.2.tgz",
+      "integrity": "sha512-gW9c0zJh4f9D2uZl13rhV8FFt7UgISLiRp4e+DynpKUkhjftDHmruii5Qw6fz9W5cf/vQcyMwCN3lO7Efqnyng==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5435,9 +5398,9 @@
       }
     },
     "node_modules/@tiptap/extension-link": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.14.0.tgz",
-      "integrity": "sha512-fsqW7eRD2xoD6xy7eFrNPAdIuZ3eicA4jKC45Vcft/Xky0DJoIehlVBLxsPbfmv3f27EBrtPkg5+msLXkLyzJA==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-2.24.2.tgz",
+      "integrity": "sha512-wsK1hqrQaJEoawsWFOdbhlaQRLtbuElAuIzGo2nOXAA3eur+fu/fTV6NebDyIroP6JUb04DMIW3w/ETYGCz0Lw==",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^4.2.0"
@@ -5452,9 +5415,9 @@
       }
     },
     "node_modules/@tiptap/extension-list-item": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.14.0.tgz",
-      "integrity": "sha512-t1jXDPEd82sC6vZVE/12/CB52uuiydCIcRfwdh21xNgBMckToKO9S0K6XEp4ROtrKQdlIH2JDVPfpUBvVrYN8Q==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.24.2.tgz",
+      "integrity": "sha512-W1goyAjBdvzITy6W+fCv6kWiXMTxF8+D+FG/9VVZOzGX0o1kIFH2szkadS73L88RgUm3RLPkMP4ZhsqTQbGI5g==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5465,9 +5428,9 @@
       }
     },
     "node_modules/@tiptap/extension-ordered-list": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.14.0.tgz",
-      "integrity": "sha512-QUZcyuW9AKvSfpFHcGmbyRCqxcpY0VNf0xipEtogxbA+JDDw3ZSPqU1dUgz9wk00RahPTwNDdY5aVjdQ5N4N9Q==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.24.2.tgz",
+      "integrity": "sha512-02IlOIv91PB1b0CS5CkjtO+BuJYpCt3Sc7NYQiG6PBK1Fr+PQ9KitFYK1eqbJCsrLdUW7SUu1Y/8w7OA+gTPyA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5478,9 +5441,9 @@
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.14.0.tgz",
-      "integrity": "sha512-bsQesVpgvDS2e+wr2fp59QO7rWRp2FqcJvBafwXS3Br9U5Mx3eFYryx4wC7cUnhlhUwX5pmaoA7zISgV9dZDgg==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.24.2.tgz",
+      "integrity": "sha512-u10UFm3WifUGf60/UGLucJjw1U01nDS4qYWDI9pGvdYdi00nvQaONj6cUK4/v/yrrzbWi94nf82/xXpH0qWIKA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5491,9 +5454,9 @@
       }
     },
     "node_modules/@tiptap/extension-strike": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.14.0.tgz",
-      "integrity": "sha512-rD5d/IL3XPfBOrHRHxt+b+0X1jbIbWONGiad/3sX0ZYQD3PandtCWboH40r/J5tFksebuY12dVYyYQKgLpDBOQ==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.24.2.tgz",
+      "integrity": "sha512-7JJ+IOTOoXlAqXDiUY9A+oRx01vRClvKuQzIDQoDtvd4Ut9rkZ+9L+Iv7AE/HzGkOOAVvfvLzYcyHiHDOpArDA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5504,9 +5467,9 @@
       }
     },
     "node_modules/@tiptap/extension-text": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.14.0.tgz",
-      "integrity": "sha512-rHny566nGZHq61zRLwQ9BPG55W/O+eDKwUJl+LhrLiVWwzpvAl9QQYixtoxJKOY48VK41PKwxe3bgDYgNs/Fhg==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.24.2.tgz",
+      "integrity": "sha512-spccJxacijTf+pdBNgyzIfxDScLKjtcpvACEw/5isYzlZ0vLyC7QhWQe8jeYEM6K9yYixIuoayV8QWRd3tzG9w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5517,9 +5480,9 @@
       }
     },
     "node_modules/@tiptap/extension-text-align": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-2.14.0.tgz",
-      "integrity": "sha512-9Wth4sAq2lYVWvQA0Qy095fsnPEavBv1FKWzVEyurwEQB7ZQsf/MRGmCNFnUXXy12w1G9UOanS4KkJ4C64+Ccw==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-align/-/extension-text-align-2.24.2.tgz",
+      "integrity": "sha512-rwzw5WUyhbxw4p4VRVvnmDSk7OVure8ksi8uhwlkUQpDD7TGtdZNEFl0yjtZS21th39H7rsIPXVk2IJV54IQkA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5530,9 +5493,9 @@
       }
     },
     "node_modules/@tiptap/extension-text-style": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.14.0.tgz",
-      "integrity": "sha512-dl0oi2i0rjLpBqTf4wGy6SLidvPpjxLcmX727pwJlCklkFJVDf8wSFeD4ddxJXiD2Rwef0D/lkcwXSY73CoDcA==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.24.2.tgz",
+      "integrity": "sha512-pp7gPdlx7qFCZ3NWZ6q9L6SmIN1cHVStt8fAGMWeM4CsoeETHULT039GUKTH+d3Tm7T2RHmCtfUPawCBL7b2iw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5543,9 +5506,9 @@
       }
     },
     "node_modules/@tiptap/extension-underline": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-2.14.0.tgz",
-      "integrity": "sha512-rlBasbwElFikaL5qPyp3OeoEBH2p9Dve0K6liqIWF4i9cECH2Bm53y2S0enVEe01hmgQEWmoYK+fq67rxr3XsQ==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-2.24.2.tgz",
+      "integrity": "sha512-vzsGRGsHkoV43tnJKjb4aLzVYtJ531Puxjf3qToGP5kRqyuSl2FyCARTZUHgVhMmD7Yu6oXsrXvTR3pNaDuIrA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5556,9 +5519,9 @@
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.14.0.tgz",
-      "integrity": "sha512-cnsfaIlvTFCDtLP/A2Fd3LmpttgY0O/tuTM2fC71vetONz83wUTYT+aD9uvxdX0GkSocoh840b0TsEazbBxhpA==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.24.2.tgz",
+      "integrity": "sha512-g9UGZRVtJJsGNtaQUlIwQQVX5akPJRZSMGvxyp02tj32mFTS8Q+ldD/4J7jCwevCJWZmb/fIbVrANzIFEiHsLw==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
@@ -5586,13 +5549,13 @@
       }
     },
     "node_modules/@tiptap/react": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-2.14.0.tgz",
-      "integrity": "sha512-6mtksbT2+EWXFLdHVFag9PSoh0GXPmL97Cm+4sJoyECUmBkAyoErapAccmZIljyMaVIHBYpYkNdp9Pw1B73ezw==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-2.24.2.tgz",
+      "integrity": "sha512-RecUJfZKs2DoRk0/94CbfJ6RFx2a6RDt65hcTtNZygRdoKe4p2VCUfhqvgZp7BSKslYBTILIPnyySv6B8r/Tyw==",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/extension-bubble-menu": "^2.14.0",
-        "@tiptap/extension-floating-menu": "^2.14.0",
+        "@tiptap/extension-bubble-menu": "^2.24.2",
+        "@tiptap/extension-floating-menu": "^2.24.2",
         "@types/use-sync-external-store": "^0.0.6",
         "fast-deep-equal": "^3",
         "use-sync-external-store": "^1"
@@ -5609,32 +5572,32 @@
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.14.0.tgz",
-      "integrity": "sha512-Z1bKAfHl14quRI3McmdU+bs675jp6/iexEQTI9M9oHa6l3McFF38g9N3xRpPPX02MX83DghsUPupndUW/yJvEQ==",
+      "version": "2.24.2",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.24.2.tgz",
+      "integrity": "sha512-GuXopmtJ8YS0q9vSa3xpuz3LeV3ls8PeAVKHUxQKnngKb2AthqXxcYIs0BS7s47HLLiWb4C6gYVpqqcJzf+xsQ==",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^2.14.0",
-        "@tiptap/extension-blockquote": "^2.14.0",
-        "@tiptap/extension-bold": "^2.14.0",
-        "@tiptap/extension-bullet-list": "^2.14.0",
-        "@tiptap/extension-code": "^2.14.0",
-        "@tiptap/extension-code-block": "^2.14.0",
-        "@tiptap/extension-document": "^2.14.0",
-        "@tiptap/extension-dropcursor": "^2.14.0",
-        "@tiptap/extension-gapcursor": "^2.14.0",
-        "@tiptap/extension-hard-break": "^2.14.0",
-        "@tiptap/extension-heading": "^2.14.0",
-        "@tiptap/extension-history": "^2.14.0",
-        "@tiptap/extension-horizontal-rule": "^2.14.0",
-        "@tiptap/extension-italic": "^2.14.0",
-        "@tiptap/extension-list-item": "^2.14.0",
-        "@tiptap/extension-ordered-list": "^2.14.0",
-        "@tiptap/extension-paragraph": "^2.14.0",
-        "@tiptap/extension-strike": "^2.14.0",
-        "@tiptap/extension-text": "^2.14.0",
-        "@tiptap/extension-text-style": "^2.14.0",
-        "@tiptap/pm": "^2.14.0"
+        "@tiptap/core": "^2.24.2",
+        "@tiptap/extension-blockquote": "^2.24.2",
+        "@tiptap/extension-bold": "^2.24.2",
+        "@tiptap/extension-bullet-list": "^2.24.2",
+        "@tiptap/extension-code": "^2.24.2",
+        "@tiptap/extension-code-block": "^2.24.2",
+        "@tiptap/extension-document": "^2.24.2",
+        "@tiptap/extension-dropcursor": "^2.24.2",
+        "@tiptap/extension-gapcursor": "^2.24.2",
+        "@tiptap/extension-hard-break": "^2.24.2",
+        "@tiptap/extension-heading": "^2.24.2",
+        "@tiptap/extension-history": "^2.24.2",
+        "@tiptap/extension-horizontal-rule": "^2.24.2",
+        "@tiptap/extension-italic": "^2.24.2",
+        "@tiptap/extension-list-item": "^2.24.2",
+        "@tiptap/extension-ordered-list": "^2.24.2",
+        "@tiptap/extension-paragraph": "^2.24.2",
+        "@tiptap/extension-strike": "^2.24.2",
+        "@tiptap/extension-text": "^2.24.2",
+        "@tiptap/extension-text-style": "^2.24.2",
+        "@tiptap/pm": "^2.24.2"
       },
       "funding": {
         "type": "github",
@@ -5751,9 +5714,9 @@
       "license": "MIT"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.17",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.17.tgz",
-      "integrity": "sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
       "license": "MIT"
     },
     "node_modules/@types/lodash.get": {
@@ -5797,9 +5760,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.0.tgz",
-      "integrity": "sha512-hfrc+1tud1xcdVTABC2JiomZJEklMcXYNTVtZLAeqTVWD+qL5jkHKT+1lOtqDdGxt+mB53DTtiz673vfjU8D1Q==",
+      "version": "20.19.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.4.tgz",
+      "integrity": "sha512-OP+We5WV8Xnbuvw0zC2m4qfB/BJvjyCwtNjhHdJxV1639SGSKrLmJkc3fMnp2Qy8nJyHp8RO6umxELN/dS1/EA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -5810,6 +5773,7 @@
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
       "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
@@ -5931,17 +5895,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.34.0.tgz",
-      "integrity": "sha512-QXwAlHlbcAwNlEEMKQS2RCgJsgXrTJdjXT08xEgbPFa2yYQgVjBymxP5DrfrE7X7iodSzd9qBUHUycdyVJTW1w==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.1.tgz",
+      "integrity": "sha512-9XNTlo7P7RJxbVeICaIIIEipqxLKguyh+3UbXuT2XQuFp6d8VOeDEGuz5IiX0dgZo8CiI6aOFLg4e8cF71SFVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.34.0",
-        "@typescript-eslint/type-utils": "8.34.0",
-        "@typescript-eslint/utils": "8.34.0",
-        "@typescript-eslint/visitor-keys": "8.34.0",
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/type-utils": "8.35.1",
+        "@typescript-eslint/utils": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -5955,7 +5919,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.34.0",
+        "@typescript-eslint/parser": "^8.35.1",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
@@ -5971,16 +5935,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.34.0.tgz",
-      "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.1.tgz",
+      "integrity": "sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.34.0",
-        "@typescript-eslint/types": "8.34.0",
-        "@typescript-eslint/typescript-estree": "8.34.0",
-        "@typescript-eslint/visitor-keys": "8.34.0",
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -5996,14 +5960,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.34.0.tgz",
-      "integrity": "sha512-iEgDALRf970/B2YExmtPMPF54NenZUf4xpL3wsCRx/lgjz6ul/l13R81ozP/ZNuXfnLCS+oPmG7JIxfdNYKELw==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.1.tgz",
+      "integrity": "sha512-VYxn/5LOpVxADAuP3NrnxxHYfzVtQzLKeldIhDhzC8UHaiQvYlXvKuVho1qLduFbJjjy5U5bkGwa3rUGUb1Q6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.34.0",
-        "@typescript-eslint/types": "^8.34.0",
+        "@typescript-eslint/tsconfig-utils": "^8.35.1",
+        "@typescript-eslint/types": "^8.35.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -6018,14 +5982,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.34.0.tgz",
-      "integrity": "sha512-9Ac0X8WiLykl0aj1oYQNcLZjHgBojT6cW68yAgZ19letYu+Hxd0rE0veI1XznSSst1X5lwnxhPbVdwjDRIomRw==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
+      "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.34.0",
-        "@typescript-eslint/visitor-keys": "8.34.0"
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6036,9 +6000,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.34.0.tgz",
-      "integrity": "sha512-+W9VYHKFIzA5cBeooqQxqNriAP0QeQ7xTiDuIOr71hzgffm3EL2hxwWBIIj4GuofIbKxGNarpKqIq6Q6YrShOA==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.1.tgz",
+      "integrity": "sha512-K5/U9VmT9dTHoNowWZpz+/TObS3xqC5h0xAIjXPw+MNcKV9qg6eSatEnmeAwkjHijhACH0/N7bkhKvbt1+DXWQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6053,14 +6017,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.34.0.tgz",
-      "integrity": "sha512-n7zSmOcUVhcRYC75W2pnPpbO1iwhJY3NLoHEtbJwJSNlVAZuwqu05zY3f3s2SDWWDSo9FdN5szqc73DCtDObAg==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.1.tgz",
+      "integrity": "sha512-HOrUBlfVRz5W2LIKpXzZoy6VTZzMu2n8q9C2V/cFngIC5U1nStJgv0tMV4sZPzdf4wQm9/ToWUFPMN9Vq9VJQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.34.0",
-        "@typescript-eslint/utils": "8.34.0",
+        "@typescript-eslint/typescript-estree": "8.35.1",
+        "@typescript-eslint/utils": "8.35.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -6077,9 +6041,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.34.0.tgz",
-      "integrity": "sha512-9V24k/paICYPniajHfJ4cuAWETnt7Ssy+R0Rbcqo5sSFr3QEZ/8TSoUi9XeXVBGXCaLtwTOKSLGcInCAvyZeMA==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
+      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6091,16 +6055,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.0.tgz",
-      "integrity": "sha512-rOi4KZxI7E0+BMqG7emPSK1bB4RICCpF7QD3KCLXn9ZvWoESsOMlHyZPAHyG04ujVplPaHbmEvs34m+wjgtVtg==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
+      "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.34.0",
-        "@typescript-eslint/tsconfig-utils": "8.34.0",
-        "@typescript-eslint/types": "8.34.0",
-        "@typescript-eslint/visitor-keys": "8.34.0",
+        "@typescript-eslint/project-service": "8.35.1",
+        "@typescript-eslint/tsconfig-utils": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -6176,16 +6140,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.34.0.tgz",
-      "integrity": "sha512-8L4tWatGchV9A1cKbjaavS6mwYwp39jql8xUmIIKJdm+qiaeHy5KMKlBrf30akXAWBzn2SqKsNOtSENWUwg7XQ==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
+      "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.34.0",
-        "@typescript-eslint/types": "8.34.0",
-        "@typescript-eslint/typescript-estree": "8.34.0"
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6200,14 +6164,14 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.34.0.tgz",
-      "integrity": "sha512-qHV7pW7E85A0x6qyrFn+O+q1k1p3tQCsqIZ1KZ5ESLXY57aTvUd3/a4rdPTeXisvhXn2VQG0VSKUqs8KHF2zcA==",
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
+      "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.34.0",
-        "eslint-visitor-keys": "^4.2.0"
+        "@typescript-eslint/types": "8.35.1",
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6237,10 +6201,38 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.10.1.tgz",
+      "integrity": "sha512-zohDKXT1Ok0yhbVGff4YAg9HUs5ietG5GpvJBPFSApZnGe7uf2cd26DRhKZbn0Be6xHUZrSzP+RAgMmzyc71EA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.10.1.tgz",
+      "integrity": "sha512-tAN6k5UrTd4nicpA7s2PbjR/jagpDzAmvXFjbpTazUe5FRsFxVcBlS1F5Lzp5jtWU6bdiqRhSvd4X8rdpCffeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.8.1.tgz",
-      "integrity": "sha512-OKuBTQdOb4Kjbe+y4KgbRhn+nu47hNyNU2K3qjD+SA/bnQouvZnRzEiR85xZAIyZ6z1C+O1Zg1dK4hGH1RPdYA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.10.1.tgz",
+      "integrity": "sha512-+FCsag8WkauI4dQ50XumCXdfvDCZEpMUnvZDsKMxfOisnEklpDFXc6ThY0WqybBYZbiwR5tWcFaZmI0G6b4vrg==",
       "cpu": [
         "arm64"
       ],
@@ -6252,9 +6244,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.8.1.tgz",
-      "integrity": "sha512-inaphBsOqqzauNvx6kSHrgqDLShicPg3+fInBcEdD7Ut8sUUbm2z19LL+S9ccGpHnYoNiJ+Qrf7/B8hRsCUvBw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.10.1.tgz",
+      "integrity": "sha512-qYKGGm5wk71ONcXTMZ0+J11qQeOAPz3nw6VtqrBUUELRyXFyvK8cHhHsLBFR4GHnilc2pgY1HTB2TvdW9wO26Q==",
       "cpu": [
         "x64"
       ],
@@ -6266,9 +6258,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.8.1.tgz",
-      "integrity": "sha512-LkGw7jDoLKEZO6yYwTKUlrboD6Qmy9Jkq7ZDPlJReq/FnCnNh0k1Z1hjtevpqPCMLz9hGW0ITMb04jdDZ796Cg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.10.1.tgz",
+      "integrity": "sha512-hOHMAhbvIQ63gkpgeNsXcWPSyvXH7ZEyeg254hY0Lp/hX8NdW+FsUWq73g9946Pc/BrcVI/I3C1cmZ4RCX9bNw==",
       "cpu": [
         "x64"
       ],
@@ -6280,9 +6272,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.8.1.tgz",
-      "integrity": "sha512-6vhu22scv64dynXTVmeClenn3OPI8cwdhtydLFDkoW4UJzNwcgJ5mVtzbtikDGM9PmIQa+ekpH6tdvKt0ToK3A==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.10.1.tgz",
+      "integrity": "sha512-6ds7+zzHJgTDmpe0gmFcOTvSUhG5oZukkt+cCsSb3k4Uiz2yEQB4iCRITX2hBwSW+p8gAieAfecITjgqCkswXw==",
       "cpu": [
         "arm"
       ],
@@ -6294,9 +6286,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.8.1.tgz",
-      "integrity": "sha512-SrQ286JVFWlnZSm1/TJwulTgJVOdb1x8BWW2ecOK0Sx+acdRpoMf4WSxH+/+R4LyE/YYyekcEtUrPhSEgJ748g==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.10.1.tgz",
+      "integrity": "sha512-P7A0G2/jW00diNJyFeq4W9/nxovD62Ay8CMP4UK9OymC7qO7rG1a8Upad68/bdfpIOn7KSp7Aj/6lEW3yyznAA==",
       "cpu": [
         "arm"
       ],
@@ -6308,9 +6300,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.8.1.tgz",
-      "integrity": "sha512-I2s4L27V+2kAee43x/qAkFjTZJgmDvSd9vtnyINOdBEdz5+QqiG6ccd5pgOw06MsUwygkrhB4jOe4ZN4SA6IwA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.10.1.tgz",
+      "integrity": "sha512-Cg6xzdkrpltcTPO4At+A79zkC7gPDQIgosJmVV8M104ImB6KZi1MrNXgDYIAfkhUYjPzjNooEDFRAwwPadS7ZA==",
       "cpu": [
         "arm64"
       ],
@@ -6322,9 +6314,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.8.1.tgz",
-      "integrity": "sha512-Drq80e/EQbdSVyJpheF65qVmfYy8OaDdQqoWV+09tZHz/P1SdSulvVtgtYrk216D++9hbx3c1bwVXwR5PZ2TzA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.10.1.tgz",
+      "integrity": "sha512-aNeg99bVkXa4lt+oZbjNRPC8ZpjJTKxijg/wILrJdzNyAymO2UC/HUK1UfDjt6T7U5p/mK24T3CYOi3/+YEQSA==",
       "cpu": [
         "arm64"
       ],
@@ -6336,9 +6328,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.8.1.tgz",
-      "integrity": "sha512-EninHQHw8Zkq8K5qB6KWNDqjCtUzTDsCRQ6LzAtQWIxic/VQxR5Kl36V/GCXNvQaR7W0AB5gvJLyQtJwkf+AJA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.10.1.tgz",
+      "integrity": "sha512-ylz5ojeXrkPrtnzVhpCO+YegG63/aKhkoTlY8PfMfBfLaUG8v6m6iqrL7sBUKdVBgOB4kSTUPt9efQdA/Y3Z/w==",
       "cpu": [
         "ppc64"
       ],
@@ -6350,9 +6342,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.8.1.tgz",
-      "integrity": "sha512-s7Xu5PS4vWhsb5ZFAi+UBguTn0g8qDhN+BbB1t9APX23AdAI7TS4DRrJV5dBVdQ6a8MiergGr1Cjb0Q1V/sW8w==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.10.1.tgz",
+      "integrity": "sha512-xcWyhmJfXXOxK7lvE4+rLwBq+on83svlc0AIypfe6x4sMJR+S4oD7n9OynaQShfj2SufPw2KJAotnsNb+4nN2g==",
       "cpu": [
         "riscv64"
       ],
@@ -6364,9 +6356,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.8.1.tgz",
-      "integrity": "sha512-Ca+bVzOJtgQ3OrMkRSeDLYWJIjRmEylDHSZuSKqqPmZI2vgX6yZgzrKY28I6hjjG9idlW4DcJzLv/TjFXev+4Q==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.10.1.tgz",
+      "integrity": "sha512-mW9JZAdOCyorgi1eLJr4gX7xS67WNG9XNPYj5P8VuttK72XNsmdw9yhOO4tDANMgiLXFiSFaiL1gEpoNtRPw/A==",
       "cpu": [
         "riscv64"
       ],
@@ -6378,9 +6370,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.8.1.tgz",
-      "integrity": "sha512-ut1vBBFs6AC5EcerH8HorcmS/9wAy6iI1tfpzT7jy+SKnMgmPth/psc3W5V04njble7cyLPjFHwYJTlxmozQ/g==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.10.1.tgz",
+      "integrity": "sha512-NZGKhBy6xkJ0k09cWNZz4DnhBcGlhDd3W+j7EYoNvf5TSwj2K6kbmfqTWITEgkvjsMUjm1wsrc4IJaH6VtjyHQ==",
       "cpu": [
         "s390x"
       ],
@@ -6392,9 +6384,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.8.1.tgz",
-      "integrity": "sha512-w5agLxesvrYKrCOlAsUkwRDogjnyRBi4/vEaujZRkXbeRCupJ9dFD0qUhLXZyIed+GSzJJIsJocUZIVzcTHYXQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.10.1.tgz",
+      "integrity": "sha512-VsjgckJ0gNMw7p0d8In6uPYr+s0p16yrT2rvG4v2jUpEMYkpnfnCiALa9SWshbvlGjKQ98Q2x19agm3iFk8w8Q==",
       "cpu": [
         "x64"
       ],
@@ -6406,9 +6398,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.8.1.tgz",
-      "integrity": "sha512-vk5htmWYCLRpfjn2wmCUne6pLvlcYUFDAAut4g02/2iWeGeZO/3GmSLmiZ9fcn9oH0FUzgetg0/zSo8oZ7liIg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.10.1.tgz",
+      "integrity": "sha512-idMnajMeejnaFi0Mx9UTLSYFDAOTfAEP7VjXNgxKApso3Eu2Njs0p2V95nNIyFi4oQVGFmIuCkoznAXtF/Zbmw==",
       "cpu": [
         "x64"
       ],
@@ -6420,9 +6412,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.8.1.tgz",
-      "integrity": "sha512-RcsLTcrqDT5XW/TnhhIeM7lVLgUv/gvPEC4WaH+OhkLCkRfH6EEuhprwrcp1WhdlrtL/U5FkHh4NtFLnMXoeXA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.10.1.tgz",
+      "integrity": "sha512-7jyhjIRNFjzlr8x5pth6Oi9hv3a7ubcVYm2GBFinkBQKcFhw4nIs5BtauSNtDW1dPIGrxF0ciynCZqzxMrYMsg==",
       "cpu": [
         "wasm32"
       ],
@@ -6437,9 +6429,9 @@
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.8.1.tgz",
-      "integrity": "sha512-XbSRLZY/gEi5weYv/aCkiUiSWvrNKkvec3m6/bDypDI+ZACwMllPH7smeOW/fdnIGhf9YtPATNliJHAS2GyMUA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.10.1.tgz",
+      "integrity": "sha512-TY79+N+Gkoo7E99K+zmsKNeiuNJYlclZJtKqsHSls8We2iGhgxtletVsiBYie93MSTDRDMI8pkBZJlIJSZPrdA==",
       "cpu": [
         "arm64"
       ],
@@ -6451,9 +6443,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.8.1.tgz",
-      "integrity": "sha512-SbCJMKOmqOsIBCklT5c+t0DjVbOkseE7ZN0OtMxRnraLKdj1AAv7d3cjJMYkPd9ZGKosHoMXo66gBs02YM8KeA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.10.1.tgz",
+      "integrity": "sha512-BAJN5PEPlEV+1m8+PCtFoKm3LQ1P57B4Z+0+efU0NzmCaGk7pUaOxuPgl+m3eufVeeNBKiPDltG0sSB9qEfCxw==",
       "cpu": [
         "ia32"
       ],
@@ -6465,9 +6457,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.8.1.tgz",
-      "integrity": "sha512-DdHqo7XbeUa/ZOcxq+q5iuO4sSxhwX9HR1JPL0JMOKEzgkIO4OKF2TPjqmo6UCCGZUXIMwrAycFXj/40sICagw==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.10.1.tgz",
+      "integrity": "sha512-2v3erKKmmCyIVvvhI2nF15qEbdBpISTq44m9pyd5gfIJB1PN94oePTLWEd82XUbIbvKhv76xTSeUQSCOGesLeg==",
       "cpu": [
         "x64"
       ],
@@ -6497,9 +6489,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.61",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.61.tgz",
-      "integrity": "sha512-w2HbBvH+qO19SB5pJOJFKs533CdZqxl3fcGonqL321VHkW7W/iBo6H8bjDy6pr/+pbMwIu5dnuaAxH7NxBqUrQ==",
+      "version": "0.1.63",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.63.tgz",
+      "integrity": "sha512-s9Kuh0nE/2+nKrvmKNMB2fE5Zlr3DL2t3OFKM55v5jRcfCOxbkOHhQoshoFum5mmXIfEtRXtLCWmkeTJsVjE9w==",
       "license": "BSD-3-Clause"
     },
     "node_modules/abort-controller": {
@@ -6507,6 +6499,7 @@
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -6576,6 +6569,7 @@
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
       "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -6868,7 +6862,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -6918,9 +6913,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
-      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -6970,9 +6965,9 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.5.tgz",
-      "integrity": "sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.6.tgz",
+      "integrity": "sha512-25RsLF33BqooOEFNdMcEhMpJy8EoR88zSMrnOQOaM3USnOK2VmaJ1uaQEwPA6AQjrv1lXChScosN6CzbwbO9OQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -7264,7 +7259,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7292,9 +7287,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001722",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001722.tgz",
-      "integrity": "sha512-DCQHBBZtiK6JVkAGw7drvAMK0Q0POD/xZvEmDp6baiMMP6QXXk9HpD6mNYBZWhOPG6LvIDb82ITqtWjhDckHCA==",
+      "version": "1.0.30001726",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
+      "integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7383,12 +7378,6 @@
       "engines": {
         "node": ">=7.0.0"
       }
-    },
-    "node_modules/chalk/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
     },
     "node_modules/character-entities": {
       "version": "2.0.2",
@@ -7544,10 +7533,16 @@
         "color-name": "1.1.3"
       }
     },
-    "node_modules/color-name": {
+    "node_modules/color-convert/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "license": "MIT"
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -7565,6 +7560,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -7600,9 +7596,9 @@
       "license": "MIT"
     },
     "node_modules/console-table-printer": {
-      "version": "2.14.3",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.14.3.tgz",
-      "integrity": "sha512-X5OCFnjYlXzRuC8ac5hPA2QflRjJvNKJocMhlnqK/Ap7q3DHXr0NJ0TGzwmEKOiOdJrjsSwEd0m+a32JAYPrKQ==",
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.14.6.tgz",
+      "integrity": "sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==",
       "license": "MIT",
       "dependencies": {
         "simple-wcswidth": "^1.0.1"
@@ -7610,7 +7606,7 @@
     },
     "node_modules/cookie": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/cookie/-/cookie-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
       "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
       "license": "MIT",
       "engines": {
@@ -7627,34 +7623,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/crelt": {
@@ -7914,6 +7882,7 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -8007,7 +7976,7 @@
     },
     "node_modules/dot-case": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmmirror.com/dot-case/-/dot-case-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
       "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
       "license": "MIT",
       "dependencies": {
@@ -8016,9 +7985,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "peer": true,
       "engines": {
@@ -8066,10 +8035,9 @@
       }
     },
     "node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
@@ -8082,9 +8050,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "version": "5.18.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
+      "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8106,36 +8074,6 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
-    },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "node_modules/error-ex/node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -8353,19 +8291,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
-      "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
+      "version": "9.30.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.1.tgz",
+      "integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.0",
-        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.0",
         "@eslint/core": "^0.14.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.28.0",
+        "@eslint/js": "9.30.1",
         "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -8377,9 +8315,9 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -8499,9 +8437,9 @@
       }
     },
     "node_modules/eslint-module-utils": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.0.tgz",
-      "integrity": "sha512-wALZ0HFoytlyh/1+4wuZ9FJCD/leWHQzzrxJ8+rebyReSLk7LApMyd3WJaLVoN+D5+WIdJyDK1c6JnE65V4Zyg==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
+      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8527,30 +8465,30 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.31.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
-      "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
-        "array-includes": "^3.1.8",
-        "array.prototype.findlastindex": "^1.2.5",
-        "array.prototype.flat": "^1.3.2",
-        "array.prototype.flatmap": "^1.3.2",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
         "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.12.0",
+        "eslint-module-utils": "^2.12.1",
         "hasown": "^2.0.2",
-        "is-core-module": "^2.15.1",
+        "is-core-module": "^2.16.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
         "object.fromentries": "^2.0.8",
         "object.groupby": "^1.0.3",
-        "object.values": "^1.2.0",
+        "object.values": "^1.2.1",
         "semver": "^6.3.1",
-        "string.prototype.trimend": "^1.0.8",
+        "string.prototype.trimend": "^1.0.9",
         "tsconfig-paths": "^3.15.0"
       },
       "engines": {
@@ -8609,6 +8547,13 @@
       "peerDependencies": {
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
+    },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
@@ -8804,6 +8749,7 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8824,12 +8770,12 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.2.tgz",
-      "integrity": "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
+      "integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/expr-eval": {
@@ -8925,6 +8871,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",
@@ -9130,6 +9082,7 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
       "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -9145,13 +9098,15 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/formdata-node": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
       "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-domexception": "1.0.0",
         "web-streams-polyfill": "4.0.0-beta.3"
@@ -9161,13 +9116,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.17.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.17.0.tgz",
-      "integrity": "sha512-2hISKgDk49yCLStwG1wf4Kdy/D6eBw9/eRNaWFIYoI9vMQ/Mqd1Fz+gzVlEtxJmtQ9y4IWnXm19/+UXD3dAYAA==",
+      "version": "12.23.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.0.tgz",
+      "integrity": "sha512-xf6NxTGAyf7zR4r2KlnhFmsRfKIbjqeBupEDBAaEtVIBJX96sAon00kMlsKButSIRwPSHjbRrAPnYdJJ9kyhbA==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.17.0",
-        "motion-utils": "^12.12.1",
+        "motion-dom": "^12.22.0",
+        "motion-utils": "^12.19.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -9378,7 +9333,7 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmmirror.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
     },
@@ -9619,9 +9574,9 @@
       }
     },
     "node_modules/hls.js": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.5.tgz",
-      "integrity": "sha512-KMn5n7JBK+olC342740hDPHnGWfE8FiHtGMOdJPfUjRdARTWj9OB+8c13fnsf9sk1VtpuU2fKSgUjHvg4rNbzQ==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.6.tgz",
+      "integrity": "sha512-S4uTCwTHOtImW+/jxMjzG7udbHy5z682YQRbm/4f7VXuVNEoGBRjPJnD3Fxrufomdhzdtv24KnxRhPMXSvL6Fw==",
       "license": "Apache-2.0"
     },
     "node_modules/hsl-to-hex": {
@@ -9710,6 +9665,7 @@
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -9737,9 +9693,9 @@
       "license": "ISC"
     },
     "node_modules/i18next": {
-      "version": "25.2.1",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.2.1.tgz",
-      "integrity": "sha512-+UoXK5wh+VlE1Zy5p6MjcvctHXAhRwQKCxiJD8noKZzIXmnAX8gdHX5fLPA3MEVxEN4vbZkQFy8N0LyD9tUqPw==",
+      "version": "25.3.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.1.tgz",
+      "integrity": "sha512-S4CPAx8LfMOnURnnJa8jFWvur+UX/LWcl6+61p9VV7SK2m0445JeBJ6tLD0D5SR0H29G4PYfWkEhivKG5p4RDg==",
       "funding": [
         {
           "type": "individual",
@@ -9756,7 +9712,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.1"
+        "@babel/runtime": "^7.27.6"
       },
       "peerDependencies": {
         "typescript": "^5"
@@ -9804,9 +9760,9 @@
       }
     },
     "node_modules/ibm-cloud-sdk-core/node_modules/@types/node": {
-      "version": "18.19.111",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.111.tgz",
-      "integrity": "sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==",
+      "version": "18.19.115",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.115.tgz",
+      "integrity": "sha512-kNrFiTgG4a9JAn1LMQeLOv3MvXIPokzXziohMrMsvpYgLpdEt/mMiVYc4sGKtDfyxM5gIDF4VgrPRyCw4fHOYg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9888,9 +9844,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.2.tgz",
-      "integrity": "sha512-qHKXW1q6liAk1Oys6umoaZbDRqjcjgSrbnrifHsfsttza7zcvRAsL7mMV6xWcyhwQy7Xj5v4hhbr6b+iDYwlmQ==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
+      "integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -9898,7 +9854,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -10526,7 +10482,7 @@
     },
     "node_modules/jose": {
       "version": "4.15.9",
-      "resolved": "https://registry.npmmirror.com/jose/-/jose-4.15.9.tgz",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
       "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
       "license": "MIT",
       "funding": {
@@ -10535,7 +10491,7 @@
     },
     "node_modules/js-cookie": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmmirror.com/js-cookie/-/js-cookie-3.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
       "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
       "license": "MIT",
       "engines": {
@@ -10581,14 +10537,6 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -10752,9 +10700,9 @@
       }
     },
     "node_modules/langchain": {
-      "version": "0.3.27",
-      "resolved": "https://registry.npmjs.org/langchain/-/langchain-0.3.27.tgz",
-      "integrity": "sha512-XfOuXetMSpkS11Mt6YJkDmvuSGTMPUsks5DJz4RCZ3y2dcbLkOe5kecjx2SWVJYqQIqcMMwsjsve3/ZjnRe7rQ==",
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-0.3.29.tgz",
+      "integrity": "sha512-L389pKlApVJPqu4hp58qY6NZAobI+MFPoBjSfjT1z3mcxtB68wLFGhaH4DVsTVg21NYO+0wTEoz24BWrxu9YGw==",
       "license": "MIT",
       "dependencies": {
         "@langchain/openai": ">=0.1.0 <0.6.0",
@@ -10762,13 +10710,12 @@
         "js-tiktoken": "^1.0.12",
         "js-yaml": "^4.1.0",
         "jsonpointer": "^5.0.1",
-        "langsmith": "^0.3.29",
+        "langsmith": "^0.3.33",
         "openapi-types": "^12.1.3",
         "p-retry": "4",
         "uuid": "^10.0.0",
         "yaml": "^2.2.1",
-        "zod": "^3.22.4",
-        "zod-to-json-schema": "^3.22.3"
+        "zod": "^3.25.32"
       },
       "engines": {
         "node": ">=18"
@@ -10778,7 +10725,7 @@
         "@langchain/aws": "*",
         "@langchain/cerebras": "*",
         "@langchain/cohere": "*",
-        "@langchain/core": ">=0.2.21 <0.4.0",
+        "@langchain/core": ">=0.3.58 <0.4.0",
         "@langchain/deepseek": "*",
         "@langchain/google-genai": "*",
         "@langchain/google-vertexai": "*",
@@ -10848,9 +10795,9 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.31.tgz",
-      "integrity": "sha512-9lwuLZuN3tXFYQ6eMg0rmbBw7oxQo4bu1NYeylbjz27bOdG1XB9XNoxaiIArkK4ciLdOIOhPMBXP4bkvZOgHRw==",
+      "version": "0.3.38",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.38.tgz",
+      "integrity": "sha512-2f3h427UCEi9jpGvdZp6eZNDhOzcSFSdwyZAax4Wo80NWozkXunepKkiXdQNloUZzE++fh3lxrjOqvimAJ0SSg==",
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^10.0.0",
@@ -10862,9 +10809,21 @@
         "uuid": "^10.0.0"
       },
       "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
         "openai": "*"
       },
       "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
         "openai": {
           "optional": true
         }
@@ -11171,14 +11130,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -11315,7 +11266,7 @@
     },
     "node_modules/lower-case": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmmirror.com/lower-case/-/lower-case-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
       "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
       "license": "MIT",
       "dependencies": {
@@ -11324,7 +11275,7 @@
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "license": "ISC",
       "dependencies": {
@@ -11333,12 +11284,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/lru-cache/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
     },
     "node_modules/lucide-react": {
       "version": "0.513.0",
@@ -11371,7 +11316,7 @@
     },
     "node_modules/map-obj": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmmirror.com/map-obj/-/map-obj-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "license": "MIT",
       "engines": {
@@ -12058,6 +12003,7 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -12067,6 +12013,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -12150,18 +12097,18 @@
       "peer": true
     },
     "node_modules/motion-dom": {
-      "version": "12.17.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.17.0.tgz",
-      "integrity": "sha512-FA6/c70R9NKs3g41XDVONzmUUrEmyaifLVGCWtAmHP0usDnX9W+RN/tmbC4EUl0w6yLGvMTOwnWCFVgA5luhRg==",
+      "version": "12.22.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.22.0.tgz",
+      "integrity": "sha512-ooH7+/BPw9gOsL9VtPhEJHE2m4ltnhMlcGMhEqA0YGNhKof7jdaszvsyThXI6LVIKshJUZ9/CP6HNqQhJfV7kw==",
       "license": "MIT",
       "dependencies": {
-        "motion-utils": "^12.12.1"
+        "motion-utils": "^12.19.0"
       }
     },
     "node_modules/motion-utils": {
-      "version": "12.12.1",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.12.1.tgz",
-      "integrity": "sha512-f9qiqUHm7hWSLlNW8gS9pisnsN7CRFRD58vNjptKdsqFLpkVnX00TNeD6Q0d27V9KzT7ySFyK1TZ/DShfVOv6w==",
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.19.0.tgz",
+      "integrity": "sha512-BuFTHINYmV07pdWs6lj6aI63vr2N4dg0vR+td0rtrdpWOhBzIkEklZyLcvKBoEtwSqx8Jg06vUB5RS0xDiUybw==",
       "license": "MIT"
     },
     "node_modules/mrmime": {
@@ -12208,9 +12155,9 @@
       }
     },
     "node_modules/napi-postinstall": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.2.4.tgz",
-      "integrity": "sha512-ZEzHJwBhZ8qQSbknHqYcdtQVr8zUgGyM/q6h6qAyhtyVMNrSgDhrC4disf03dYW0e+czXyLnZINnCTEkWy0eJg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.0.tgz",
+      "integrity": "sha512-M7NqKyhODKV1gRLdkwE7pDsZP2/SC2a2vHkOYh9MCpKMbWVfyVfUw5MaH83Fv6XMjxr5jryUp3IDDL9rlxsTeA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -12295,7 +12242,7 @@
     },
     "node_modules/next-auth": {
       "version": "4.24.11",
-      "resolved": "https://registry.npmmirror.com/next-auth/-/next-auth-4.24.11.tgz",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
       "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
       "license": "ISC",
       "dependencies": {
@@ -12327,7 +12274,7 @@
     },
     "node_modules/next-auth/node_modules/cookie": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmmirror.com/cookie/-/cookie-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
@@ -12336,11 +12283,20 @@
     },
     "node_modules/next-auth/node_modules/uuid": {
       "version": "8.3.2",
-      "resolved": "https://registry.npmmirror.com/uuid/-/uuid-8.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/nanoid": {
@@ -12421,7 +12377,7 @@
     },
     "node_modules/no-case": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmmirror.com/no-case/-/no-case-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
       "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
       "license": "MIT",
       "dependencies": {
@@ -12453,6 +12409,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.5.0"
       }
@@ -12488,7 +12445,7 @@
     },
     "node_modules/oauth": {
       "version": "0.9.15",
-      "resolved": "https://registry.npmmirror.com/oauth/-/oauth-0.9.15.tgz",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
       "license": "MIT"
     },
@@ -12503,7 +12460,7 @@
     },
     "node_modules/object-hash": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmmirror.com/object-hash/-/object-hash-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
       "license": "MIT",
       "engines": {
@@ -12625,7 +12582,7 @@
     },
     "node_modules/oidc-token-hash": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmmirror.com/oidc-token-hash/-/oidc-token-hash-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.0.tgz",
       "integrity": "sha512-y0W+X7Ppo7oZX6eovsRkuzcSM40Bicg2JEJkDJ4irIt1wsYAP5MLSNv+QAogO8xivMffw/9OvV3um1pxXgt1uA==",
       "license": "MIT",
       "engines": {
@@ -12646,6 +12603,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
       "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -12672,10 +12630,11 @@
       }
     },
     "node_modules/openai/node_modules/@types/node": {
-      "version": "18.19.111",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.111.tgz",
-      "integrity": "sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==",
+      "version": "18.19.115",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.115.tgz",
+      "integrity": "sha512-kNrFiTgG4a9JAn1LMQeLOv3MvXIPokzXziohMrMsvpYgLpdEt/mMiVYc4sGKtDfyxM5gIDF4VgrPRyCw4fHOYg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -12684,7 +12643,8 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/openapi-types": {
       "version": "12.1.3",
@@ -12704,7 +12664,7 @@
     },
     "node_modules/openid-client": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmmirror.com/openid-client/-/openid-client-5.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
       "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
       "license": "MIT",
       "dependencies": {
@@ -12883,7 +12843,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -12916,26 +12876,6 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/parse-svg-path": {
       "version": "0.1.2",
@@ -13016,13 +12956,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
-      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.2.tgz",
+      "integrity": "sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
-        "playwright-core": "1.53.0"
+        "playwright-core": "1.53.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13035,9 +12975,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
-      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
+      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -13058,9 +12998,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
       "funding": [
         {
@@ -13119,7 +13059,7 @@
     },
     "node_modules/preact": {
       "version": "10.26.9",
-      "resolved": "https://registry.npmmirror.com/preact/-/preact-10.26.9.tgz",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.9.tgz",
       "integrity": "sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==",
       "license": "MIT",
       "funding": {
@@ -13129,7 +13069,7 @@
     },
     "node_modules/preact-render-to-string": {
       "version": "5.2.6",
-      "resolved": "https://registry.npmmirror.com/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
       "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
       "license": "MIT",
       "dependencies": {
@@ -13151,7 +13091,7 @@
     },
     "node_modules/pretty-format": {
       "version": "3.8.0",
-      "resolved": "https://registry.npmmirror.com/pretty-format/-/pretty-format-3.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
       "license": "MIT"
     },
@@ -13499,29 +13439,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/puppeteer": {
-      "version": "24.11.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.11.1.tgz",
-      "integrity": "sha512-QbccB/LgxX4tSZRzr9KQ1Jajdvu3n35Dlf/Otjz0QfR+6mDoZdMWLcWF94uQoC3OJerCyYm5hlU2Ru4nBoId2A==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@puppeteer/browsers": "2.10.5",
-        "chromium-bidi": "5.1.0",
-        "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1464554",
-        "puppeteer-core": "24.11.1",
-        "typed-query-selector": "^2.12.0"
-      },
-      "bin": {
-        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/puppeteer-core": {
       "version": "24.11.2",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.11.2.tgz",
@@ -13534,25 +13451,6 @@
         "devtools-protocol": "0.0.1464554",
         "typed-query-selector": "^2.12.0",
         "ws": "^8.18.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/puppeteer/node_modules/puppeteer-core": {
-      "version": "24.11.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.11.1.tgz",
-      "integrity": "sha512-I0Gv3jWBRY9E3NTBElp7br7Gaid5RbFTxCRRMHym1kCf0ompO0Pel4REGsGDwMWkg3uwFzIH7t7qXs3T4DKRWA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@puppeteer/browsers": "2.10.5",
-        "chromium-bidi": "5.1.0",
-        "debug": "^4.4.1",
-        "devtools-protocol": "0.0.1464554",
-        "typed-query-selector": "^2.12.0",
-        "ws": "^8.18.2"
       },
       "engines": {
         "node": ">=18"
@@ -13727,6 +13625,12 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-dom/node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
     "node_modules/react-dropzone": {
       "version": "14.3.8",
       "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
@@ -13745,12 +13649,12 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.5.2.tgz",
-      "integrity": "sha512-ePODyXgmZQAOYTbZXQn5rRsSBu3Gszo69jxW6aKmlSgxKAI1fOhDwSu6bT4EKHciWPKQ7v7lPrjeiadR6Gi+1A==",
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.0.tgz",
+      "integrity": "sha512-W135dB0rDfiFmbMipC17nOhGdttO5mzH8BivY+2ybsQBbXvxWIwl3cmeH3T9d+YPBSJu/ouyJKFJTtkK7rJofw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.25.0",
+        "@babel/runtime": "^7.27.6",
         "html-parse-stringify": "^3.0.1"
       },
       "peerDependencies": {
@@ -14136,7 +14040,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -14328,9 +14232,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
       "license": "MIT"
     },
     "node_modules/secure-json-parse": {
@@ -14481,13 +14385,6 @@
         "node": ">=7.0.0"
       }
     },
-    "node_modules/sharp/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -14595,9 +14492,9 @@
       }
     },
     "node_modules/simple-wcswidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.0.1.tgz",
-      "integrity": "sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
+      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
       "license": "MIT"
     },
     "node_modules/sirv": {
@@ -14627,7 +14524,7 @@
     },
     "node_modules/snake-case": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmmirror.com/snake-case/-/snake-case-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
       "integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
       "license": "MIT",
       "dependencies": {
@@ -14637,7 +14534,7 @@
     },
     "node_modules/snakecase-keys": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmmirror.com/snakecase-keys/-/snakecase-keys-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-8.0.1.tgz",
       "integrity": "sha512-Sj51kE1zC7zh6TDlNNz0/Jn1n5HiHdoQErxO8jLtnyrkJW/M5PrI7x05uDgY3BO7OUQYKCvmeMurW6BPUdwEOw==",
       "license": "MIT",
       "dependencies": {
@@ -14678,9 +14575,9 @@
       }
     },
     "node_modules/sonner": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.5.tgz",
-      "integrity": "sha512-YwbHQO6cSso3HBXlbCkgrgzDNIhws14r4MO87Ofy+cV2X7ES4pOoAK3+veSmVTvqNx1BWUxlhPmZzP00Crk2aQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.6.tgz",
+      "integrity": "sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
@@ -14739,6 +14636,16 @@
         "node": ">=0.1.14"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
@@ -14773,7 +14680,7 @@
     },
     "node_modules/std-env": {
       "version": "3.9.0",
-      "resolved": "https://registry.npmmirror.com/std-env/-/std-env-3.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.9.0.tgz",
       "integrity": "sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==",
       "license": "MIT"
     },
@@ -15125,9 +15032,9 @@
       }
     },
     "node_modules/swr": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
-      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
+      "integrity": "sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==",
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3",
@@ -15148,9 +15055,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.9.tgz",
-      "integrity": "sha512-anBZRcvfNMsQdHB9XSGzAtIQWlhs49uK75jfkwrqjRUbjt4d7q9RE1wR1xWyfYZhLFnFX4ahWp88Au2lcEw5IQ==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.11.tgz",
+      "integrity": "sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==",
       "dev": true,
       "license": "MIT"
     },
@@ -15205,6 +15112,16 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/text-decoder": {
@@ -15539,7 +15456,7 @@
     },
     "node_modules/type-fest": {
       "version": "4.41.0",
-      "resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-4.41.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
       "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -15802,36 +15719,38 @@
       }
     },
     "node_modules/unrs-resolver": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.8.1.tgz",
-      "integrity": "sha512-M5++xH5Tu/m3NNAc0+dBHidXfF6bTC08mfhQ3AB5UTonEzQSH9ASC/a7EbZN3WU5m0OWMTvf12GHVJZ3uUmPtA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.10.1.tgz",
+      "integrity": "sha512-EFrL7Hw4kmhZdwWO3dwwFJo6hO3FXuQ6Bg8BK/faHZ9m1YxqBS31BNSTxklIQkxK/4LlV8zTYnPsIRLBzTzjCA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "napi-postinstall": "^0.2.2"
+        "napi-postinstall": "^0.3.0"
       },
       "funding": {
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-darwin-arm64": "1.8.1",
-        "@unrs/resolver-binding-darwin-x64": "1.8.1",
-        "@unrs/resolver-binding-freebsd-x64": "1.8.1",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.8.1",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.8.1",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.8.1",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.8.1",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.8.1",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.8.1",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.8.1",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.8.1",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.8.1",
-        "@unrs/resolver-binding-linux-x64-musl": "1.8.1",
-        "@unrs/resolver-binding-wasm32-wasi": "1.8.1",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.8.1",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.8.1",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.8.1"
+        "@unrs/resolver-binding-android-arm-eabi": "1.10.1",
+        "@unrs/resolver-binding-android-arm64": "1.10.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.10.1",
+        "@unrs/resolver-binding-darwin-x64": "1.10.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.10.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.10.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.10.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.10.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.10.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.10.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.10.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.10.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.10.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.10.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.10.1"
       }
     },
     "node_modules/uri-js": {
@@ -16048,9 +15967,9 @@
       "license": "MIT"
     },
     "node_modules/weaviate-client": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/weaviate-client/-/weaviate-client-3.6.1.tgz",
-      "integrity": "sha512-C/sVYLqLuRQn2FeP3YQFNSOV61gNNtswNDRnb117ZfweSU/DIGAYeZZn63DpNI11qDSWTS3Cbz/aQjUzZXbA6Q==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/weaviate-client/-/weaviate-client-3.6.2.tgz",
+      "integrity": "sha512-6z+Du0Sp+nVp4Mhsn25sd+Qw6fr60vbyUS1e3gTZqtMrxLuNC1xgA0J/MHu5oHcm6moCBqT/2AQCt4ZV4fYSaw==",
       "license": "BSD 3-Clause",
       "dependencies": {
         "abort-controller-x": "^0.4.3",
@@ -16084,6 +16003,7 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
       "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -16322,12 +16242,6 @@
         "node": ">=7.0.0"
       }
     },
-    "node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -16365,14 +16279,10 @@
       }
     },
     "node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.0",
@@ -16443,27 +16353,27 @@
       "license": "MIT"
     },
     "node_modules/zod": {
-      "version": "3.25.61",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.61.tgz",
-      "integrity": "sha512-fzfJgUw78LTNnHujj9re1Ov/JJQkRZZGDMcYqSx7Hp4rPOkKywaFHq0S6GoHeXs0wGNE/sIOutkXgnwzrVOGCQ==",
+      "version": "3.25.73",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.73.tgz",
+      "integrity": "sha512-fuIKbQAWQl22Ba5d1quwEETQYjqnpKVyZIWAhbnnHgnDd3a+z4YgEfkI5SZ2xMELnLAXo/Flk2uXgysZNf0uaA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
-      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
+    "dev:turbo": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/src/app/api/generate-pdf/route.ts
+++ b/src/app/api/generate-pdf/route.ts
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest) {
       browser = await puppeteer.launch({
         headless: true,
         args: baseArgs,
-        executablePath: process.env.CHROME_BIN || '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+        executablePath: process.env.CHROME_BIN || 'C:/Program Files/Google/Chrome/Application/chrome.exe',
         timeout: 30000,
       });
     }

--- a/src/app/components/landing/Footer.tsx
+++ b/src/app/components/landing/Footer.tsx
@@ -21,8 +21,7 @@ export function Footer() {
       opacity: 1, 
       y: 0, 
       transition: { 
-        duration: 0.6, 
-        ease: [0.25, 0.46, 0.45, 0.94] 
+        duration: 0.6
       } 
     },
   };

--- a/src/app/dashboard/edit/_components/ResumePreviewPanel.tsx
+++ b/src/app/dashboard/edit/_components/ResumePreviewPanel.tsx
@@ -67,7 +67,17 @@ const ResumePreviewPanel: React.FC<ResumePreviewPanelProps> = ({
               </div>
             </TransformComponent>
 
-            <Tools isMobile={isMobile} zoomIn={zoomIn} zoomOut={zoomOut} resetTransform={resetTransform} info={activeResume.info} onShowAI={onShowAI} rightCollapsed={rightCollapsed} />
+            <Tools 
+              isMobile={isMobile} 
+              zoomIn={zoomIn} 
+              zoomOut={zoomOut} 
+              resetTransform={resetTransform} 
+              info={activeResume.info} 
+              onShowAI={onShowAI} 
+              rightCollapsed={rightCollapsed}
+              templateId={activeResume.template}
+              customTemplate={activeResume.customTemplate}
+            />
           </>
         )}
       </TransformWrapper>

--- a/src/app/dashboard/edit/_components/Tools.tsx
+++ b/src/app/dashboard/edit/_components/Tools.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils";
 import { exportOriginalStyle } from "@/lib/puppeteer-export";
-import { InfoType } from "@/store/useResumeStore";
+import { InfoType, CustomTemplateConfig } from "@/store/useResumeStore";
 import { DownloadIcon } from "@radix-ui/react-icons";
 import { Bot } from "lucide-react";
 import { useTranslation } from "react-i18next";
@@ -12,10 +12,12 @@ export type ToolsProps = {
   resetTransform: (step?: number) => void;
   info: InfoType;
   onShowAI: () => void;
-  rightCollapsed?: boolean; 
+  rightCollapsed?: boolean;
+  templateId?: string;
+  customTemplate?: CustomTemplateConfig;
 };
 
-export function Tools({ isMobile, zoomIn, zoomOut, resetTransform, info, onShowAI, rightCollapsed = false }: ToolsProps){
+export function Tools({ isMobile, zoomIn, zoomOut, resetTransform, info, onShowAI, rightCollapsed = false, templateId, customTemplate }: ToolsProps){
   const { t } = useTranslation();
   
   // 计算桌面端工具栏的right位置，避免被模板栏遮挡
@@ -47,7 +49,7 @@ export function Tools({ isMobile, zoomIn, zoomOut, resetTransform, info, onShowA
       
       <button
         className="w-8 h-8 rounded-full bg-neutral-800 border border-neutral-700 flex items-center justify-center text-white hover:bg-neutral-700 transition"
-        onClick={() => exportOriginalStyle(info)}
+        onClick={() => exportOriginalStyle(info, templateId, customTemplate)}
         title={t('tools.exportPDF')}
         type="button"
       >

--- a/src/lib/puppeteer-export.ts
+++ b/src/lib/puppeteer-export.ts
@@ -1,9 +1,11 @@
 import { toast } from "sonner";
-import { InfoType } from "@/store/useResumeStore";
+import { InfoType, CustomTemplateConfig } from "@/store/useResumeStore";
 import i18n from '@/i18n';
+import { getMagicTemplateById, getDefaultMagicTemplate } from '@/templates/config/magic-templates';
+import { mergeTemplateConfig } from '@/lib/templateUtils';
 
 // 原样式导出（保持与预览一致，支持单页无限延长）
-export async function exportOriginalStyle(info: InfoType) {
+export async function exportOriginalStyle(info: InfoType, templateId?: string, customTemplate?: CustomTemplateConfig) {
   const resumeElement = document.getElementById('resume-to-export');
   if (!resumeElement) {
     toast.error(i18n.t('export.notifications.elementNotFound'));
@@ -27,6 +29,53 @@ export async function exportOriginalStyle(info: InfoType) {
         }
       })
       .join('\n');
+      
+    // 获取正确的模板颜色配置
+    let colorPrimary = '#3b82f6';
+    let colorText = '#1f2937';
+    let colorTextSecondary = '#6b7280';
+    let colorBackground = '#ffffff';
+    let colorSidebar = null;
+    
+    try {
+      // 如果提供了模板配置，则使用模板配置中的颜色
+      if (templateId || customTemplate) {
+        let baseTemplate;
+        if (templateId) {
+          try {
+            baseTemplate = await getMagicTemplateById(templateId);
+          } catch {
+            baseTemplate = await getDefaultMagicTemplate();
+          }
+        } else {
+          baseTemplate = await getDefaultMagicTemplate();
+        }
+        
+        // 合并自定义配置
+        const finalTemplate = mergeTemplateConfig(baseTemplate, customTemplate);
+        colorPrimary = finalTemplate.designTokens.colors.primary;
+        colorText = finalTemplate.designTokens.colors.text;
+        colorTextSecondary = finalTemplate.designTokens.colors.textSecondary;
+        colorBackground = finalTemplate.designTokens.colors.background;
+        if (finalTemplate.designTokens.colors.sidebar) {
+          colorSidebar = finalTemplate.designTokens.colors.sidebar;
+        }
+      } else {
+        // 回退到从DOM获取CSS变量值
+        const rootElement = document.documentElement;
+        const computedStyle = getComputedStyle(rootElement);
+        colorPrimary = computedStyle.getPropertyValue('--color-primary').trim() || colorPrimary;
+        colorText = computedStyle.getPropertyValue('--color-text').trim() || colorText;
+        colorTextSecondary = computedStyle.getPropertyValue('--color-text-secondary').trim() || colorTextSecondary;
+        colorBackground = computedStyle.getPropertyValue('--color-background').trim() || colorBackground;
+        const sidebarColor = computedStyle.getPropertyValue('--color-sidebar').trim();
+        if (sidebarColor) {
+          colorSidebar = sidebarColor;
+        }
+      }
+    } catch (error) {
+      console.warn('Failed to get template colors, using defaults:', error);
+    }
 
     // 构建完整的HTML文档（支持单页无限延长）
     const fullHTML = `
@@ -38,6 +87,161 @@ export async function exportOriginalStyle(info: InfoType) {
           <title>简历 - ${info.fullName || 'Resume'}</title>
           <style>
             ${styles}
+            
+            /* Timeline组件CSS变量定义 - 使用实际模板颜色 */
+            :root {
+              --color-text: ${colorText};
+              --color-primary: ${colorPrimary};
+              --color-text-secondary: ${colorTextSecondary};
+              --color-background: ${colorBackground};
+              ${colorSidebar ? `--color-sidebar: ${colorSidebar};` : ''}
+              --line-height: 1.6;
+              --letter-spacing: normal;
+              --section-spacing: 2rem;
+              --paragraph-spacing: 1rem;
+            }
+            
+            /* Timeline组件完整Tailwind CSS样式补充 */
+            /* 布局样式 */
+            .relative { position: relative !important; }
+            .absolute { position: absolute !important; }
+            .flex { display: flex !important; }
+            .flex-col { flex-direction: column !important; }
+            .flex-row { flex-direction: row !important; }
+            .space-y-6 > * + * { margin-top: 1.5rem !important; }
+            
+            /* 定位和尺寸 */
+            .left-0 { left: 0px !important; }
+            .top-2 { top: 0.5rem !important; }
+            .top-6 { top: 1.5rem !important; }
+            .w-3 { width: 0.75rem !important; }
+            .h-3 { height: 0.75rem !important; }
+            .w-0\.5 { width: 0.125rem !important; }
+            .h-full { height: 100% !important; }
+            .pl-6 { padding-left: 1.5rem !important; }
+            .pb-2 { padding-bottom: 0.5rem !important; }
+            .mt-1 { margin-top: 0.25rem !important; }
+            
+                         /* 颜色和背景 */
+             .bg-blue-500 { background-color: ${colorPrimary} !important; }
+             .bg-gray-200 { background-color: #e5e7eb !important; }
+             .border-white { border-color: #ffffff !important; }
+             .text-primary { color: ${colorPrimary} !important; }
+            
+            /* 边框和阴影 */
+            .rounded-full { border-radius: 9999px !important; }
+            .border-2 { border-width: 2px !important; }
+            .shadow-md { 
+              box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 
+                          0 2px 4px -1px rgba(0, 0, 0, 0.06) !important; 
+            }
+            
+            /* 字体样式 */
+            .font-bold { font-weight: 700 !important; }
+            .font-medium { font-weight: 500 !important; }
+            .text-lg { font-size: 1.125rem !important; line-height: 1.75rem !important; }
+            .text-base { font-size: 1rem !important; line-height: 1.5rem !important; }
+            .text-sm { font-size: 0.875rem !important; line-height: 1.25rem !important; }
+            
+            /* Timeline特殊类名修复 - Tailwind left-[5px] */
+            [class*="left-"][class*="5px"],
+            .absolute.left-\[5px\] {
+              left: 5px !important;
+            }
+            
+            /* 直接匹配Timeline线条元素 */
+            .absolute.top-6.w-0\.5.h-full.bg-gray-200,
+            .absolute[class*="top-6"][class*="w-0"][class*="h-full"][class*="bg-gray-200"] {
+              position: absolute !important;
+              left: 5px !important;
+              top: 1.5rem !important;
+              width: 0.125rem !important;
+              height: 100% !important;
+              background-color: #e5e7eb !important;
+            }
+            
+                         /* 更多Tailwind CSS类名支持 */
+             .justify-between { justify-content: space-between !important; }
+             .items-start { align-items: flex-start !important; }
+             .items-center { align-items: center !important; }
+             .space-y-4 > * + * { margin-top: 1rem !important; }
+             .space-y-2 > * + * { margin-top: 0.5rem !important; }
+             .mb-2 { margin-bottom: 0.5rem !important; }
+             .mb-4 { margin-bottom: 1rem !important; }
+             .p-4 { padding: 1rem !important; }
+             .p-2 { padding: 0.5rem !important; }
+             .px-4 { padding-left: 1rem !important; padding-right: 1rem !important; }
+             .py-2 { padding-top: 0.5rem !important; padding-bottom: 0.5rem !important; }
+             .border { border-width: 1px !important; }
+             .border-gray-200 { border-color: #e5e7eb !important; }
+             .rounded { border-radius: 0.25rem !important; }
+             .rounded-lg { border-radius: 0.5rem !important; }
+             .bg-white { background-color: ${colorBackground} !important; }
+             .bg-gray-50 { background-color: #f9fafb !important; }
+             .bg-gray-100 { background-color: #f3f4f6 !important; }
+             ${colorSidebar ? `.sidebar, [data-area="sidebar"] { background-color: ${colorSidebar} !important; }` : ''}
+             .text-gray-600 { color: #4b5563 !important; }
+             .text-gray-700 { color: #374151 !important; }
+             .text-gray-800 { color: ${colorText} !important; }
+             .text-gray-900 { color: ${colorText} !important; }
+             .text-xs { font-size: 0.75rem !important; line-height: 1rem !important; }
+             .leading-relaxed { line-height: 1.625 !important; }
+             .leading-normal { line-height: 1.5 !important; }
+             .text-center { text-align: center !important; }
+             .text-left { text-align: left !important; }
+             .text-right { text-align: right !important; }
+             .w-full { width: 100% !important; }
+             .h-auto { height: auto !important; }
+             .block { display: block !important; }
+             .inline { display: inline !important; }
+             .inline-block { display: inline-block !important; }
+             .hidden { display: none !important; }
+             .overflow-hidden { overflow: hidden !important; }
+             .truncate { overflow: hidden !important; text-overflow: ellipsis !important; white-space: nowrap !important; }
+             
+             /* 响应式样式支持 */
+             @media (min-width: 640px) {
+               .sm\:flex-row { flex-direction: row !important; }
+               .sm\:justify-between { justify-content: space-between !important; }
+               .sm\:items-start { align-items: flex-start !important; }
+               .sm\:mt-0 { margin-top: 0px !important; }
+               .sm\:text-left { text-align: left !important; }
+               .sm\:text-right { text-align: right !important; }
+               .sm\:block { display: block !important; }
+               .sm\:hidden { display: none !important; }
+             }
+             
+             @media (min-width: 768px) {
+               .md\:flex-row { flex-direction: row !important; }
+               .md\:justify-between { justify-content: space-between !important; }
+               .md\:items-start { align-items: flex-start !important; }
+               .md\:text-lg { font-size: 1.125rem !important; line-height: 1.75rem !important; }
+               .md\:text-xl { font-size: 1.25rem !important; line-height: 1.75rem !important; }
+             }
+            
+                         /* Timeline圆点样式确保 */
+             .timeline-dot {
+               position: absolute !important;
+               left: 0px !important;
+               top: 0.5rem !important;
+               width: 0.75rem !important;
+               height: 0.75rem !important;
+               background-color: ${colorPrimary} !important;
+               border-radius: 9999px !important;
+               border: 2px solid #ffffff !important;
+               box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 
+                           0 2px 4px -1px rgba(0, 0, 0, 0.06) !important;
+             }
+            
+            /* Timeline线条样式确保 */
+            .timeline-line {
+              position: absolute !important;
+              left: 5px !important;
+              top: 1.5rem !important;
+              width: 0.125rem !important;
+              height: 100% !important;
+              background-color: #e5e7eb !important;
+            }
             
             /* 单页无限延长核心样式 - 完全禁用分页 */
             @page {

--- a/src/templates/templateLayout/Timeline.tsx
+++ b/src/templates/templateLayout/Timeline.tsx
@@ -30,6 +30,7 @@ export function Timeline({ title, items, fieldMap = {}, style }: Props) {
   const textColor = style?.color || 'var(--color-text)';
   const primaryColor = 'var(--color-primary)'; // 使用主色调
   const secondaryColor = style?.color ? `${style.color}80` : 'var(--color-text-secondary)'; // 半透明版本
+  const timelineLineColor = '#e5e7eb'; // 统一的灰色线条
 
   return (
     <section 
@@ -63,11 +64,34 @@ export function Timeline({ title, items, fieldMap = {}, style }: Props) {
           return (
             <div key={idx} className="relative pl-6">
               {/* Timeline dot */}
-              <div className="absolute left-0 top-2 w-3 h-3 bg-blue-500 rounded-full border-2 border-white shadow-md"></div>
+              <div 
+                className="absolute left-0 top-2 w-3 h-3 bg-blue-500 rounded-full border-2 border-white shadow-md timeline-dot"
+                style={{
+                  position: 'absolute',
+                  left: '0px',
+                  top: '0.5rem',
+                  width: '0.75rem',
+                  height: '0.75rem',
+                  backgroundColor: primaryColor,
+                  borderRadius: '9999px',
+                  border: '2px solid #ffffff',
+                  boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)'
+                }}
+              ></div>
               
               {/* Timeline line */}
               {idx < items.length - 1 && (
-                <div className="absolute left-[5px] top-6 w-0.5 h-full bg-gray-200"></div>
+                <div 
+                  className="absolute left-[5px] top-6 w-0.5 h-full bg-gray-200 timeline-line"
+                  style={{
+                    position: 'absolute',
+                    left: '5px',
+                    top: '1.5rem',
+                    width: '0.125rem',
+                    height: '100%',
+                    backgroundColor: timelineLineColor
+                  }}
+                ></div>
               )}
               
               <div className="space-y-2">


### PR DESCRIPTION
## 问题描述
Timeline组件在PDF导出时存在样式丢失问题：
- Timeline圆点不显示
- 连接线缺失
- 布局样式丢失  
- 颜色不正确（始终显示蓝色，不响应用户自定义颜色）

## 解决方案

### 1. Timeline组件增强
- 为Timeline圆点和线条添加内联样式作为fallback
- 添加timeline-dot和timeline-line类名
- 确保在PDF导出时有可靠的样式支持

### 2. PDF导出样式补充
- 添加完整的Tailwind CSS类名定义到puppeteer-export.ts
- 修复特殊类名left-[5px]在PDF中的解析问题
- 添加Timeline特定样式规则

### 3. 颜色配置修复（核心修复）
- 更新exportOriginalStyle函数签名，添加templateId和customTemplate参数
- 实现正确的颜色获取逻辑：优先从模板配置获取颜色，使用mergeTemplateConfig合并配置
- 更新参数传递链：ResumeEdit  ResumePreviewPanel  Tools  exportOriginalStyle

## 修改文件
- src/templates/templateLayout/Timeline.tsx
- src/lib/puppeteer-export.ts  
- src/app/dashboard/edit/_components/Tools.tsx
- src/app/dashboard/edit/_components/ResumePreviewPanel.tsx

## 测试结果
修复后Timeline组件在PDF导出中能够：
-  正确显示时间轴圆点（使用用户自定义主色调）
-  显示连接线
-  保持正确的布局结构
-  应用用户在模板定制器中设置的所有颜色配置
-  支持所有使用Timeline的模板（Azurill、Gengar、Teal Professional等）