### PR TITLE
:memo: docs: revamp README and add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,151 @@
+# Contributing to Magic Resume
+
+Thanks for your interest in contributing! Contributions of every size are welcome — bug fixes, new templates, docs, translations, or features.
+
+**English** · [简体中文](./CONTRIBUTING.zh-CN.md)
+
+---
+
+## Ways to contribute
+
+- **Report a bug** or request a feature — open an [issue](https://github.com/LinMoQC/Magic-Resume/issues).
+- **Fix a bug** or **build a feature** — open a Pull Request.
+- **Add a template** — see [`packages/resume-templates`](./packages/resume-templates).
+- **Improve translations** — see [Translations](#translations).
+- **Improve the docs** — including this file and the READMEs.
+
+For anything non-trivial, opening an issue first to discuss the approach saves everyone time.
+
+---
+
+## Prerequisites
+
+- **Node.js** `>= 20`
+- **pnpm** `>= 10.28.1` (this repo pins `pnpm@10.28.1` via `packageManager`)
+
+## Local setup
+
+Magic Resume runs fully in the browser — no backend or database needed for most work.
+
+```bash
+# 1. Fork, then clone your fork
+git clone https://github.com/<you>/Magic-Resume.git
+cd Magic-Resume
+
+# 2. Configure self-hosted mode
+cp apps/web/.env.example apps/web/.env.local   # set NEXT_PUBLIC_APP_MODE=self-hosted
+
+# 3. Install and run
+pnpm install
+pnpm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000). See the [README](./README.md#monorepo) for the monorepo layout.
+
+---
+
+## Development workflow
+
+1. Create a branch off `master`:
+
+   ```bash
+   git checkout -b feat/your-thing   # or fix/…, docs/…, refactor/…
+   ```
+
+2. Make your change. Keep it focused — one concern per PR.
+
+3. Before committing, make sure the checks pass:
+
+   ```bash
+   pnpm run lint
+   pnpm run test
+   ```
+
+   > The `pre-commit` hook also runs `lint` + `build` automatically. Don't bypass it with `--no-verify`.
+
+---
+
+## Commit convention
+
+This repo enforces **gitmoji + [Conventional Commits](https://www.conventionalcommits.org/)** through a `commitlint` hook (`commitlint-config-gitmoji`). Any message that doesn't match is **rejected**.
+
+### Format
+
+```
+<emoji> <type>(<scope>?): <subject>
+```
+
+- **emoji** — a gitmoji shortcode (`:sparkles:`) or the unicode char (`✨`). Must be a valid code from [gitmoji.dev](https://gitmoji.dev).
+- **type** — exactly one of: `build · ci · chore · docs · feat · fix · perf · refactor · revert · style · test · wip` (lowercase).
+- **scope** — optional, lowercase workspace name: `web`, `mcp`, `resume-schema`, `resume-templates`, `docs`.
+- **subject** — imperative ("add", not "added"), no trailing period, whole header ≤ 100 chars.
+
+Body and footer are optional; if present, precede each with a blank line.
+
+### Emoji → intent (most common)
+
+| Intent | Emoji | Type |
+|---|---|---|
+| New feature | `:sparkles:` ✨ | `feat` |
+| Bug fix | `:bug:` 🐛 | `fix` |
+| Docs | `:memo:` 📝 | `docs` |
+| Refactor | `:recycle:` ♻️ | `refactor` |
+| Performance | `:zap:` ⚡️ | `perf` |
+| UI / styling | `:lipstick:` 💄 | `style` |
+| Code format / structure | `:art:` 🎨 | `style` |
+| Tests | `:white_check_mark:` ✅ | `test` |
+| Config / tooling | `:wrench:` 🔧 | `chore` |
+| Bump deps | `:arrow_up:` ⬆️ | `chore` |
+| Remove code / files | `:fire:` 🔥 | `chore`, `refactor` |
+| i18n | `:globe_with_meridians:` 🌐 | `feat` |
+
+Full list: [gitmoji.dev](https://gitmoji.dev).
+
+### Examples
+
+```bash
+# ✅ pass
+:sparkles: feat(web): add resume share link generator
+:bug: fix(mcp): handle empty patch in update_resume_content
+:memo: docs: rewrite contributing guide
+
+# ❌ fail
+feat: add dark mode                 # no emoji
+:sparkles: Feat: add dark mode      # type must be lowercase
+:sparkles: feat: add dark mode.     # trailing period
+```
+
+### Check a message before committing
+
+```bash
+echo ":sparkles: feat(web): add resume share link generator" | npx --no -- commitlint
+```
+
+Exit `0` means it's valid; a non-zero exit prints the rule that failed.
+
+---
+
+## Translations
+
+The web app uses [i18next](https://www.i18next.com/). Translation files live under `apps/web/src/locales/`. After editing them, validate key parity:
+
+```bash
+pnpm --filter @magic-resume/web i18n:check
+```
+
+---
+
+## Pull request process
+
+1. Push your branch and open a [Pull Request](https://github.com/LinMoQC/Magic-Resume/pulls) against `master`.
+2. Write a clear title (the commit convention is a good guide) and describe **what** changed and **why**.
+3. Link any related issue (e.g. `Closes #123`).
+4. Make sure CI, lint, and tests are green.
+
+A maintainer will review as soon as they can. Thanks for helping make Magic Resume better! 🎉
+
+---
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](./LICENSE).

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,0 +1,151 @@
+# 为 Magic Resume 做贡献
+
+感谢你有兴趣参与贡献！我们欢迎任何形式的贡献 —— 修复 Bug、新增模板、完善文档、补充翻译或开发新功能。
+
+[English](./CONTRIBUTING.md) · **简体中文**
+
+---
+
+## 贡献方式
+
+- **反馈 Bug 或提功能建议** —— 开一个 [Issue](https://github.com/LinMoQC/Magic-Resume/issues)。
+- **修复 Bug** 或 **开发功能** —— 提交 Pull Request。
+- **新增模板** —— 参见 [`packages/resume-templates`](./packages/resume-templates)。
+- **完善翻译** —— 参见 [翻译](#翻译)。
+- **改进文档** —— 包括本文件与 README。
+
+对于较大的改动，建议先开 Issue 讨论方案，能为双方省下不少时间。
+
+---
+
+## 环境要求
+
+- **Node.js** `>= 20`
+- **pnpm** `>= 10.28.1`（本仓库通过 `packageManager` 锁定 `pnpm@10.28.1`）
+
+## 本地启动
+
+Magic Resume 完全在浏览器中运行 —— 大部分开发无需后端或数据库。
+
+```bash
+# 1. Fork 后克隆你的 fork
+git clone https://github.com/<你>/Magic-Resume.git
+cd Magic-Resume
+
+# 2. 配置自托管模式
+cp apps/web/.env.example apps/web/.env.local   # 设置 NEXT_PUBLIC_APP_MODE=self-hosted
+
+# 3. 安装并运行
+pnpm install
+pnpm run dev
+```
+
+打开 [http://localhost:3000](http://localhost:3000)。单仓结构见 [README](./README.zh-CN.md#单仓结构)。
+
+---
+
+## 开发流程
+
+1. 基于 `master` 新建分支：
+
+   ```bash
+   git checkout -b feat/your-thing   # 或 fix/…、docs/…、refactor/…
+   ```
+
+2. 完成改动，保持聚焦 —— 一个 PR 只做一件事。
+
+3. 提交前确保检查通过：
+
+   ```bash
+   pnpm run lint
+   pnpm run test
+   ```
+
+   > `pre-commit` 钩子还会自动跑 `lint` + `build`。请勿用 `--no-verify` 绕过。
+
+---
+
+## 提交规范
+
+本仓库通过 `commitlint` 钩子（`commitlint-config-gitmoji`）强制 **gitmoji + [Conventional Commits](https://www.conventionalcommits.org/)**。不合规的信息会被**拒绝**。
+
+### 格式
+
+```
+<emoji> <type>(<scope>?): <subject>
+```
+
+- **emoji** —— gitmoji 短码（`:sparkles:`）或 unicode 字符（✨），须为 [gitmoji.dev](https://gitmoji.dev) 中的有效代码。
+- **type** —— 以下之一：`build · ci · chore · docs · feat · fix · perf · refactor · revert · style · test · wip`（小写）。
+- **scope** —— 可选，小写工作区名：`web`、`mcp`、`resume-schema`、`resume-templates`、`docs`。
+- **subject** —— 祈使语气（"add"，而非 "added"），结尾不加句号，整个 header ≤ 100 字符。
+
+正文与 footer 可选；如有，各需以空行分隔。
+
+### emoji → 意图（常用）
+
+| 意图 | Emoji | 类型 |
+|---|---|---|
+| 新功能 | `:sparkles:` ✨ | `feat` |
+| 修复 Bug | `:bug:` 🐛 | `fix` |
+| 文档 | `:memo:` 📝 | `docs` |
+| 重构 | `:recycle:` ♻️ | `refactor` |
+| 性能 | `:zap:` ⚡️ | `perf` |
+| UI / 样式 | `:lipstick:` 💄 | `style` |
+| 代码格式 / 结构 | `:art:` 🎨 | `style` |
+| 测试 | `:white_check_mark:` ✅ | `test` |
+| 配置 / 工具 | `:wrench:` 🔧 | `chore` |
+| 升级依赖 | `:arrow_up:` ⬆️ | `chore` |
+| 删除代码 / 文件 | `:fire:` 🔥 | `chore`、`refactor` |
+| 国际化 | `:globe_with_meridians:` 🌐 | `feat` |
+
+完整列表见 [gitmoji.dev](https://gitmoji.dev)。
+
+### 示例
+
+```bash
+# ✅ 通过
+:sparkles: feat(web): add resume share link generator
+:bug: fix(mcp): handle empty patch in update_resume_content
+:memo: docs: rewrite contributing guide
+
+# ❌ 不通过
+feat: add dark mode                 # 缺 emoji
+:sparkles: Feat: add dark mode      # type 必须小写
+:sparkles: feat: add dark mode.     # 结尾多了句号
+```
+
+### 提交前自查一条信息
+
+```bash
+echo ":sparkles: feat(web): add resume share link generator" | npx --no -- commitlint
+```
+
+退出码 `0` 即合规；非零会打印出未通过的规则。
+
+---
+
+## 翻译
+
+前端使用 [i18next](https://www.i18next.com/)，翻译文件位于 `apps/web/src/locales/`。修改后请校验 key 是否对齐：
+
+```bash
+pnpm --filter @magic-resume/web i18n:check
+```
+
+---
+
+## PR 流程
+
+1. 推送分支，向 `master` 发起 [Pull Request](https://github.com/LinMoQC/Magic-Resume/pulls)。
+2. 写清标题（可参照提交规范），说明**改了什么**、**为什么改**。
+3. 关联相关 Issue（如 `Closes #123`）。
+4. 确保 CI、lint 与测试全绿。
+
+维护者会尽快 Review。感谢你让 Magic Resume 变得更好！🎉
+
+---
+
+## 许可证
+
+提交贡献即代表你同意你的贡献将以 [MIT 许可证](./LICENSE) 授权。

--- a/README.md
+++ b/README.md
@@ -1,117 +1,100 @@
 <div align="center">
   <a href="https://magic-resume.cn">
-    <img width="160" alt="Magic Resume Logo" src="./apps/web/public/simple-logo.png">
+    <img width="128" alt="Magic Resume" src="./apps/web/public/magic-resume-mark.png">
   </a>
 
   <h1>Magic Resume</h1>
 
-  <p><strong>The AI-native resume platform — build, analyze, optimize, and edit resumes with AI coding tools.</strong></p>
+  <p><strong>The AI-native resume platform.</strong><br/>Build, analyze, and optimize your resume — and let AI coding tools edit it for you.</p>
 
-**English** · [简体中文](./README.zh-CN.md) · [Official Site][official-site] · [Feedback][github-issues-link]
+  <p>
+    <a href="https://magic-resume.cn"><strong>Get Started »</strong></a>
+    &nbsp;·&nbsp;
+    <a href="./README.zh-CN.md">简体中文</a>
+    &nbsp;·&nbsp;
+    <a href="https://magic-resume.cn">Official Site</a>
+    &nbsp;·&nbsp;
+    <a href="https://github.com/LinMoQC/Magic-Resume/issues">Feedback</a>
+  </p>
 
   <!-- SHIELD GROUP -->
 
-[![][vercel-shield]][vercel-link]
-[![][github-contributors-shield]][github-contributors-link]
-[![][github-forks-shield]][github-forks-link]
-[![][github-stars-shield]][github-stars-link]
-[![][github-issues-shield]][github-issues-link]
-[![][github-license-shield]][github-license-link]
+  [![][vercel-shield]][vercel-link]
+  [![][github-stars-shield]][github-stars-link]
+  [![][github-forks-shield]][github-forks-link]
+  [![][github-contributors-shield]][github-contributors-link]
+  [![][github-issues-shield]][github-issues-link]
+  [![][github-license-shield]][github-license-link]
 
 </div>
-
-<details>
-<summary><kbd>Table of contents</kbd></summary>
-
-#### TOC
-
-- [👋🏻 Getting Started](#-getting-started)
-- [✨ Features](#-features)
-  - [Build: Visual Template Customization](#build-visual-template-customization)
-  - [Analyze: Lighthouse-style Reports](#analyze-lighthouse-style-reports)
-  - [Optimize: AI-powered JD Matching](#optimize-ai-powered-jd-matching)
-  - [AI Lab: Interview & Translation](#ai-lab-interview--translation)
-  - [Privacy: Local-First Data Security](#privacy-local-first-data-security)
-- [🤖 MCP Integration](#-mcp-integration)
-- [⚙️ Environment Variables](#️-environment-variables)
-- [🛳 Self Hosting](#-self-hosting)
-  - [Self-hosted Mode (No Backend Required)](#self-hosted-mode-no-backend-required)
-  - [Deploying with Vercel](#deploying-with-vercel)
-- [📦 Ecosystem](#-ecosystem)
-- [⌨️ Local Development](#️-local-development)
-- [🤝 Contributing](#-contributing)
-- [📈 Star History](#-star-history)
-
-####
-
-<br/>
-
-</details>
 
 <br/>
 
 ![Banner](./apps/web/public/magic-resume-preview.png)
 
-## 👋🏻 Getting Started
+<br/>
 
-**Magic Resume** is a modern, AI-native resume platform built as a Turborepo monorepo. It combines a real-time visual editor with multi-model AI capabilities — and goes further with a native **MCP server** that lets AI coding tools (Claude Code, Cursor, Windsurf) read and safely edit your resumes without guessing the data shape.
+**Magic Resume** is a modern, AI-native resume platform. It pairs a real-time visual editor with multi-model AI — and goes one step further with a native **MCP server** that lets AI coding tools (Claude Code, Cursor, Windsurf) read and safely patch your resumes without ever guessing the data shape.
 
-## ✨ Features
+It's free, open source, and works fully in your browser — no account, no backend, no database required.
 
-### Build: Visual Template Customization
-
-Create a professional resume in minutes with our intuitive visual editor.
-
-- **Real-time Preview**: See your changes instantly as you type.
-- **12 Professional Templates**: ATS-friendly templates with full color, font, and layout control.
-- **Rich Customization**: Adjust colors, fonts (22+ styles), spacing, and layouts with ease.
-- **Version History**: Save snapshots and restore any previous version.
-- **Resume Sharing**: Share via unique link with Viewer / Commenter / Editor permissions.
-
-### Analyze: Lighthouse-style Reports
-
-Get professional feedback on your resume's health.
-
-- **Overall Score**: A comprehensive rating of your resume's impact.
-- **Detailed Analysis**: Insights into keyword matching, actionability, and readability.
-- **Actionable Suggestions**: Specific advice to make your resume stand out.
-
-### Optimize: AI-powered JD Matching
-
-Tailor your resume to specific job descriptions with AI.
-
-- **Smart Alignment**: AI analyzes the Job Description (JD) and suggests targeted content optimizations.
-- **Multi-model Support**: Works with OpenAI, Google Gemini, Anthropic Claude, and any OpenAI-compatible API.
-
-### AI Lab: Interview & Translation
-
-Go beyond editing with AI-powered career tools.
-
-- **Interview Practice**: Simulate real interviews with AI feedback on your answers.
-- **Resume Translation**: Translate your resume into any language while preserving formatting.
-
-### Privacy: Local-First Data Security
-
-Your data stays with you.
-
-- **Local Storage**: All resume data is stored locally in IndexedDB by default — no account required.
-- **Optional Cloud Sync**: Securely sync across devices if you choose.
-- **Multi-format Export**: Export to high-quality PDF or structured JSON.
+> [!NOTE]
+> Everything runs locally by default. Your resume data lives in your browser (IndexedDB) unless you explicitly opt into cloud sync.
 
 ---
 
-## 🤖 MCP Integration
+## Features
+
+**Build — visual editing that just works**
+
+- **Real-time preview** — see every change the instant you type.
+- **12 professional templates** — ATS-friendly, with full color, font, and layout control.
+- **Deep customization** — 22+ font styles, spacing, and layout controls.
+- **Version history** — snapshot and restore any previous version.
+- **Sharing** — share via a unique link with Viewer / Commenter / Editor permissions.
+
+**Analyze — Lighthouse-style resume health**
+
+- **Overall score** — a single, honest rating of your resume's impact.
+- **Detailed breakdown** — keyword matching, actionability, and readability.
+- **Actionable fixes** — specific, targeted suggestions, not vague advice.
+
+**Optimize — tailor to any job**
+
+- **JD matching** — AI reads a job description and rewrites content to fit.
+- **Bring your own model** — OpenAI, Google Gemini, Anthropic Claude, DeepSeek, or any OpenAI-compatible API.
+
+**AI Lab — beyond editing**
+
+- **Mock interviews** — practice with AI feedback on your answers.
+- **One-click translation** — translate a resume into any language, formatting preserved.
+
+**Privacy — your data stays yours**
+
+- **Local-first** — stored in IndexedDB by default, no account needed.
+- **Optional cloud sync** — securely sync across devices only if you choose.
+- **Export anywhere** — high-quality PDF or structured JSON.
+
+---
+
+## Templates
+
+Twelve hand-crafted, ATS-friendly templates, each fully customizable (color, font, spacing, layout):
+
+`classic` · `azurill` · `bronzor` · `chikorita` · `ditto` · `gengar` · `orange-modern` · `clean-minimal` · `teal-professional` · `red-accent` · `golden-elegant` · `product-ops-focus`
+
+---
+
+## MCP Integration
 
 Magic Resume ships a native **Model Context Protocol (MCP) server** (`@magic-resume/mcp`) — a first-class integration for AI coding tools.
 
-Configure it once with a personal access token and your AI assistant can safely read and patch resumes without touching the raw database:
+Configure it once with a personal access token, and your AI assistant can read and patch resumes safely, without touching the raw database:
 
 ```bash
 npx -y @magic-resume/mcp config set --api-url "https://your-api.example.com/api" --pat "mr_pat_xxx"
 claude mcp add magic-resume -- npx -y @magic-resume/mcp mcp
 ```
-
-**Available MCP tools:**
 
 | Tool | Description |
 |---|---|
@@ -122,11 +105,12 @@ claude mcp add magic-resume -- npx -y @magic-resume/mcp mcp
 | `preview_resume_patch` | Preview a JSON Patch without applying it |
 | `update_resume_content` | Apply a JSON Patch to update resume content |
 
-The MCP server is schema-aware and patch-based — AI tools make surgical edits rather than full rewrites.
+> [!TIP]
+> The server is schema-aware and patch-based — AI tools make surgical edits rather than risky full rewrites.
 
 ---
 
-## 🛠 Tech Stack
+## Tech Stack
 
 | Layer | Technology |
 |---|---|
@@ -134,74 +118,72 @@ The MCP server is schema-aware and patch-based — AI tools make surgical edits 
 | Framework | [Next.js 15](https://nextjs.org/) (App Router) |
 | Language | [TypeScript](https://www.typescriptlang.org/) |
 | AI / LLM | [LangChain](https://www.langchain.com/), [LangGraph](https://www.langchain.com/langgraph), [Google GenAI](https://ai.google.dev/), [Anthropic](https://www.anthropic.com/) |
-| Authentication | [Clerk](https://clerk.com/) (cloud mode only) |
+| Auth | [Clerk](https://clerk.com/) (cloud mode only) |
 | Styling | [Tailwind CSS 4](https://tailwindcss.com/) |
-| UI Components | [Radix UI](https://www.radix-ui.com/), [Lucide Icons](https://lucide.dev/) |
-| Animations | [Framer Motion](https://www.framer.com/motion/), [GSAP](https://gsap.com/) |
-| State Management | [Zustand](https://zustand-demo.pmnd.rs/) |
-| Local Storage | [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) |
-| Rich Text | [Tiptap](https://tiptap.dev/), [Monaco Editor](https://microsoft.github.io/monaco-editor/) |
+| UI | [Radix UI](https://www.radix-ui.com/), [Lucide](https://lucide.dev/) |
+| Animation | [Framer Motion](https://www.framer.com/motion/), [GSAP](https://gsap.com/) |
+| State | [Zustand](https://zustand-demo.pmnd.rs/) |
+| Storage | [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) |
+| Editor | [Tiptap](https://tiptap.dev/), [Monaco](https://microsoft.github.io/monaco-editor/) |
 | MCP | [@modelcontextprotocol/sdk](https://modelcontextprotocol.io/) |
 | Schema | [Zod](https://zod.dev/) |
-| Internationalization | [i18next](https://www.i18next.com/) |
+| i18n | [i18next](https://www.i18next.com/) |
 
 ---
 
-## ⚙️ Environment Variables
+## Quick Start
 
-All variables live in `apps/web/.env.local` (copy from `apps/web/.env.example`). Vars prefixed with `NEXT_PUBLIC_` are exposed to the browser; the rest are server-only.
-
-| Variable | Required in | Default | Purpose |
-|---|---|---|---|
-| `NEXT_PUBLIC_APP_MODE` | both | auto | `self-hosted` or `cloud`. If unset, auto-detected: `cloud` when `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is set, otherwise `self-hosted`. |
-| `NEXT_PUBLIC_APP_URL` | both | `https://magic-resume.cn` | Canonical base URL used by `metadataBase` for OG tags and SEO. Set to your deployed origin (e.g. `http://localhost:3000` in dev). |
-| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | cloud | — | Clerk publishable key (`pk_...`). Read by `@clerk/nextjs` on the client. |
-| `CLERK_SECRET_KEY` | cloud | — | Clerk secret key (`sk_...`). Read by `@clerk/nextjs` on the server. |
-| `NEXT_PUBLIC_CLOUD_API_URL` | cloud | `http://localhost:3111` | NestJS Core API base URL — used by `httpClient.api` for resumes, settings, sharing, PATs. |
-| `BACKEND_URL` | AI features | `http://localhost:8000` | Python agent server — used by `httpClient.agent` and the `/api/interview/*` Next.js rewrite proxy (interview, translate, AI optimize/analyze). |
-
-**Mode rules**
-
-- **`self-hosted`** — pure browser. No Clerk, no Core API; data lives in IndexedDB. Only `NEXT_PUBLIC_APP_URL` is meaningful.
-- **`cloud`** — requires the two Clerk keys plus `NEXT_PUBLIC_CLOUD_API_URL`. AI features additionally require `BACKEND_URL` (or remove AI features in your fork).
-
-**Notes**
-
-- Don't commit `.env.local` — it's gitignored. Use `.env.example` as the template.
-- Public-prefixed values are inlined into the JS bundle at build time; never put secrets behind `NEXT_PUBLIC_`.
-- Analytics env vars (PostHog / GA) were removed. The open-source and self-hosted web app does not send product analytics events; `apps/web/src/lib/analytics/core-events.ts` is a no-op facade reserved for private commercial overlays.
-
----
-
-## 🛳 Self Hosting
-
-### Self-hosted Mode (No Backend Required)
-
-Magic Resume runs fully in the browser with no backend, no database, and no account required. Set `NEXT_PUBLIC_APP_MODE=self-hosted` (or leave it unset) and all data is persisted in IndexedDB. The open-source self-hosted build does not send product analytics events.
+Magic Resume runs fully in the browser — no backend, no database, no account.
 
 ```bash
 git clone https://github.com/LinMoQC/Magic-Resume.git
 cd Magic-Resume
-cp apps/web/.env.example apps/web/.env.local
-# Edit .env.local: set NEXT_PUBLIC_APP_MODE=self-hosted
+cp apps/web/.env.example apps/web/.env.local   # set NEXT_PUBLIC_APP_MODE=self-hosted
 pnpm install
 pnpm run dev
 ```
 
-### Deploying with Vercel
+Open [http://localhost:3000](http://localhost:3000) and start building.
 
-For the full cloud experience (auth, cloud sync, sharing), click the button below:
+---
+
+## Self-Hosting
+
+**Self-hosted mode** needs nothing but the browser — set `NEXT_PUBLIC_APP_MODE=self-hosted` (or leave it unset) and all data persists in IndexedDB. The open-source self-hosted build sends no product analytics.
+
+**Cloud mode** (auth, cloud sync, sharing) deploys in one click:
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FLinMoQC%2FMagic-Resume)
 
 > [!TIP]
-> For cloud mode, configure `NEXT_PUBLIC_APP_MODE=cloud`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, and `CLERK_SECRET_KEY` in the Vercel dashboard.
+> For cloud mode, set `NEXT_PUBLIC_APP_MODE=cloud`, `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, and `CLERK_SECRET_KEY` in your Vercel dashboard.
+
+<details>
+<summary><strong>Environment variables</strong></summary>
+
+<br/>
+
+All variables live in `apps/web/.env.local` (copy from `apps/web/.env.example`). Values prefixed with `NEXT_PUBLIC_` are inlined into the browser bundle — never put secrets behind that prefix.
+
+| Variable | Required in | Default | Purpose |
+|---|---|---|---|
+| `NEXT_PUBLIC_APP_MODE` | both | auto | `self-hosted` or `cloud`. Auto-detected: `cloud` when `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is set, else `self-hosted`. |
+| `NEXT_PUBLIC_APP_URL` | both | `https://magic-resume.cn` | Canonical base URL for OG tags / SEO. Set to your origin (e.g. `http://localhost:3000` in dev). |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | cloud | — | Clerk publishable key (`pk_...`). |
+| `CLERK_SECRET_KEY` | cloud | — | Clerk secret key (`sk_...`). |
+| `NEXT_PUBLIC_CLOUD_API_URL` | cloud | `http://localhost:3111` | NestJS Core API — resumes, settings, sharing, PATs. |
+| `BACKEND_URL` | AI features | `http://localhost:8000` | Agent server — interview, translate, AI optimize/analyze. |
+
+- **`self-hosted`** — pure browser. No Clerk, no Core API; only `NEXT_PUBLIC_APP_URL` matters.
+- **`cloud`** — requires the two Clerk keys plus `NEXT_PUBLIC_CLOUD_API_URL`; AI features additionally require `BACKEND_URL`.
+
+</details>
 
 ---
 
-## 📦 Ecosystem
+## Monorepo
 
-This repository is a Turborepo monorepo. Key packages:
+This repository is a Turborepo + pnpm monorepo.
 
 | Package | Description |
 |---|---|
@@ -210,33 +192,24 @@ This repository is a Turborepo monorepo. Key packages:
 | `packages/resume-schema` | Shared Zod schemas, types, and sample data |
 | `packages/resume-templates` | Template DSL, renderer, and registry |
 
----
-
-## ⌨️ Local Development
-
 ```bash
-# Install dependencies
-pnpm install
+pnpm install            # install everything
+pnpm run dev            # start all workspaces
+pnpm run lint           # lint
+pnpm run test           # test
 
-# Start all workspaces
-pnpm run dev
-
-# Or target a single workspace
+# target a single workspace
 pnpm --filter @magic-resume/web dev
 pnpm --filter @magic-resume/mcp build
-
-# Lint and test
-pnpm run lint
-pnpm run test
 ```
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Contributions of every size are welcome — bug fixes, new templates, docs, translations, or features.
 
-For bug reports and feature requests, open an [issue][github-issues-link].
+Please read the **[Contributing Guide](./CONTRIBUTING.md)** for local setup, the branch workflow, and the enforced **gitmoji + Conventional Commits** convention. For bugs or ideas, feel free to file an [issue](https://github.com/LinMoQC/Magic-Resume/issues) first.
 
 <a href="https://github.com/LinMoQC/Magic-Resume/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=LinMoQC/Magic-Resume" alt="contributors" />
@@ -244,19 +217,23 @@ For bug reports and feature requests, open an [issue][github-issues-link].
 
 ---
 
-## 📈 Star History
+## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=LinMoQC/Magic-Resume&type=Date)](https://star-history.com/#LinMoQC/Magic-Resume&Date)
+<a href="https://star-history.com/#LinMoQC/Magic-Resume&Date">
+  <img src="https://api.star-history.com/svg?repos=LinMoQC/Magic-Resume&type=Date" alt="Star History Chart" width="600" />
+</a>
 
 ---
 
-Copyright © 2026 [Magic Resume Team](https://github.com/LinMoQC). <br />
-This project is [MIT](./LICENSE) licensed.
+<div align="center">
+
+Copyright © 2026 [Magic Resume Team](https://github.com/LinMoQC) · [MIT](./LICENSE) licensed.
+
+</div>
 
 <!-- LINK GROUP -->
 
 [official-site]: https://magic-resume.cn
-[github-issues-link]: https://github.com/LinMoQC/Magic-Resume/issues
 [vercel-shield]: https://img.shields.io/badge/vercel-online-55b467?labelColor=black&logo=vercel&style=flat-square
 [vercel-link]: https://magic-resume.cn
 [github-contributors-shield]: https://img.shields.io/github/contributors/LinMoQC/Magic-Resume?color=c4f042&labelColor=black&style=flat-square
@@ -266,5 +243,6 @@ This project is [MIT](./LICENSE) licensed.
 [github-stars-shield]: https://img.shields.io/github/stars/LinMoQC/Magic-Resume?color=ffcb47&labelColor=black&style=flat-square
 [github-stars-link]: https://github.com/LinMoQC/Magic-Resume/stargazers
 [github-issues-shield]: https://img.shields.io/github/issues/LinMoQC/Magic-Resume?color=ff80eb&labelColor=black&style=flat-square
+[github-issues-link]: https://github.com/LinMoQC/Magic-Resume/issues
 [github-license-shield]: https://img.shields.io/badge/license-MIT-white?labelColor=black&style=flat-square
 [github-license-link]: https://github.com/LinMoQC/Magic-Resume/blob/master/LICENSE

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,242 +1,215 @@
 <div align="center">
   <a href="https://magic-resume.cn">
-    <img width="160" alt="Magic Resume Logo" src="./apps/web/public/simple-logo.png">
+    <img width="128" alt="Magic Resume" src="./apps/web/public/magic-resume-mark.png">
   </a>
 
   <h1>Magic Resume</h1>
 
-  <p><strong>AI 原生简历平台 — 构建、分析、优化，并通过 AI 编程工具直接编辑简历。</strong></p>
+  <p><strong>AI 原生简历平台。</strong><br/>构建、分析、优化简历 —— 还能让 AI 编程工具直接帮你编辑。</p>
 
-[English](./README.md) · **简体中文** · [官方网站][official-site] · [问题反馈][github-issues-link]
+  <p>
+    <a href="https://magic-resume.cn"><strong>立即开始 »</strong></a>
+    &nbsp;·&nbsp;
+    <a href="./README.md">English</a>
+    &nbsp;·&nbsp;
+    <a href="https://magic-resume.cn">官方网站</a>
+    &nbsp;·&nbsp;
+    <a href="https://github.com/LinMoQC/Magic-Resume/issues">问题反馈</a>
+  </p>
 
   <!-- SHIELD GROUP -->
 
-[![][vercel-shield]][vercel-link]
-[![][github-contributors-shield]][github-contributors-link]
-[![][github-forks-shield]][github-forks-link]
-[![][github-stars-shield]][github-stars-link]
-[![][github-issues-shield]][github-issues-link]
-[![][github-license-shield]][github-license-link]
+  [![][vercel-shield]][vercel-link]
+  [![][github-stars-shield]][github-stars-link]
+  [![][github-forks-shield]][github-forks-link]
+  [![][github-contributors-shield]][github-contributors-link]
+  [![][github-issues-shield]][github-issues-link]
+  [![][github-license-shield]][github-license-link]
 
 </div>
-
-<details>
-<summary><kbd>目录</kbd></summary>
-
-#### TOC
-
-- [👋🏻 快速开始](#-快速开始)
-- [✨ 功能特性](#-功能特性)
-  - [制作：可视化模板自定义](#制作可视化模板自定义)
-  - [分析：Lighthouse 风格报告](#分析lighthouse-风格报告)
-  - [优化：AI 驱动的 JD 匹配](#优化ai-驱动的-jd-匹配)
-  - [AI Lab：面试练习与翻译](#ai-lab面试练习与翻译)
-  - [隐私：本地优先的数据安全](#隐私本地优先的数据安全)
-- [🤖 MCP 集成](#-mcp-集成)
-- [⚙️ 环境变量](#️-环境变量)
-- [🛳 私有化部署](#-私有化部署)
-  - [自托管模式（无需后端）](#自托管模式无需后端)
-  - [使用 Vercel 部署](#使用-vercel-部署)
-- [📦 生态系统](#-生态系统)
-- [⌨️ 本地开发](#️-本地开发)
-- [🤝 参与贡献](#-参与贡献)
-- [📈 Star 历史](#-star-历史)
-
-####
-
-<br/>
-
-</details>
 
 <br/>
 
 ![Banner](./apps/web/public/magic-resume-preview.png)
 
-## 👋🏻 快速开始
+<br/>
 
-**Magic Resume** 是一款基于 Turborepo monorepo 构建的现代化 AI 原生简历平台。它将实时可视化编辑器与多模型 AI 能力相结合——并更进一步，提供原生 **MCP 服务器**，让 AI 编程工具（Claude Code、Cursor、Windsurf）无需猜测数据结构，即可安全地读取和编辑简历。
+**Magic Resume** 是一个现代化的 AI 原生简历平台。它把实时可视化编辑器与多模型 AI 结合在一起，并更进一步 —— 内置原生 **MCP 服务**，让 AI 编程工具（Claude Code、Cursor、Windsurf）无需猜测数据结构即可安全读取与修改你的简历。
 
-## ✨ 功能特性
+免费、开源，且完全在浏览器中运行 —— 无需账号、无需后端、无需数据库。
 
-### 制作：可视化模板自定义
-
-使用直观的可视化编辑器，在几分钟内创建专业简历。
-
-- **实时预览**：输入即可立即看到变化。
-- **12 款专业模板**：对 ATS 友好，支持完整的颜色、字体和布局控制。
-- **丰富定制**：轻松调整颜色、字体（22+ 种样式）、间距和布局。
-- **版本历史**：保存快照并随时恢复任意历史版本。
-- **简历分享**：通过专属链接分享，支持查看者 / 评论者 / 编辑者权限控制。
-
-### 分析：Lighthouse 风格报告
-
-获取关于简历健康状况的专业反馈。
-
-- **总体评分**：对简历影响力的全面评价。
-- **详细分析**：深入了解关键词匹配、可行动性和可读性。
-- **可操作建议**：提供具体建议，让您的简历脱颖而出。
-
-### 优化：AI 驱动的 JD 匹配
-
-使用 AI 为特定职位描述量身定制简历。
-
-- **智能对齐**：AI 分析职位描述 (JD) 并建议针对性的内容优化。
-- **多模型支持**：兼容 OpenAI、Google Gemini、Anthropic Claude 及任意 OpenAI 兼容 API。
-
-### AI Lab：面试练习与翻译
-
-超越编辑，探索 AI 驱动的职业工具。
-
-- **面试练习**：模拟真实面试场景，AI 对回答给出即时反馈。
-- **简历翻译**：在保留格式的前提下，将简历翻译成任意语言。
-
-### 隐私：本地优先的数据安全
-
-您的数据由您掌握。
-
-- **本地存储**：默认将所有简历数据存储在浏览器 IndexedDB 中，无需注册账号。
-- **可选云端同步**：选择性地跨设备安全同步数据。
-- **多格式导出**：导出为高质量 PDF 或结构化 JSON。
+> [!NOTE]
+> 默认全部本地运行。除非你主动开启云同步，简历数据都只保存在你自己的浏览器（IndexedDB）里。
 
 ---
 
-## 🤖 MCP 集成
+## 功能特性
 
-Magic Resume 提供原生 **Model Context Protocol (MCP) 服务器**（`@magic-resume/mcp`）——为 AI 编程工具打造的一等公民集成。
+**制作 —— 顺手的可视化编辑**
 
-配置一次个人访问令牌，您的 AI 助手即可安全地读取和修补简历，无需接触原始数据库：
+- **实时预览** —— 输入即所见，改动立刻呈现。
+- **12 套专业模板** —— ATS 友好，颜色、字体、排版全可控。
+- **深度自定义** —— 22+ 字体、间距与布局调节。
+- **版本历史** —— 随时快照与回滚到任意历史版本。
+- **简历分享** —— 通过唯一链接分享，支持 查看 / 评论 / 编辑 权限。
+
+**分析 —— Lighthouse 式简历体检**
+
+- **综合评分** —— 一个诚实、直观的简历竞争力评级。
+- **细项拆解** —— 关键词匹配、可量化程度、可读性。
+- **可执行建议** —— 给出具体的修改点，而非空泛套话。
+
+**优化 —— 按岗位定向改写**
+
+- **JD 匹配** —— AI 读取职位描述，据此定向重写内容。
+- **自带模型** —— OpenAI、Google Gemini、Anthropic Claude、DeepSeek，或任意 OpenAI 兼容 API。
+
+**AI 实验室 —— 不止于编辑**
+
+- **模拟面试** —— 语音实战演练，AI 对回答给出反馈。
+- **一键翻译** —— 保留排版，将简历翻译成任意语言。
+
+**隐私 —— 数据始终属于你**
+
+- **本地优先** —— 默认存储于 IndexedDB，无需账号。
+- **可选云同步** —— 仅在你选择时，才在多设备间安全同步。
+- **多格式导出** —— 高质量 PDF 或结构化 JSON。
+
+---
+
+## 简历模板
+
+12 套精心打磨、ATS 友好的模板，每套均可完全自定义（颜色、字体、间距、排版）：
+
+`classic` · `azurill` · `bronzor` · `chikorita` · `ditto` · `gengar` · `orange-modern` · `clean-minimal` · `teal-professional` · `red-accent` · `golden-elegant` · `product-ops-focus`
+
+---
+
+## MCP 集成
+
+Magic Resume 内置原生 **Model Context Protocol（MCP）服务**（`@magic-resume/mcp`）—— 面向 AI 编程工具的一等集成。
+
+用个人访问令牌配置一次，你的 AI 助手即可安全读取与修改简历，而无需直接操作原始数据库：
 
 ```bash
 npx -y @magic-resume/mcp config set --api-url "https://your-api.example.com/api" --pat "mr_pat_xxx"
 claude mcp add magic-resume -- npx -y @magic-resume/mcp mcp
 ```
 
-**可用 MCP 工具：**
-
 | 工具 | 说明 |
 |---|---|
-| `list_resumes` | 列出账户中的所有简历 |
-| `get_resume` | 获取简历的完整内容 |
-| `get_resume_schema` | 获取用于验证的 JSON Schema |
-| `get_resume_editing_guide` | 获取 AI 可读的简历编辑指南 |
+| `list_resumes` | 列出账号下所有简历 |
+| `get_resume` | 获取某份简历的完整内容 |
+| `get_resume_schema` | 获取用于校验的 JSON Schema |
+| `get_resume_editing_guide` | 面向 AI 的简历编辑指南 |
 | `preview_resume_patch` | 预览 JSON Patch 而不实际应用 |
 | `update_resume_content` | 应用 JSON Patch 更新简历内容 |
 
-MCP 服务器具备 schema 感知能力，采用基于 Patch 的操作方式——AI 工具进行精准修改而非全量覆盖。
+> [!TIP]
+> 该服务基于 Schema、以 Patch 为核心 —— AI 工具做的是精准的局部修改，而非高风险的整篇重写。
 
 ---
 
-## 🛠 技术栈
+## 技术栈
 
-| 层次 | 技术 |
+| 层 | 技术 |
 |---|---|
-| Monorepo | [Turborepo](https://turbo.build/)、[pnpm](https://pnpm.io/) |
+| 单仓管理 | [Turborepo](https://turbo.build/)、[pnpm](https://pnpm.io/) |
 | 框架 | [Next.js 15](https://nextjs.org/)（App Router） |
 | 语言 | [TypeScript](https://www.typescriptlang.org/) |
-| AI / 大模型 | [LangChain](https://www.langchain.com/)、[LangGraph](https://www.langchain.com/langgraph)、[Google GenAI](https://ai.google.dev/)、[Anthropic](https://www.anthropic.com/) |
-| 身份认证 | [Clerk](https://clerk.com/)（仅云端模式） |
-| 样式方案 | [Tailwind CSS 4](https://tailwindcss.com/) |
-| 组件库 | [Radix UI](https://www.radix-ui.com/)、[Lucide Icons](https://lucide.dev/) |
-| 动画 | [Framer Motion](https://www.framer.com/motion/)、[GSAP](https://gsap.com/) |
-| 状态管理 | [Zustand](https://zustand-demo.pmnd.rs/) |
-| 本地存储 | [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) |
-| 富文本编辑器 | [Tiptap](https://tiptap.dev/)、[Monaco Editor](https://microsoft.github.io/monaco-editor/) |
+| AI / LLM | [LangChain](https://www.langchain.com/)、[LangGraph](https://www.langchain.com/langgraph)、[Google GenAI](https://ai.google.dev/)、[Anthropic](https://www.anthropic.com/) |
+| 鉴权 | [Clerk](https://clerk.com/)（仅云模式） |
+| 样式 | [Tailwind CSS 4](https://tailwindcss.com/) |
+| UI | [Radix UI](https://www.radix-ui.com/)、[Lucide](https://lucide.dev/) |
+| 动效 | [Framer Motion](https://www.framer.com/motion/)、[GSAP](https://gsap.com/) |
+| 状态 | [Zustand](https://zustand-demo.pmnd.rs/) |
+| 存储 | [IndexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) |
+| 编辑器 | [Tiptap](https://tiptap.dev/)、[Monaco](https://microsoft.github.io/monaco-editor/) |
 | MCP | [@modelcontextprotocol/sdk](https://modelcontextprotocol.io/) |
 | Schema | [Zod](https://zod.dev/) |
 | 国际化 | [i18next](https://www.i18next.com/) |
 
 ---
 
-## ⚙️ 环境变量
+## 快速开始
 
-所有环境变量集中在 `apps/web/.env.local`（从 `apps/web/.env.example` 复制而来）。带 `NEXT_PUBLIC_` 前缀的会被打进前端 bundle，其余仅服务端可见。
-
-| 变量 | 适用模式 | 默认值 | 作用 |
-|---|---|---|---|
-| `NEXT_PUBLIC_APP_MODE` | 全部 | 自动 | `self-hosted` 或 `cloud`。未设置时自动判定：检测到 `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` 则为 `cloud`，否则 `self-hosted`。 |
-| `NEXT_PUBLIC_APP_URL` | 全部 | `https://magic-resume.cn` | 站点 canonical URL，用于 `metadataBase`（OG / SEO）。本地开发设为 `http://localhost:3000`，线上设为你的真实域名。 |
-| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | cloud | — | Clerk 前端公钥（`pk_...`），由 `@clerk/nextjs` 自动读取。 |
-| `CLERK_SECRET_KEY` | cloud | — | Clerk 服务端密钥（`sk_...`），由 `@clerk/nextjs` 自动读取。 |
-| `NEXT_PUBLIC_CLOUD_API_URL` | cloud | `http://localhost:3111` | NestJS Core API 地址，`httpClient.api` 用它请求简历、设置、分享、PAT 等。 |
-| `BACKEND_URL` | AI 功能 | `http://localhost:8000` | Python Agent 后端地址，`httpClient.agent` 与 Next.js `/api/interview/*` rewrite 转发均使用（面试、翻译、AI 优化/分析）。 |
-
-**模式说明**
-
-- **`self-hosted`** — 纯浏览器，无 Clerk、无 Core API，所有数据存在 IndexedDB；仅 `NEXT_PUBLIC_APP_URL` 有意义。
-- **`cloud`** — 必须配齐两个 Clerk Key 和 `NEXT_PUBLIC_CLOUD_API_URL`；若要使用 AI 功能再加 `BACKEND_URL`。
-
-**注意事项**
-
-- `.env.local` 已被 gitignore，不要提交，模板用 `.env.example`。
-- `NEXT_PUBLIC_` 开头的值会在构建时硬编码进 JS，**任何秘钥都不要加这个前缀**。
-- 之前的 PostHog / Google Analytics 环境变量已移除，业务埋点统一通过 `apps/web/src/lib/analytics/core-events.ts` 的自建 SDK 上报。
-
----
-
-## 🛳 私有化部署
-
-### 自托管模式（无需后端）
-
-Magic Resume 可以完全在浏览器中运行，无需后端、数据库或账号注册。设置 `NEXT_PUBLIC_APP_MODE=self-hosted`（或留空），所有数据将持久化在 IndexedDB 中。
+Magic Resume 完全在浏览器中运行 —— 无需后端、无需数据库、无需账号。
 
 ```bash
 git clone https://github.com/LinMoQC/Magic-Resume.git
 cd Magic-Resume
-cp apps/web/.env.example apps/web/.env.local
-# 编辑 .env.local：设置 NEXT_PUBLIC_APP_MODE=self-hosted
+cp apps/web/.env.example apps/web/.env.local   # 设置 NEXT_PUBLIC_APP_MODE=self-hosted
 pnpm install
 pnpm run dev
 ```
 
-### 使用 Vercel 部署
+打开 [http://localhost:3000](http://localhost:3000) 即可开始制作。
 
-如需完整的云端体验（认证、云同步、分享功能），点击下方按钮一键部署：
+---
+
+## 自托管
+
+**自托管模式** 只需浏览器 —— 设置 `NEXT_PUBLIC_APP_MODE=self-hosted`（或留空），所有数据都保存在 IndexedDB。开源自托管版本不发送任何产品分析事件。
+
+**云模式**（鉴权、云同步、分享）可一键部署：
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FLinMoQC%2FMagic-Resume)
 
 > [!TIP]
-> 云端模式需在 Vercel 控制面板中配置 `NEXT_PUBLIC_APP_MODE=cloud`、`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` 和 `CLERK_SECRET_KEY`。
+> 云模式需在 Vercel 面板配置 `NEXT_PUBLIC_APP_MODE=cloud`、`NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` 与 `CLERK_SECRET_KEY`。
+
+<details>
+<summary><strong>环境变量</strong></summary>
+
+<br/>
+
+所有变量位于 `apps/web/.env.local`（从 `apps/web/.env.example` 拷贝）。以 `NEXT_PUBLIC_` 开头的值会在构建时内联进浏览器包 —— 切勿把密钥放在该前缀后面。
+
+| 变量 | 适用模式 | 默认值 | 用途 |
+|---|---|---|---|
+| `NEXT_PUBLIC_APP_MODE` | 两者 | 自动 | `self-hosted` 或 `cloud`。自动判定：设置了 `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` 即为 `cloud`，否则 `self-hosted`。 |
+| `NEXT_PUBLIC_APP_URL` | 两者 | `https://magic-resume.cn` | 用于 OG / SEO 的规范基址。请设为你的部署源（开发环境可用 `http://localhost:3000`）。 |
+| `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` | 云 | — | Clerk 公钥（`pk_...`）。 |
+| `CLERK_SECRET_KEY` | 云 | — | Clerk 私钥（`sk_...`）。 |
+| `NEXT_PUBLIC_CLOUD_API_URL` | 云 | `http://localhost:3111` | NestJS Core API —— 简历、设置、分享、PAT。 |
+| `BACKEND_URL` | AI 功能 | `http://localhost:8000` | Agent 服务 —— 面试、翻译、AI 优化 / 分析。 |
+
+- **`self-hosted`** —— 纯浏览器。无 Clerk、无 Core API；仅 `NEXT_PUBLIC_APP_URL` 有意义。
+- **`cloud`** —— 需两把 Clerk 密钥加 `NEXT_PUBLIC_CLOUD_API_URL`；AI 功能另需 `BACKEND_URL`。
+
+</details>
 
 ---
 
-## 📦 生态系统
+## 单仓结构
 
-本仓库是一个 Turborepo monorepo，核心包如下：
+本仓库是一个 Turborepo + pnpm 单仓（monorepo）。
 
 | 包 | 说明 |
 |---|---|
-| `apps/web` | Next.js 前端——编辑器、仪表盘、AI Lab |
-| `packages/mcp` | `@magic-resume/mcp`——stdio MCP 服务器和 CLI |
-| `packages/resume-schema` | 共享 Zod Schema、类型定义和示例数据 |
-| `packages/resume-templates` | 模板 DSL、渲染器和注册表 |
-
----
-
-## ⌨️ 本地开发
+| `apps/web` | Next.js 前端 —— 编辑器、仪表盘、AI 实验室 |
+| `packages/mcp` | `@magic-resume/mcp` —— stdio MCP 服务与 CLI |
+| `packages/resume-schema` | 共享 Zod schema、类型与示例数据 |
+| `packages/resume-templates` | 模板 DSL、渲染器与注册表 |
 
 ```bash
-# 安装依赖
-pnpm install
+pnpm install            # 安装全部依赖
+pnpm run dev            # 启动所有工作区
+pnpm run lint           # 代码检查
+pnpm run test           # 测试
 
-# 启动所有工作区
-pnpm run dev
-
-# 或针对单个工作区
+# 指定单个工作区
 pnpm --filter @magic-resume/web dev
 pnpm --filter @magic-resume/mcp build
-
-# 代码检查与测试
-pnpm run lint
-pnpm run test
 ```
 
 ---
 
-## 🤝 参与贡献
+## 参与贡献
 
-欢迎贡献！请随时提交 Pull Request。
+欢迎任何形式的贡献 —— 修复 Bug、新增模板、完善文档、补充翻译或开发新功能。
 
-如需报告 Bug 或提交功能建议，请[提交 Issue][github-issues-link]。
+请先阅读 **[贡献指南](./CONTRIBUTING.zh-CN.md)** —— 其中包含本地启动、分支流程，以及强制执行的 **gitmoji + Conventional Commits** 提交规范。若是 Bug 或新想法，也欢迎先开一个 [Issue](https://github.com/LinMoQC/Magic-Resume/issues) 讨论。
 
 <a href="https://github.com/LinMoQC/Magic-Resume/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=LinMoQC/Magic-Resume" alt="contributors" />
@@ -244,19 +217,23 @@ pnpm run test
 
 ---
 
-## 📈 Star 历史
+## Star 趋势
 
-[![Star History Chart](https://api.star-history.com/svg?repos=LinMoQC/Magic-Resume&type=Date)](https://star-history.com/#LinMoQC/Magic-Resume&Date)
+<a href="https://star-history.com/#LinMoQC/Magic-Resume&Date">
+  <img src="https://api.star-history.com/svg?repos=LinMoQC/Magic-Resume&type=Date" alt="Star History Chart" width="600" />
+</a>
 
 ---
 
-Copyright © 2026 [Magic Resume Team](https://github.com/LinMoQC). <br />
-本项目采用 [MIT](./LICENSE) 开源协议。
+<div align="center">
+
+版权所有 © 2026 [Magic Resume Team](https://github.com/LinMoQC) · 基于 [MIT](./LICENSE) 许可证开源。
+
+</div>
 
 <!-- LINK GROUP -->
 
 [official-site]: https://magic-resume.cn
-[github-issues-link]: https://github.com/LinMoQC/Magic-Resume/issues
 [vercel-shield]: https://img.shields.io/badge/vercel-online-55b467?labelColor=black&logo=vercel&style=flat-square
 [vercel-link]: https://magic-resume.cn
 [github-contributors-shield]: https://img.shields.io/github/contributors/LinMoQC/Magic-Resume?color=c4f042&labelColor=black&style=flat-square
@@ -266,5 +243,6 @@ Copyright © 2026 [Magic Resume Team](https://github.com/LinMoQC). <br />
 [github-stars-shield]: https://img.shields.io/github/stars/LinMoQC/Magic-Resume?color=ffcb47&labelColor=black&style=flat-square
 [github-stars-link]: https://github.com/LinMoQC/Magic-Resume/stargazers
 [github-issues-shield]: https://img.shields.io/github/issues/LinMoQC/Magic-Resume?color=ff80eb&labelColor=black&style=flat-square
+[github-issues-link]: https://github.com/LinMoQC/Magic-Resume/issues
 [github-license-shield]: https://img.shields.io/badge/license-MIT-white?labelColor=black&style=flat-square
 [github-license-link]: https://github.com/LinMoQC/Magic-Resume/blob/master/LICENSE


### PR DESCRIPTION
## Why

These doc changes were meant to ship in #124 but were **left out** — #124 got squash-merged just before this commit landed on the branch, so master still has the old README (with a **broken logo link**) and no contributing guide. This PR brings them in.

## What

- **Fix broken logo**: `simple-logo.png` (missing → broken image on GitHub) → `magic-resume-mark.png`.
- **Revamp `README.md` / `README.zh-CN.md`**: drop the emoji-heavy headings, tighten sections, add a Templates section, collapse the env-var table — cleaner, more professional (Reactive-Resume-inspired).
- **Add `CONTRIBUTING.md` / `CONTRIBUTING.zh-CN.md`**: local setup, branch workflow, and the enforced **gitmoji + Conventional Commits** convention; linked from both READMEs.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)