### PR TITLE
fix(web): preserve sections after AI resume import

### DIFF
--- a/apps/web/src/app.test.ts
+++ b/apps/web/src/app.test.ts
@@ -290,16 +290,31 @@ function testImportResumeValidation() {
   assert.equal(normalized.sections.experience[0].extraBackendField, 'kept');
   assert.deepEqual(normalized.sections.education, []);
   assert.deepEqual(normalized.sections.customSection, [{ id: 'custom-1', title: 'Notes' }]);
+  assert.deepEqual(normalized.sectionOrder.map(({ key }) => key), [
+    'basics',
+    'experience',
+    'projects',
+    'education',
+    'skills',
+    'languages',
+    'certificates',
+    'customSection',
+  ]);
 
-  assert.throws(
-    () =>
-      validateAndNormalizeImportedResume({
-        info: {},
-        sections: {},
-        sectionOrder: [],
-      }),
-    ZodError,
-  );
+  const repairedEmptyOrder = validateAndNormalizeImportedResume({
+    info: {},
+    sections: {},
+    sectionOrder: [],
+  });
+  assert.deepEqual(repairedEmptyOrder.sectionOrder.map(({ key }) => key), [
+    'basics',
+    'projects',
+    'education',
+    'skills',
+    'languages',
+    'certificates',
+    'experience',
+  ]);
 
   const message = formatResumeImportValidationError(
     new ZodError([

--- a/apps/web/src/lib/utils/resumeSectionOrder.ts
+++ b/apps/web/src/lib/utils/resumeSectionOrder.ts
@@ -1,0 +1,48 @@
+import type { SectionOrder } from '@/types/frontend/resume';
+
+const DEFAULT_SECTION_ORDER: SectionOrder[] = [
+  { key: 'basics', label: 'Basics' },
+  { key: 'projects', label: 'sections.projects' },
+  { key: 'education', label: 'sections.education' },
+  { key: 'skills', label: 'sections.skills' },
+  { key: 'languages', label: 'sections.languages' },
+  { key: 'certificates', label: 'sections.certificates' },
+  { key: 'experience', label: 'sections.experience' },
+];
+
+const DEFAULT_LABELS = new Map(DEFAULT_SECTION_ORDER.map((item) => [item.key, item.label]));
+
+const fallbackLabel = (key: string) =>
+  DEFAULT_LABELS.get(key) ?? (key ? key.charAt(0).toUpperCase() + key.slice(1) : key);
+
+/**
+ * `sectionOrder` also controls which forms exist in the editor. AI-generated
+ * resumes may only order sections they found content for, so repair the order
+ * without disturbing the sequence or labels it did provide.
+ */
+export function normalizeResumeSectionOrder(
+  sectionOrder: SectionOrder[] | null | undefined,
+  sections: Record<string, unknown> | null | undefined,
+): SectionOrder[] {
+  const normalized: SectionOrder[] = [];
+  const seen = new Set<string>();
+
+  const add = (item: SectionOrder) => {
+    const key = typeof item.key === 'string' ? item.key.trim() : '';
+    if (!key || seen.has(key) || key === 'basics') return;
+
+    seen.add(key);
+    normalized.push({
+      key,
+      label: typeof item.label === 'string' && item.label.trim()
+        ? item.label
+        : fallbackLabel(key),
+    });
+  };
+
+  for (const item of sectionOrder ?? []) add(item);
+  for (const item of DEFAULT_SECTION_ORDER) add(item);
+  for (const key of Object.keys(sections ?? {})) add({ key, label: fallbackLabel(key) });
+
+  return [{ key: 'basics', label: 'Basics' }, ...normalized];
+}

--- a/apps/web/src/lib/validation/importResume.ts
+++ b/apps/web/src/lib/validation/importResume.ts
@@ -1,4 +1,5 @@
 import { z, type ZodError } from 'zod';
+import { normalizeResumeSectionOrder } from '@/lib/utils/resumeSectionOrder';
 
 const importedResumeInfoSchema = z.object({
   fullName: z.string().default(''),
@@ -54,7 +55,7 @@ const importedResumeSectionsSchema = z
 export const importedResumeSchema = z.object({
   info: importedResumeInfoSchema,
   sections: importedResumeSectionsSchema,
-  sectionOrder: z.array(importedResumeSectionOrderItemSchema).min(1),
+  sectionOrder: z.array(importedResumeSectionOrderItemSchema).default([]),
 });
 
 export type ImportedResume = z.infer<typeof importedResumeSchema> & Record<string, unknown>;
@@ -71,7 +72,7 @@ export function validateAndNormalizeImportedResume(data: unknown): ImportedResum
     ...raw,
     info: parsed.info,
     sections: parsed.sections,
-    sectionOrder: parsed.sectionOrder,
+    sectionOrder: normalizeResumeSectionOrder(parsed.sectionOrder, parsed.sections),
   };
 }
 

--- a/apps/web/src/store/useResumeStore.ts
+++ b/apps/web/src/store/useResumeStore.ts
@@ -10,6 +10,7 @@ import { resumeApi } from '@/lib/api/resume';
 import { getAuthToken } from '@/lib/api/httpClient';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
+import { normalizeResumeSectionOrder } from '@/lib/utils/resumeSectionOrder';
 import { 
   Resume, 
   InfoType, 
@@ -91,10 +92,11 @@ export const initialResume: Omit<Resume, 'id' | 'updatedAt' | 'name'> = {
 
 export const getSanitizedResume = (resume: Resume): Omit<Resume, 'id' | 'updatedAt' | 'versions'> => {
   const r = resume || {};
+  const sections = r.sections || initialResume.sections;
   const sanitized: Omit<Resume, 'id' | 'updatedAt' | 'versions'> = {
     info: r.info || initialResume.info,
-    sections: r.sections || initialResume.sections,
-    sectionOrder: r.sectionOrder || initialResume.sectionOrder,
+    sections,
+    sectionOrder: normalizeResumeSectionOrder(r.sectionOrder, sections),
     template: r.template || initialResume.template,
     themeColor: r.themeColor || initialResume.themeColor,
     typography: r.typography || initialResume.typography,
@@ -731,18 +733,20 @@ const useResumeStore = create<ResumeState>()(
     const { activeResume } = get();
     if (!activeResume) return;
 
-    if (isEqual(activeResume.sectionOrder, sectionOrder)) {
+    const normalizedSectionOrder = normalizeResumeSectionOrder(sectionOrder, activeResume.sections);
+
+    if (isEqual(activeResume.sectionOrder, normalizedSectionOrder)) {
       return;
     }
 
     set(state => {
       if (!state.activeResume) return;
-      state.activeResume.sectionOrder = sectionOrder;
+      state.activeResume.sectionOrder = normalizedSectionOrder;
       state.activeResume.updatedAt = Date.now();
 
       const resumeIndex = state.resumes.findIndex(r => r.id === state.activeResume?.id);
       if (resumeIndex !== -1) {
-        state.resumes[resumeIndex].sectionOrder = sectionOrder;
+        state.resumes[resumeIndex].sectionOrder = normalizedSectionOrder;
         state.resumes[resumeIndex].updatedAt = state.activeResume.updatedAt;
       }
 


### PR DESCRIPTION
## Summary
- normalize imported section order while preserving AI-provided ordering and labels
- always restore basics, standard sections, and custom sections so editor forms cannot disappear
- apply the repair at import, persistence, and store update boundaries

## Testing
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/tsx src/app.test.ts
- ESLint on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resume section order is now automatically normalized for imported and saved resumes, keeping sections in a consistent, predictable order.
  * Missing or empty resume section ordering can now be repaired automatically instead of failing.

* **Bug Fixes**
  * Imported resumes with incomplete section data now load more reliably.
  * Section order updates are handled more consistently across the app, reducing unexpected ordering issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->