### PR TITLE
:lipstick: style(web): refine AI Lab skill menu & confirm dialog

### DIFF
--- a/apps/web/src/app/dashboard/edit/_components/ai/conversation/Composer.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ai/conversation/Composer.tsx
@@ -146,9 +146,9 @@ export default function Composer({
               animate={{ opacity: 1, y: 0, scale: 1 }}
               exit={{ opacity: 0, y: 8, scale: 0.98 }}
               transition={{ duration: 0.16, ease: [0.22, 1, 0.36, 1] }}
-              className="absolute left-0 right-0 bottom-[calc(100%+10px)] rounded-2xl bg-neutral-900/95 backdrop-blur-xl border border-neutral-800 p-2 z-20 shadow-2xl shadow-black/60 origin-bottom"
+              className="absolute left-0 right-0 bottom-[calc(100%+10px)] rounded-2xl bg-neutral-900/95 backdrop-blur-xl border border-white/[0.06] p-2 z-20 shadow-2xl shadow-black/60 origin-bottom"
             >
-              <div className="px-2 pb-1.5 pt-0.5 text-[10px] font-medium uppercase tracking-wider text-neutral-600">
+              <div className="px-2.5 pb-2 pt-1 text-[10px] font-medium uppercase tracking-[0.14em] text-neutral-600">
                 {t('aiLab.composer.skills')}
               </div>
               {matches.map((s, i) => {
@@ -161,23 +161,35 @@ export default function Composer({
                     onMouseEnter={() => setHighlight(i)}
                     onClick={() => chooseSkill(s.id)}
                     className={cn(
-                      'w-full flex items-center gap-3 px-2 py-2 rounded-xl transition-colors cursor-pointer text-left',
-                      active ? 'bg-neutral-800' : 'hover:bg-neutral-800/50'
+                      'group w-full flex items-center gap-3 px-2.5 py-2.5 rounded-xl transition-colors cursor-pointer text-left',
+                      // The single sky accent on the whole surface: only the active row.
+                      active ? 'bg-sky-400/[0.08]' : 'hover:bg-white/[0.04]'
                     )}
                   >
-                    <span
-                      className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
-                      style={{ backgroundColor: `${s.accentHex}1f` }}
-                    >
-                      <Icon size={16} className={s.accent} />
+                    <span className="flex items-center justify-center w-7 h-7 shrink-0">
+                      <Icon
+                        size={17}
+                        className={cn(
+                          'transition-colors',
+                          // Neutral at rest (tinted a touch toward sky), sky only when active.
+                          active ? 'text-sky-400' : 'text-neutral-500 group-hover:text-neutral-400'
+                        )}
+                      />
                     </span>
                     <span className="min-w-0 flex-1">
-                      <span className="block text-[13px] font-medium text-neutral-100 truncate">{s.name}</span>
+                      <span
+                        className={cn(
+                          'block text-[13px] font-medium truncate transition-colors',
+                          active ? 'text-neutral-50' : 'text-neutral-300'
+                        )}
+                      >
+                        {s.name}
+                      </span>
                       <span className="block text-[11px] text-neutral-500 truncate">{s.tagline}</span>
                     </span>
                     <kbd
                       className={cn(
-                        'shrink-0 rounded bg-neutral-700/70 px-1.5 py-0.5 font-mono text-[10px] leading-none text-sky-300 transition-opacity',
+                        'shrink-0 rounded-md px-1.5 py-0.5 font-mono text-[10px] leading-none bg-sky-400/15 text-sky-300 transition-opacity',
                         active ? 'opacity-100' : 'opacity-0'
                       )}
                     >
@@ -186,17 +198,19 @@ export default function Composer({
                   </button>
                 );
               })}
-              <div className="mt-1.5 flex items-center gap-3 px-2 pt-2 text-[10px] text-neutral-600 border-t border-neutral-800/80">
-                <span className="inline-flex items-center gap-1">
-                  <kbd className="rounded bg-neutral-800 px-1 py-0.5 font-mono text-neutral-400">{'↑↓'}</kbd>
+              <div className="mt-1 flex items-center gap-2 px-2.5 pt-2.5 pb-0.5 text-[10px] text-neutral-600">
+                <span className="inline-flex items-center gap-1.5">
+                  <kbd className="rounded bg-white/[0.05] px-1 py-0.5 font-mono text-neutral-500">{'↑↓'}</kbd>
                   {t('aiLab.composer.switch')}
                 </span>
-                <span className="inline-flex items-center gap-1">
-                  <kbd className="rounded bg-neutral-800 px-1 py-0.5 font-mono text-neutral-400">{'↵'}</kbd>
+                <span className="text-neutral-700">·</span>
+                <span className="inline-flex items-center gap-1.5">
+                  <kbd className="rounded bg-white/[0.05] px-1 py-0.5 font-mono text-neutral-500">{'↵'}</kbd>
                   {t('aiLab.composer.select')}
                 </span>
-                <span className="inline-flex items-center gap-1">
-                  <kbd className="rounded bg-neutral-800 px-1 py-0.5 font-mono text-neutral-400">{'esc'}</kbd>
+                <span className="text-neutral-700">·</span>
+                <span className="inline-flex items-center gap-1.5">
+                  <kbd className="rounded bg-white/[0.05] px-1 py-0.5 font-mono text-neutral-500">{'esc'}</kbd>
                   {t('aiLab.composer.exit')}
                 </span>
               </div>

--- a/apps/web/src/components/shared/ConfirmDialog.tsx
+++ b/apps/web/src/components/shared/ConfirmDialog.tsx
@@ -38,22 +38,28 @@ export default function ConfirmDialog({
 
   return (
     <AlertDialog open={isOpen} onOpenChange={onClose}>
-      {/* Add overlay with higher z-index */}
+      {/* Custom overlay carries a higher z-index so the dialog floats above the AI Lab. */}
       <div className={`fixed inset-0 z-150 ${isOpen ? 'block' : 'hidden'}`}>
-        <div className="fixed inset-0 bg-black/50 cursor-pointer" onClick={onClose} />
-        <AlertDialogContent className="bg-neutral-950 border-neutral-800 text-white fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-150">
-          <AlertDialogHeader>
-            <AlertDialogTitle className="text-xl font-bold">{title}</AlertDialogTitle>
+        {/* Slightly deeper scrim + soft blur to focus the dialog over the dark workbench. */}
+        <div
+          className="fixed inset-0 bg-black/60 backdrop-blur-[2px] cursor-pointer"
+          onClick={onClose}
+        />
+        <AlertDialogContent className="fixed top-1/2 left-1/2 z-150 grid w-full max-w-[calc(100%-2rem)] sm:max-w-md -translate-x-1/2 -translate-y-1/2 gap-3.5 rounded-2xl border border-white/[0.06] bg-neutral-950 p-6 text-white shadow-2xl shadow-black/60">
+          <AlertDialogHeader className="gap-2">
+            <AlertDialogTitle className="text-lg font-semibold tracking-tight text-neutral-50">
+              {title}
+            </AlertDialogTitle>
             {description && (
-              <AlertDialogDescription className="text-neutral-400">
+              <AlertDialogDescription className="text-[13px] leading-relaxed text-neutral-400">
                 {description}
               </AlertDialogDescription>
             )}
           </AlertDialogHeader>
-          <AlertDialogFooter className="mt-4">
-            <AlertDialogCancel 
+          <AlertDialogFooter className="mt-3 gap-2">
+            <AlertDialogCancel
               onClick={onClose}
-              className="bg-transparent border-neutral-700 hover:bg-neutral-900 text-white"
+              className="rounded-lg border border-white/[0.08] bg-transparent px-4 text-neutral-300 hover:bg-white/[0.04] hover:text-neutral-100 focus-visible:ring-2 focus-visible:ring-white/15 focus-visible:ring-offset-0"
             >
               {cancelText || t('common.cancel')}
             </AlertDialogCancel>
@@ -62,7 +68,13 @@ export default function ConfirmDialog({
                 onConfirm();
                 onClose();
               }}
-              className={variant === 'danger' ? "bg-red-600 hover:bg-red-500 text-white border-none" : "bg-indigo-600 hover:bg-indigo-500 text-white border-none"}
+              className={
+                variant === 'danger'
+                  ? // Restrained destructive: theme red #dc2626, softened a touch so it signals without shouting.
+                    'rounded-lg border-none bg-red-600/90 px-4 font-medium text-white hover:bg-red-600 focus-visible:ring-2 focus-visible:ring-red-500/40 focus-visible:ring-offset-0'
+                  : // Positive confirm uses the brand sky accent, matching the composer send button.
+                    'rounded-lg border-none bg-sky-500 px-4 font-medium text-white hover:bg-sky-600 focus-visible:ring-2 focus-visible:ring-sky-400/40 focus-visible:ring-offset-0'
+              }
             >
               {confirmText || t('common.confirm')}
             </AlertDialogAction>


### PR DESCRIPTION
## What

前端样式打磨,让 AI 实验室的两个界面更贴合深色工作台设计主题(单一 sky 点缀、少割裂、动效克制)。纯样式,行为 / props / i18n 均不变。

### 技能调用菜单(`/` slash menu · `Composer.tsx`)
- 去掉五个饱和撞色图标方块 → 统一中性图标,**仅当前选中行**用 sky 高亮(唯一点缀)。
- 选中行改为极淡 sky 染色,替代抢眼的 neutral 整块。
- 面板边框软化(`neutral-800` → `white/[0.06]`),行距更松。
- 底部快捷键提示收拢为一行、降对比,去掉分隔线的割裂感。

### 共享确认弹窗(`ConfirmDialog.tsx`)
- **克制红**:破坏性确认钮收敛为更柔和的主题红,不再抢镜。
- default 变体由 off-brand `indigo` 改为主题 `sky`。
- 取消钮降为安静 ghost,与确认钮拉开层级。
- 弹窗边框 / 遮罩软化 + 轻微 backdrop-blur,三个按钮加主题色 `focus-visible` 焦点环。

> 共享组件重塑,删除简历等其他确认框一并受益。

## Test
- `pnpm --filter @magic-resume/web lint` / build 通过(commit 时 husky 已跑 build)。
- 手测:编辑器输入框敲 `/` 查看技能菜单;AI 实验室点「新对话」查看确认弹窗。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the `/` skills suggestion dropdown with updated panel, row, icon, and keycap styling for a cleaner visual hierarchy.
  * Improved the keyboard help legend spacing and separators for clearer guidance.
  * Updated the confirm dialog’s backdrop, layout, and button styling to better match the latest visual design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->