### PR TITLE
🚀 ci: publish Docker image to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.next
+.turbo
+node_modules
+**/node_modules
+**/.next
+**/.turbo
+**/dist
+**/coverage
+.env
+.env.*
+!.env.example
+npm-debug.log*
+pnpm-debug.log*
+Dockerfile
+docker-compose*.yml

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,8 +1,17 @@
 name: Build and Push Docker Image
 
 on:
+  workflow_dispatch:
   push:
     branches: [ "master" ]
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: linmoqc/magic-resume
 
 jobs:
   build_and_push:
@@ -17,18 +26,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
+            type=sha,prefix=
 
       - name: Build and push Docker image
-        # This action builds the image from your Dockerfile and pushes it to Docker Hub.
+        # This action builds the web app image and pushes it to GitHub Container Registry.
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: apps/web/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/magic-resume:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }} 
+            NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${{ secrets.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -2,42 +2,58 @@
 FROM node:20-alpine AS deps
 WORKDIR /app
 
-# Install dependencies
-COPY package.json package-lock.json* ./
-RUN npm ci
+RUN corepack enable
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json .npmrc ./
+COPY patches ./patches
+COPY apps/docs/package.json apps/docs/package.json
+COPY apps/web/package.json apps/web/package.json
+COPY packages/env/package.json packages/env/package.json
+COPY packages/mcp/package.json packages/mcp/package.json
+COPY packages/resume-schema/package.json packages/resume-schema/package.json
+COPY packages/resume-templates/package.json packages/resume-templates/package.json
+COPY packages/tsconfig/package.json packages/tsconfig/package.json
+COPY packages/utils/package.json packages/utils/package.json
+
+RUN pnpm install --frozen-lockfile
 
 ### STAGE 2: BUILDER ###
 FROM node:20-alpine AS builder
 WORKDIR /app
+
+RUN corepack enable
+
 COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/apps ./apps
+COPY --from=deps /app/packages ./packages
 COPY . .
 
 # Disable telemetry
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NEXT_TELEMETRY_DISABLED=1
 
 # Declare build arguments
 ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 
-RUN npm run build
+RUN pnpm --filter @magic-resume/web... build
 
 ### STAGE 3: RUNNER ###
 FROM node:20-alpine AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
-ENV NEXT_TELEMETRY_DISABLED 1
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
 
 # Copy files from builder stage
-COPY --from=builder /app/public ./public
+COPY --from=builder --chown=node:node /app/apps/web/public ./apps/web/public
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=node:node /app/.next/standalone ./
-COPY --from=builder --chown=node:node /app/.next/static ./.next/static
+COPY --from=builder --chown=node:node /app/apps/web/.next/standalone ./
+COPY --from=builder --chown=node:node /app/apps/web/.next/static ./apps/web/.next/static
 
 USER node
 
 EXPOSE 3000
-ENV PORT 3000
+ENV PORT=3000
 
-CMD ["node", "server.js"] 
+CMD ["node", "apps/web/server.js"]


### PR DESCRIPTION
## Summary
- switch Docker image publishing from Docker Hub secrets to GitHub Container Registry using GITHUB_TOKEN
- point docker/build-push-action at apps/web/Dockerfile and add metadata tags for latest and commit SHA
- update the web Dockerfile for the pnpm/turborepo monorepo build and add a root .dockerignore