### PR TITLE
:lipstick: style(web): 优化 dashboard 与 editor 骨架屏适配新版布局

### DIFF
--- a/apps/web/src/app/dashboard/_components/DashboardSidebar.tsx
+++ b/apps/web/src/app/dashboard/_components/DashboardSidebar.tsx
@@ -128,23 +128,29 @@ export default function DashboardSidebar() {
 
         <div className="flex-1" />
 
-        {/* account — the whole row is the trigger (name/email live inside the button) */}
+        {/* account — the whole row is the trigger (name/email live inside the button).
+            Cloud mode resolves the user async; show a skeleton row until it lands so
+            the footer never flashes a lone, unlabelled avatar icon. */}
         <div className="h-px bg-white/[0.06]" />
         <div className="mt-3">
-          <AccountMenu
-            placement={collapsed ? 'right' : 'up'}
-            label={
-              !collapsed && (name || email) ? (
-                <span
-                  className="block max-w-[142px] overflow-hidden pl-1 text-left opacity-100"
-                  style={labelStyle}
-                >
-                  {name && <span className="block truncate text-[13px] font-medium text-neutral-100">{name}</span>}
-                  {email && <span className="block truncate text-[11px] text-neutral-500">{email}</span>}
-                </span>
-              ) : undefined
-            }
-          />
+          {isCloudMode && !user ? (
+            <AccountRowSkeleton collapsed={collapsed} labelStyle={labelStyle} />
+          ) : (
+            <AccountMenu
+              placement={collapsed ? 'right' : 'up'}
+              label={
+                !collapsed && (name || email) ? (
+                  <span
+                    className="block max-w-[142px] overflow-hidden pl-1 text-left opacity-100"
+                    style={labelStyle}
+                  >
+                    {name && <span className="block truncate text-[13px] font-medium text-neutral-100">{name}</span>}
+                    {email && <span className="block truncate text-[11px] text-neutral-500">{email}</span>}
+                  </span>
+                ) : undefined
+              }
+            />
+          )}
         </div>
       </div>
 
@@ -158,6 +164,34 @@ export default function DashboardSidebar() {
         <ChevronLeft className={cn('h-3.5 w-3.5 transition-transform duration-300', collapsed && 'rotate-180')} />
       </button>
     </aside>
+  );
+}
+
+/** Placeholder for the account footer while the user resolves. Mirrors the real
+ *  row: avatar in a fixed 36px column + name/email lines that collapse with the panel. */
+function AccountRowSkeleton({
+  collapsed,
+  labelStyle,
+}: {
+  collapsed: boolean;
+  labelStyle?: React.CSSProperties;
+}) {
+  return (
+    <div className="flex h-11 items-center rounded-xl px-2">
+      <span className="grid w-9 shrink-0 place-items-center">
+        <span className="h-8 w-8 animate-pulse rounded-full bg-white/[0.06] ring-1 ring-white/[0.06]" />
+      </span>
+      <span
+        className={cn(
+          'overflow-hidden pl-1',
+          collapsed ? 'max-w-0 opacity-0' : 'max-w-[142px] opacity-100',
+        )}
+        style={labelStyle}
+      >
+        <span className="block h-3 w-24 animate-pulse rounded bg-white/[0.06]" />
+        <span className="mt-1.5 block h-2.5 w-28 animate-pulse rounded bg-white/[0.04]" />
+      </span>
+    </div>
   );
 }
 

--- a/apps/web/src/app/dashboard/_components/ResumeList.tsx
+++ b/apps/web/src/app/dashboard/_components/ResumeList.tsx
@@ -327,6 +327,43 @@ function ResumeCardSkeleton() {
   );
 }
 
+/* ── 全页骨架:挂载 / 首屏加载时替代空白黑屏,结构与真实布局同构
+      (标题 + 创建/导入入口 + 简历栅格),不用 i18n 以避免水合闪烁 ── */
+function DashboardSkeleton() {
+  return (
+    <div className="flex-1 overflow-y-auto bg-[#0A0A0A] [contain:layout_paint]">
+      <div className="mx-auto w-full max-w-[1400px] px-6 py-10 md:px-12">
+        {/* 标题 */}
+        <header className="mb-8 flex items-end justify-between gap-4">
+          <div className="h-7 w-32 animate-pulse rounded-lg bg-white/[0.06]" />
+          <div className="h-6 w-24 animate-pulse rounded-full bg-white/[0.03]" />
+        </header>
+
+        {/* 入口区:主(创建)+ 次(导入) */}
+        <section className="mb-10 grid grid-cols-1 gap-4 md:grid-cols-[1.6fr_1fr]">
+          <div className="h-40 rounded-2xl border border-sky-400/15 bg-sky-400/[0.05] px-6 py-6">
+            <div className="h-9 w-9 animate-pulse rounded-xl bg-sky-400/15" />
+            <div className="mt-4 h-5 w-32 animate-pulse rounded bg-white/[0.06]" />
+            <div className="mt-2 h-3.5 w-40 animate-pulse rounded bg-white/[0.04]" />
+          </div>
+          <div className="h-40 rounded-2xl border border-white/[0.06] bg-white/[0.02] px-6 py-6">
+            <div className="h-9 w-9 animate-pulse rounded-xl bg-white/[0.05]" />
+            <div className="mt-4 h-5 w-28 animate-pulse rounded bg-white/[0.06]" />
+            <div className="mt-2 h-3.5 w-32 animate-pulse rounded bg-white/[0.04]" />
+          </div>
+        </section>
+
+        {/* 简历栅格 */}
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <ResumeCardSkeleton key={`skeleton-${i}`} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function EmptyState() {
   const { t } = useTranslation();
   return (
@@ -356,8 +393,9 @@ const ResumeList = React.memo(
         .catch((e) => console.error('Failed to load templates for dashboard', e));
     }, []);
 
-    // Prevent SSR/CSR flicker for this client-only list.
-    if (!isMounted) return null;
+    // Prevent SSR/CSR flicker for this client-only list. Render a full-page
+    // skeleton (not a blank screen) until the client mounts and data is ready.
+    if (!isMounted || isLoading) return <DashboardSkeleton />;
 
     return (
       // contain: layout paint — isolate this large subtree so the sidebar's width
@@ -371,7 +409,7 @@ const ResumeList = React.memo(
               <h1 className="text-2xl font-semibold tracking-tight text-neutral-50">
                 {t('dashboard.library.title')}
               </h1>
-              {!isLoading && resumes.length > 0 && (
+              {resumes.length > 0 && (
                 <span className="text-sm text-neutral-500">
                   {t('dashboard.library.count', { count: resumes.length })}
                 </span>
@@ -396,9 +434,7 @@ const ResumeList = React.memo(
             initial="hidden"
             animate="show"
           >
-            {isLoading ? (
-              Array.from({ length: 6 }).map((_, i) => <ResumeCardSkeleton key={`skeleton-${i}`} />)
-            ) : resumes.length === 0 ? (
+            {resumes.length === 0 ? (
               <EmptyState />
             ) : (
               <AnimatePresence>

--- a/apps/web/src/app/dashboard/edit/_components/layout/ResumeEditSkeleton.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/layout/ResumeEditSkeleton.tsx
@@ -1,86 +1,163 @@
-import { Skeleton } from '@/components/ui/Skeleton';
+import { LEFT_PANEL_WIDTH, LEFT_RAIL_WIDTH } from "./OutlineRail";
+import { PANEL_WIDTH, RAIL_WIDTH } from "../templates/TemplatePanel";
+
+/* 骨架条:与新版工作台一致,用极轻的白色叠加而非实心灰块,呼吸感来自 animate-pulse */
+function Bar({ className = "" }: { className?: string }) {
+  return <div className={`animate-pulse rounded-md bg-white/[0.05] ${className}`} />;
+}
+
+/* 图标轨占位:一列小方块,顶部一个折叠钮 + 分隔线 + 若干分区图标 */
+function RailSkeleton({ side }: { side: "left" | "right" }) {
+  return (
+    <div
+      className={`flex h-full shrink-0 flex-col items-center gap-2 bg-[#0A0A0A] py-3 ${
+        side === "left" ? "border-r" : "border-l"
+      } border-white/[0.06]`}
+      style={{ width: side === "left" ? LEFT_RAIL_WIDTH : RAIL_WIDTH }}
+    >
+      <Bar className="h-8 w-8 rounded-xl" />
+      <div className="my-0.5 h-px w-6 bg-white/[0.08]" />
+      {Array.from({ length: side === "left" ? 7 : 4 }).map((_, i) => (
+        <Bar key={i} className="h-8 w-8 rounded-xl" />
+      ))}
+      {side === "left" && (
+        <div className="mt-auto flex flex-col items-center gap-2.5 pt-2">
+          <div className="h-px w-6 bg-white/[0.08]" />
+          <Bar className="h-8 w-8 rounded-full" />
+        </div>
+      )}
+    </div>
+  );
+}
 
 export default function ResumeEditSkeleton() {
   return (
-    <main className="flex flex-col lg:flex-row flex-1 h-screen bg-black text-white font-sans overflow-hidden relative">
-
-      {/* Main Form Panel - Desktop Only */}
-      <div className="hidden lg:block w-[300px] p-8 overflow-y-auto shrink-0 border-r border-neutral-800">
-        <div className="mb-8">
-          <Skeleton className="h-8 w-32 mb-6" />
-          <div className="flex items-center gap-4 mb-6">
-            <Skeleton className="h-16 w-16 rounded-full shrink-0" />
-            <div className="w-full space-y-2">
-              <Skeleton className="h-5 w-24" />
-              <Skeleton className="h-10 w-full" />
-            </div>
+    // 三列 in-flow flex:左右面板 shrink-0、中间画布 flex-1,画布自然居中于两侧面板之间;
+    // 移动端面板 hidden,画布占满全宽。无需 fixed / margin,天然对称。
+    <main className="flex h-screen min-w-0 flex-1 overflow-hidden bg-black text-white">
+      {/* ── 左:图标轨 + 内容表单面板 ── */}
+      <div className="hidden h-full shrink-0 lg:flex">
+        <RailSkeleton side="left" />
+        <div
+          className="h-full border-r border-white/[0.06] bg-[#0A0A0A]"
+          style={{ width: LEFT_PANEL_WIDTH }}
+        >
+          <div className="flex items-center border-b border-white/[0.06] px-4 py-4">
+            <Bar className="h-5 w-16" />
           </div>
-          <div className="grid grid-cols-2 gap-4">
-            {[...Array(6)].map((_, i) => (
-              <div key={i} className="space-y-2">
-                <Skeleton className="h-5 w-24" />
-                <Skeleton className="h-10 w-full" />
+
+          <div className="space-y-6 px-4 py-5">
+            {/* 基本信息:头像 + 名称 */}
+            <div className="space-y-4">
+              <Bar className="h-4 w-24" />
+              <div className="flex items-center gap-3">
+                <Bar className="h-14 w-14 shrink-0 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <Bar className="h-3.5 w-16" />
+                  <Bar className="h-9 w-full rounded-lg" />
+                </div>
+              </div>
+              {/* 字段两列栅格 */}
+              <div className="grid grid-cols-2 gap-3">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <div key={i} className="space-y-2">
+                    <Bar className="h-3 w-14" />
+                    <Bar className="h-9 w-full rounded-lg" />
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* 折叠分区标题占位 */}
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 border-t border-white/[0.06] pt-5">
+                <Bar className="h-8 w-8 rounded-lg" />
+                <Bar className="h-4 w-28" />
               </div>
             ))}
           </div>
         </div>
+      </div>
 
-        <div className="space-y-6">
-          <Skeleton className="h-8 w-40" />
-          <Skeleton className="h-12 w-full rounded-lg border border-dashed border-neutral-700" />
+      {/* ── 中:画布(顶栏 scrim + 预览纸 + 底部工具坞) ── */}
+      <div className="relative flex min-w-0 flex-1 flex-col items-center justify-center bg-black">
+        {/* 顶栏:返回 + 标题 */}
+        <div className="pointer-events-none absolute inset-x-0 top-0 flex h-16 items-center gap-2 px-6">
+          <Bar className="h-8 w-8 rounded-lg" />
+          <Bar className="h-5 w-40" />
         </div>
 
-        <div className="mt-8 pt-6 border-t border-neutral-800 flex justify-end gap-3">
-          <Skeleton className="h-9 w-28" />
-          <Skeleton className="h-9 w-20" />
+        {/* 预览纸:A4 比例 */}
+        <div className="flex h-full max-h-[calc(100vh-8rem)] items-center px-4 py-16">
+          <div className="aspect-[210/297] h-full max-w-full animate-pulse rounded-lg bg-white/[0.04] shadow-2xl" />
+        </div>
+
+        {/* 底部工具坞:胶囊 */}
+        <div className="absolute bottom-6 left-1/2 -translate-x-1/2">
+          <div className="flex items-center gap-1.5 rounded-full border border-white/10 bg-neutral-900/70 px-2.5 py-2 backdrop-blur-md">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <Bar key={i} className="h-6 w-6 rounded-lg" />
+            ))}
+          </div>
         </div>
       </div>
 
-      {/* Center Preview Panel - Visible on both, adopted for Mobile */}
-      <div className="flex flex-1 min-w-0 flex-col items-center justify-center p-4 lg:p-8 bg-[#101010] relative">
-        
-        {/* Mobile Top Floating Buttons Skeleton */}
-        <div className="lg:hidden absolute top-4 left-4 z-10">
-           <Skeleton className="h-10 w-10 rounded-full bg-neutral-800" />
-        </div>
-        <div className="lg:hidden absolute top-4 left-1/2 -translate-x-1/2 z-10">
-           <Skeleton className="h-10 w-10 rounded-full bg-neutral-800" />
-        </div>
-        <div className="lg:hidden absolute top-4 right-4 z-10">
-           <Skeleton className="h-10 w-10 rounded-full bg-neutral-800" />
-        </div>
+      {/* ── 右:自定义面板 + 图标轨 ── */}
+      <div className="hidden h-full shrink-0 lg:flex">
+        <div
+          className="h-full border-l border-white/[0.06] bg-[#0A0A0A]"
+          style={{ width: PANEL_WIDTH }}
+        >
+          <div className="flex items-center border-b border-white/[0.06] px-4 py-4">
+            <Bar className="h-5 w-16" />
+          </div>
 
-        {/* Main Resume Paper Skeleton */}
-        <div className="w-full max-w-4xl h-full flex items-center justify-center">
-          <Skeleton className="w-full lg:w-[210mm] max-w-full aspect-210/297 rounded-lg shadow-2xl opacity-50 lg:opacity-100" />
-        </div>
+          <div className="space-y-6 px-4 py-5">
+            {/* 模板卡片 */}
+            <div className="space-y-3">
+              <div className="flex items-center gap-3">
+                <Bar className="h-8 w-8 rounded-lg" />
+                <Bar className="h-4 w-20" />
+              </div>
+              <div className="flex gap-3 rounded-xl border border-white/10 bg-white/[0.03] p-3">
+                <Bar className="h-20 w-[60px] shrink-0 rounded-md" />
+                <div className="flex-1 space-y-2 py-1">
+                  <Bar className="h-4 w-24" />
+                  <Bar className="h-3 w-full" />
+                  <Bar className="h-3 w-3/4" />
+                </div>
+              </div>
+              {/* 标签 */}
+              <div className="flex flex-wrap gap-1.5">
+                {["w-16", "w-12", "w-20", "w-14"].map((w, i) => (
+                  <Bar key={i} className={`h-6 rounded-full ${w}`} />
+                ))}
+              </div>
+            </div>
 
-        {/* Desktop Bottom Toolbar Logic */}
-        <div className="hidden lg:flex items-center gap-3 mt-6">
-          <Skeleton className="h-8 w-8 rounded-full" />
-          <Skeleton className="h-8 w-8 rounded-full" />
-          <Skeleton className="h-10 w-10 rounded-full" />
-          <Skeleton className="h-8 w-8 rounded-full" />
-          <Skeleton className="h-8 w-8 rounded-full" />
-        </div>
+            {/* 折叠分区标题 */}
+            {Array.from({ length: 2 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-3 border-t border-white/[0.06] pt-5">
+                <Bar className="h-8 w-8 rounded-lg" />
+                <Bar className="h-4 w-24" />
+              </div>
+            ))}
 
-         {/* Mobile Bottom Dock Skeleton */}
-         <div className="lg:hidden absolute bottom-8 left-1/2 -translate-x-1/2 flex items-center gap-2 p-2 rounded-full bg-neutral-900/80 border border-neutral-700 backdrop-blur-sm z-20">
-            <Skeleton className="h-8 w-8 rounded-full bg-neutral-700" />
-            <Skeleton className="h-8 w-8 rounded-full bg-neutral-700" />
-            <Skeleton className="h-8 w-8 rounded-full bg-neutral-700" />
-            <Skeleton className="h-8 w-8 rounded-full bg-neutral-700" />
-         </div>
-      </div>
-
-      {/* Right Template Panel - Desktop Only */}
-      <div className="hidden lg:block w-80 bg-black border-l border-neutral-800 p-6 shrink-0 overflow-y-auto">
-        <Skeleton className="h-8 w-32 mb-6" />
-        <div className="grid grid-cols-2 gap-4">
-          {[...Array(6)].map((_, i) => (
-            <Skeleton key={i} className="w-full aspect-210/297 rounded-md" />
-          ))}
+            {/* 配色:快速主题色板 */}
+            <div className="space-y-3 border-t border-white/[0.06] pt-5">
+              <div className="flex items-center gap-3">
+                <Bar className="h-8 w-8 rounded-lg" />
+                <Bar className="h-4 w-16" />
+              </div>
+              <div className="flex gap-2">
+                {Array.from({ length: 6 }).map((_, i) => (
+                  <Bar key={i} className="h-9 w-9 rounded-lg" />
+                ))}
+              </div>
+            </div>
+          </div>
         </div>
+        <RailSkeleton side="right" />
       </div>
     </main>
   );


### PR DESCRIPTION
## 背景

新版工作台(编辑页三栏 + dashboard 简历库)上线后,原有的加载骨架屏还停留在旧布局,加载时会「跳版」或出现空白/未完成的元素。本 PR 让骨架屏与真实布局同构。

## 改动

### 编辑页 `ResumeEditSkeleton`
- 按新版**三栏工作台**重建:左侧图标轨 + 内容表单面板、中间画布(顶栏 + A4 预览纸 + 底部工具坞)、右侧自定义面板 + 图标轨。
- 采用 **in-flow flex 三列**(左右面板 `shrink-0`、中间画布 `flex-1`),预览纸天然居中于两侧面板之间,不再依赖 `fixed` + CSS 变量边距。
- `<main>` 补 `flex-1` 以填满编辑路由容器(此前只按内容取宽,右侧留黑边)。
- 配色统一为新版 `#0A0A0A` + `white/[0.05~0.08]` 细边。

### Dashboard 全页骨架 `DashboardSkeleton`
- 首屏挂载 / 数据加载期间渲染结构化占位(标题 + 创建/导入入口 + 简历栅格),替代此前的纯黑空白屏;不使用 i18n 以避免水合闪烁。

### 侧边栏账号占位 `AccountRowSkeleton`
- Cloud 模式下用户信息异步解析,footer 不再闪现一个「孤零零的无标签头像」;解析完成后切回正常 `AccountMenu`。自托管模式行为不变。

## 验证
- `pnpm lint` ✅(pre-commit 全量 lint + build 通过)
- 逐张对照新版设计截图核对左右对称 / 占满全屏 / 账号区占位

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fuller loading placeholders across the dashboard, including a consistent skeleton view while content loads.
  * Improved the account area in the sidebar with a loading placeholder before user details appear.
  * Updated the resume editor loading screen with a more polished, responsive skeleton layout.

* **Bug Fixes**
  * Reduced blank or partially rendered states during initial page load for a smoother experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->