### PR TITLE
:bug: fix(web): keep chat-agent SSE unbuffered through nginx

### DIFF
--- a/apps/web/src/app/api/chat-agent/approve/route.ts
+++ b/apps/web/src/app/api/chat-agent/approve/route.ts
@@ -74,8 +74,12 @@ export async function POST(req: NextRequest) {
       return new Response(readable, {
         headers: {
           'Content-Type': 'text/event-stream',
-          'Cache-Control': 'no-cache',
+          // no-transform stops intermediaries gzipping the stream; X-Accel-Buffering
+          // tells nginx not to buffer this response even if proxy_buffering is on
+          // globally (host BaoTa reverse proxy defaults to on).
+          'Cache-Control': 'no-cache, no-transform',
           Connection: 'keep-alive',
+          'X-Accel-Buffering': 'no',
         },
       });
     }

--- a/apps/web/src/app/api/chat-agent/route.ts
+++ b/apps/web/src/app/api/chat-agent/route.ts
@@ -91,8 +91,15 @@ export async function POST(req: NextRequest) {
             return new Response(readable, {
                 headers: {
                     'Content-Type': 'text/event-stream',
-                    'Cache-Control': 'no-cache',
+                    // no-transform stops any intermediary (nginx/CDN) from gzipping
+                    // the stream (gzip batches chunks and defeats SSE).
+                    'Cache-Control': 'no-cache, no-transform',
                     'Connection': 'keep-alive',
+                    // Tell nginx to disable response buffering for THIS stream even
+                    // if proxy_buffering is on globally (host BaoTa reverse proxy
+                    // defaults to on) — code-level safety net so streaming survives
+                    // an nginx config reset.
+                    'X-Accel-Buffering': 'no',
                 },
             });
         } else {


### PR DESCRIPTION
## 问题
线上 AI Lab 不流式输出:token 憋到最后一次性到达,本地正常。

## 根因
AI Lab 走前端自己的 `/api/chat-agent` 路由,该响应经过宿主机的宝塔反代 nginx(默认 `proxy_buffering on`)。这层把 `text/event-stream` 缓冲了。仓库里的 `magic-nginx` 已 `proxy_buffering off`,但它不在这条链路上。本地无宝塔层,故本地正常。

## 改动
给两个 chat-agent SSE 响应加头(只加头,不改逻辑):
- `X-Accel-Buffering: no` — 让 nginx 对这条流关闭缓冲,即使全局 `proxy_buffering on`;
- `Cache-Control: no-cache, no-transform` — 阻止中间层 gzip(gzip 会攒批,破坏 SSE)。

宝塔那层已手动加 `proxy_buffering off` 修复;本 PR 是**代码级双保险**,防止 nginx 配置被重置后复发。

## 影响 / 风险
- 只作用于带这些头的 SSE 响应,不影响其它接口/静态资源/gzip。
- 无 nginx 环境忽略该头,本地行为不变。无安全/正确性影响,可回滚。
- pre-commit 全量 build 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming chat responses so they are less likely to be buffered or altered by intermediaries.
  * Updated response settings to better support real-time event delivery in browsers and across proxies.
  * Added safeguards to keep server-sent events flowing as intended.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->