### PR TITLE
:sparkles: feat(web): stream PDF import with scanline parse progress

### DIFF
--- a/apps/web/src/app/api/pdf/parse/route.ts
+++ b/apps/web/src/app/api/pdf/parse/route.ts
@@ -1,30 +1,96 @@
+import { NextRequest, NextResponse } from 'next/server';
 import { getServerUserId } from '@/lib/auth/server';
 import { serverFetchBackend } from '@/lib/auth/serverFetchBackend';
 
-export async function POST(request: Request) {
+export async function POST(req: NextRequest) {
   try {
     // 验证用户身份 — 未登录直接拒绝
     const userId = await getServerUserId();
     if (!userId) {
-      return new Response(
-        JSON.stringify({ error: 'Unauthorized' }),
-        { status: 401, headers: { 'Content-Type': 'application/json' } }
-      );
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    // 透传前端的 FormData（包含 file + config）给 Python 后端
-    const formData = await request.formData();
-
+    // 透传前端的 FormData（file + config）给 agent-service。pass req.signal so a
+    // closed dialog / navigation cancels upstream generation promptly.
+    const formData = await req.formData();
     const backendResponse = await serverFetchBackend('/api/pdf/parse', {
       method: 'POST',
       body: formData,
+      signal: req.signal,
     });
 
+    const contentType = backendResponse.headers.get('content-type');
+
+    // Success path: agent-service streams parse progress + the final resume as SSE.
+    // Forward it line-by-line so the stream reaches the browser unbuffered (mirror
+    // of app/api/chat-agent/route.ts).
+    if (contentType && contentType.includes('text/event-stream')) {
+      if (!backendResponse.body) {
+        throw new Error('No response body');
+      }
+
+      let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+      const readable = new ReadableStream({
+        async start(controller) {
+          reader = backendResponse.body!.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+
+              buffer += decoder.decode(value, { stream: true });
+              const lines = buffer.split('\n');
+              buffer = lines.pop() || '';
+
+              for (const line of lines) {
+                if (line.trim()) {
+                  controller.enqueue(new TextEncoder().encode(line + '\n'));
+                }
+              }
+            }
+
+            if (buffer.trim()) {
+              controller.enqueue(new TextEncoder().encode(buffer));
+            }
+            controller.close();
+          } catch (error) {
+            // Client/upstream abort (dialog closed) surfaces as AbortError — an
+            // expected cancel, not a stream failure.
+            if ((error as Error)?.name === 'AbortError') {
+              controller.close();
+            } else {
+              console.error('[PDF_PARSE] Stream error:', error);
+              controller.error(error);
+            }
+          }
+        },
+        cancel(reason) {
+          reader?.cancel(reason).catch(() => {});
+        },
+      });
+
+      return new Response(readable, {
+        headers: {
+          'Content-Type': 'text/event-stream',
+          // no-transform stops any intermediary (nginx/CDN) from gzipping the
+          // stream (gzip batches chunks and defeats SSE).
+          'Cache-Control': 'no-cache, no-transform',
+          Connection: 'keep-alive',
+          // Disable nginx buffering for THIS stream even if proxy_buffering is on
+          // globally (host BaoTa reverse proxy defaults to on).
+          'X-Accel-Buffering': 'no',
+        },
+      });
+    }
+
+    // Non-stream path: the backend rejected before it started streaming (bad file,
+    // over-budget, no LLM config, …) — surface the human-readable message.
+    const errorBody = await backendResponse.text();
     if (!backendResponse.ok) {
-      const errorBody = await backendResponse.text();
       console.error(`[PDF_PARSE] Backend error: ${backendResponse.status} ${errorBody}`);
-      // Surface the backend's human-readable message (the { code, message }
-      // envelope) rather than dumping the raw JSON at the user.
       let message = errorBody;
       try {
         const parsed = JSON.parse(errorBody);
@@ -32,43 +98,20 @@ export async function POST(request: Request) {
       } catch {
         /* not JSON — use the raw text */
       }
-      return new Response(
-        JSON.stringify({ error: message }),
-        { status: backendResponse.status, headers: { 'Content-Type': 'application/json' } }
-      );
+      return new Response(JSON.stringify({ error: message }), {
+        status: backendResponse.status,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
 
-    const result = await backendResponse.json();
-
-    // The agent-service wraps every response in a { code, data, message }
-    // envelope and nests the parsed resume under `data.resume_json`. Unwrap to
-    // the bare { info, sections, sectionOrder } shape the client-side validator
-    // expects, tolerating an already-bare or differently-shaped response.
-    const payload =
-      result && typeof result === 'object' && 'data' in result
-        ? (result as { data?: unknown }).data
-        : result;
-    const resume =
-      payload && typeof payload === 'object' && 'resume_json' in payload
-        ? (payload as { resume_json?: unknown }).resume_json
-        : payload;
-
-    if (!resume || typeof resume !== 'object') {
-      return new Response(
-        JSON.stringify({ error: 'The AI could not extract a resume from this PDF.' }),
-        { status: 422, headers: { 'Content-Type': 'application/json' } },
-      );
-    }
-
-    return new Response(JSON.stringify(resume), {
+    // Unexpected: a 2xx that isn't SSE. Forward the body as-is rather than guess.
+    return new Response(errorBody || '{}', {
       headers: { 'Content-Type': 'application/json' },
     });
   } catch (error: unknown) {
     console.error('[PDF_PARSE_API_ERROR]', error);
-    const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred.';
-    return new Response(
-      JSON.stringify({ error: errorMessage }),
-      { status: 500, headers: { 'Content-Type': 'application/json' } }
-    );
+    const errorMessage =
+      error instanceof Error ? error.message : 'An unexpected error occurred.';
+    return NextResponse.json({ error: errorMessage }, { status: 500 });
   }
 }

--- a/apps/web/src/app/dashboard/_components/ImportResumeDialog.tsx
+++ b/apps/web/src/app/dashboard/_components/ImportResumeDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Loader2, X, FileText, FileJson, AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -16,15 +16,192 @@ import { useAccountUiStore } from '@/store/useAccountUiStore';
 import { toast } from 'sonner';
 import { FaFileUpload } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { appLifecycle } from '@/lib/extensions/app-lifecycle';
 import { getFileSizeBucket } from '@/lib/utils/fileSize';
 import {
   formatResumeImportError,
   validateAndNormalizeImportedResume,
 } from '@/lib/validation/importResume';
+import { streamPdfParse } from '@/app/dashboard/edit/_components/ai/lib/services/agentClient';
 
 type FileType = 'json' | 'pdf' | null;
+
+type PdfPhase = 'extracting' | 'analyzing' | null;
+
+/**
+ * Resume sections lit up as the parser streams them, in the order their anchors
+ * appear in the model's JSON (kept in sync with agent-service
+ * `document/lib/pdf-field-progress.ts`). The `key` matches the backend field key.
+ */
+const PDF_SECTIONS: { key: string; labelKey: string; defaultLabel: string }[] = [
+  { key: 'info', labelKey: 'importDialog.pdf.sections.info', defaultLabel: '个人信息' },
+  { key: 'experience', labelKey: 'importDialog.pdf.sections.experience', defaultLabel: '工作经历' },
+  { key: 'education', labelKey: 'importDialog.pdf.sections.education', defaultLabel: '教育经历' },
+  { key: 'projects', labelKey: 'importDialog.pdf.sections.projects', defaultLabel: '项目经历' },
+  { key: 'skills', labelKey: 'importDialog.pdf.sections.skills', defaultLabel: '技能' },
+  { key: 'languages', labelKey: 'importDialog.pdf.sections.languages', defaultLabel: '语言能力' },
+  { key: 'certificates', labelKey: 'importDialog.pdf.sections.certificates', defaultLabel: '证书' },
+];
+
+// ease-out-expo — natural deceleration, no bounce (per design language).
+const EASE_OUT_EXPO = [0.16, 1, 0.3, 1] as const;
+
+/**
+ * Smoothly counts the displayed number toward `value` (ease-out-cubic over 300ms).
+ * A quiet liveness signal while parsing; jumps instantly under reduced motion.
+ */
+function CountUp({ value, animate }: { value: number; animate: boolean }) {
+  const [display, setDisplay] = useState(value);
+  const fromRef = useRef(value);
+
+  useEffect(() => {
+    const from = fromRef.current;
+    const to = value;
+    if (from === to) return;
+    if (!animate) {
+      fromRef.current = to;
+      setDisplay(to);
+      return;
+    }
+    const start = performance.now();
+    const duration = 300;
+    let raf = 0;
+    const tick = (now: number) => {
+      const p = Math.min(1, (now - start) / duration);
+      const eased = 1 - Math.pow(1 - p, 3);
+      setDisplay(Math.round(from + (to - from) * eased));
+      if (p < 1) raf = requestAnimationFrame(tick);
+      else fromRef.current = to;
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [value, animate]);
+
+  return <>{display.toLocaleString()}</>;
+}
+
+/** A checkmark that draws itself in a single stroke when a section lights up. */
+function SectionCheck({ draw, delay }: { draw: boolean; delay: number }) {
+  return (
+    <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" aria-hidden>
+      <motion.path
+        d="M5 13l4 4L19 7"
+        stroke="currentColor"
+        strokeWidth={3}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        initial={draw ? { pathLength: 0 } : false}
+        animate={{ pathLength: 1 }}
+        transition={{ duration: 0.24, ease: 'easeOut', delay }}
+      />
+    </svg>
+  );
+}
+
+/**
+ * PDF parse progress, "scanline" style: a sky band rides the active section (the
+ * frontier of what's been parsed) while each section lights up — sky node + a
+ * drawn check — as its data streams in. No spinner; the scan *is* the progress.
+ */
+function PdfScanProgress({
+  phase,
+  charCount,
+  litFields,
+  complete,
+}: {
+  phase: PdfPhase;
+  charCount: number;
+  litFields: Set<string>;
+  complete: boolean;
+}) {
+  const { t } = useTranslation();
+  const reduceMotion = useReducedMotion();
+  // The active row is the frontier: first section not yet lit. Anchored to real
+  // progress — never a constant-speed fake sweep.
+  const activeIndex = complete
+    ? -1
+    : PDF_SECTIONS.findIndex((s) => !litFields.has(s.key));
+
+  const heading = complete
+    ? t('importDialog.pdf.done', { defaultValue: '解析完成' })
+    : phase === 'analyzing'
+      ? t('importDialog.pdf.analyzing', { defaultValue: '解析中' })
+      : t('importDialog.pdf.extracting', { defaultValue: '读取 PDF' });
+
+  return (
+    <div className="text-left">
+      <div className="mb-4 flex items-baseline justify-between">
+        <span className="text-sm font-medium text-neutral-100">{heading}</span>
+        {phase === 'analyzing' && !complete && charCount > 0 && (
+          <span className="text-xs tabular-nums text-neutral-500">
+            <CountUp value={charCount} animate={!reduceMotion} />{' '}
+            {t('importDialog.pdf.charUnit', { defaultValue: '字' })}
+          </span>
+        )}
+      </div>
+
+      <ul className="relative flex flex-col gap-0.5">
+        {/* Completion sweep: a single sky band runs down the whole list and fades. */}
+        {complete && !reduceMotion && (
+          <motion.div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 h-full rounded-lg bg-gradient-to-b from-transparent via-sky-500/10 to-transparent"
+            initial={{ y: '-110%', opacity: 0.9 }}
+            animate={{ y: '110%', opacity: 0 }}
+            transition={{ duration: 0.6, ease: 'easeOut' }}
+          />
+        )}
+        {PDF_SECTIONS.map((section, i) => {
+          const lit = litFields.has(section.key) || complete;
+          const active = i === activeIndex;
+          return (
+            <li
+              key={section.key}
+              className="relative flex h-10 items-center gap-3 rounded-lg px-3"
+            >
+              {active && !complete && (
+                <motion.div
+                  layoutId="pdf-scanband"
+                  className="absolute inset-0 rounded-lg bg-sky-500/[0.08] ring-1 ring-inset ring-sky-500/25"
+                  transition={{ duration: 0.32, ease: EASE_OUT_EXPO }}
+                >
+                  {!reduceMotion && (
+                    <motion.span
+                      className="absolute inset-x-3 bottom-0 h-px bg-sky-400"
+                      animate={{ opacity: [0.25, 0.75, 0.25] }}
+                      transition={{ duration: 1.6, repeat: Infinity, ease: 'easeInOut' }}
+                    />
+                  )}
+                </motion.div>
+              )}
+              <span
+                className={`relative z-10 flex h-5 w-5 shrink-0 items-center justify-center rounded-full transition-colors duration-200 ${
+                  lit
+                    ? 'bg-sky-500 text-neutral-950'
+                    : active
+                      ? 'border border-sky-500/60'
+                      : 'border border-neutral-700'
+                }`}
+                style={complete ? { transitionDelay: `${i * 45}ms` } : undefined}
+              >
+                {lit && <SectionCheck draw={!reduceMotion} delay={complete ? i * 0.045 : 0} />}
+              </span>
+              <span
+                className={`relative z-10 text-sm transition-colors duration-200 ${
+                  lit ? 'text-neutral-100' : active ? 'text-sky-200' : 'text-neutral-500'
+                }`}
+                style={complete ? { transitionDelay: `${i * 45}ms` } : undefined}
+              >
+                {t(section.labelKey, { defaultValue: section.defaultLabel })}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
 
 type ImportResumeDialogProps = {
   open: boolean;
@@ -40,19 +217,39 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
   const [isImporting, setIsImporting] = useState(false);
   const [importStatus, setImportStatus] = useState<string>('');
   const [fileType, setFileType] = useState<FileType>(null);
+  // PDF streaming progress: current phase, running char count, and the set of
+  // sections lit up so far. Decorative — the imported result still comes from the
+  // final `resume_update` + validation.
+  const [pdfPhase, setPdfPhase] = useState<PdfPhase>(null);
+  const [pdfCharCount, setPdfCharCount] = useState(0);
+  const [pdfLitFields, setPdfLitFields] = useState<Set<string>>(new Set());
+  const [pdfComplete, setPdfComplete] = useState(false);
+  const pdfAbortRef = useRef<AbortController | null>(null);
   const { t } = useTranslation();
   // Shared readiness check (provider + key + baseUrl + model + maxTokens) — see useSettingStore.
   const hasLlmConfig = hasLlmConfigFn();
 
+  const resetPdfProgress = useCallback(() => {
+    setPdfPhase(null);
+    setPdfCharCount(0);
+    setPdfLitFields(new Set());
+    setPdfComplete(false);
+  }, []);
+
   const handleClose = useCallback((open: boolean) => {
     if (!open) {
+      // Cancel any in-flight parse so the backend stops generating (no orphaned
+      // token burn) when the user closes mid-import.
+      pdfAbortRef.current?.abort();
+      pdfAbortRef.current = null;
       setFileType(null);
       setUploadError(null);
       setLlmConfigMissing(false);
       setImportStatus('');
+      resetPdfProgress();
     }
     onOpenChange(open);
-  }, [onOpenChange]);
+  }, [onOpenChange, resetPdfProgress]);
 
   const handleSelectType = useCallback((value: string) => {
     const type = value as FileType;
@@ -77,33 +274,56 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
     return validateAndNormalizeImportedResume(result);
   }, [t]);
 
-  // ─── PDF 文件处理（前端传递 LLM 配置）───
+  // ─── PDF 文件处理（流式解析 + 逐板块点亮）───
   const handlePdfFile = useCallback(async (file: File) => {
-    setImportStatus(t('importDialog.pdf.extracting', { defaultValue: 'Extracting text from PDF...' }));
-
     const formData = new FormData();
     formData.append('file', file);
-
     // 传递用户的 LLM 配置
-    const llmConfig = { apiKey, baseUrl, modelName: model, maxTokens };
-    formData.append('config', JSON.stringify(llmConfig));
+    formData.append('config', JSON.stringify({ apiKey, baseUrl, modelName: model, maxTokens }));
 
-    setImportStatus(t('importDialog.pdf.analyzing', { defaultValue: 'AI is analyzing your resume...' }));
+    const controller = new AbortController();
+    pdfAbortRef.current = controller;
 
-    const response = await fetch('/api/pdf/parse', {
-      method: 'POST',
-      body: formData,
-    });
+    resetPdfProgress();
+    setPdfPhase('extracting');
 
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => ({ error: 'Unknown error' }));
-      const detail = errorData.detail || errorData.error || `Server error: ${response.status}`;
-      throw new Error(detail);
+    let resume: unknown = null;
+
+    for await (const ev of streamPdfParse(formData, controller.signal)) {
+      if (ev.type === 'tool_result') {
+        const payload = ev.payload as
+          | { kind?: string; phase?: PdfPhase; charCount?: number; fields?: string[] }
+          | undefined;
+        if (payload?.kind !== 'pdf_progress') continue;
+        if (payload.phase) setPdfPhase(payload.phase);
+        if (typeof payload.charCount === 'number') setPdfCharCount(payload.charCount);
+        if (payload.fields?.length) {
+          setPdfLitFields((prev) => {
+            const next = new Set(prev);
+            for (const f of payload.fields!) next.add(f);
+            return next;
+          });
+        }
+      } else if (ev.type === 'resume_update') {
+        // Final product: prefer `data`, fall back to the chat-shaped `payload.resume`.
+        resume = ev.data ?? (ev.payload as { resume?: unknown } | undefined)?.resume ?? null;
+      } else if (ev.type === 'error' || ev.type === 'run_failed') {
+        throw new Error(ev.error || t('importDialog.errors.parseFailed'));
+      }
     }
 
-    const result = await response.json();
-    return validateAndNormalizeImportedResume(result);
-  }, [apiKey, baseUrl, model, maxTokens, t]);
+    if (!resume) {
+      throw new Error(t('importDialog.errors.parseFailed'));
+    }
+
+    // Completion beat: light every section, run the finishing sweep, and hold on
+    // "解析完成" briefly so the user sees the parse land before the dialog closes.
+    setPdfLitFields(new Set(PDF_SECTIONS.map((s) => s.key)));
+    setPdfComplete(true);
+    await new Promise((r) => setTimeout(r, 600));
+
+    return validateAndNormalizeImportedResume(resume);
+  }, [apiKey, baseUrl, model, maxTokens, t, resetPdfProgress]);
 
   // ─── 统一文件处理 ───
   const onDrop = useCallback(async (acceptedFiles: File[]) => {
@@ -160,6 +380,7 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
     } finally {
       setIsImporting(false);
       setImportStatus('');
+      pdfAbortRef.current = null;
     }
   }, [fileType, hasLlmConfig, importResume, handleClose, t, handleJsonFile, handlePdfFile, cloudSync]);
 
@@ -296,7 +517,14 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
                       `}
                     >
                       <input {...getInputProps()} />
-                      {isImporting ? (
+                      {isImporting && fileType === 'pdf' ? (
+                        <PdfScanProgress
+                          phase={pdfPhase}
+                          charCount={pdfCharCount}
+                          litFields={pdfLitFields}
+                          complete={pdfComplete}
+                        />
+                      ) : isImporting ? (
                         <div className="flex flex-col items-center justify-center text-sky-500">
                           <Loader2 className="w-10 h-10 mb-3 animate-spin" />
                           <p className="font-medium text-sm">{importStatus || t('importDialog.importing')}</p>

--- a/apps/web/src/app/dashboard/_components/ImportResumeDialog.tsx
+++ b/apps/web/src/app/dashboard/_components/ImportResumeDialog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { useDropzone } from 'react-dropzone';
 import { Loader2, X, FileText, FileJson, AlertTriangle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -16,7 +16,7 @@ import { useAccountUiStore } from '@/store/useAccountUiStore';
 import { toast } from 'sonner';
 import { FaFileUpload } from 'react-icons/fa';
 import { useTranslation } from 'react-i18next';
-import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import { appLifecycle } from '@/lib/extensions/app-lifecycle';
 import { getFileSizeBucket } from '@/lib/utils/fileSize';
 import {
@@ -24,184 +24,14 @@ import {
   validateAndNormalizeImportedResume,
 } from '@/lib/validation/importResume';
 import { streamPdfParse } from '@/app/dashboard/edit/_components/ai/lib/services/agentClient';
+import {
+  getCompletePdfSectionSet,
+  PdfScanProgress,
+  PDF_SCAN_TIMING,
+  type PdfPhase,
+} from './PdfScanProgress';
 
 type FileType = 'json' | 'pdf' | null;
-
-type PdfPhase = 'extracting' | 'analyzing' | null;
-
-/**
- * Resume sections lit up as the parser streams them, in the order their anchors
- * appear in the model's JSON (kept in sync with agent-service
- * `document/lib/pdf-field-progress.ts`). The `key` matches the backend field key.
- */
-const PDF_SECTIONS: { key: string; labelKey: string; defaultLabel: string }[] = [
-  { key: 'info', labelKey: 'importDialog.pdf.sections.info', defaultLabel: '个人信息' },
-  { key: 'experience', labelKey: 'importDialog.pdf.sections.experience', defaultLabel: '工作经历' },
-  { key: 'education', labelKey: 'importDialog.pdf.sections.education', defaultLabel: '教育经历' },
-  { key: 'projects', labelKey: 'importDialog.pdf.sections.projects', defaultLabel: '项目经历' },
-  { key: 'skills', labelKey: 'importDialog.pdf.sections.skills', defaultLabel: '技能' },
-  { key: 'languages', labelKey: 'importDialog.pdf.sections.languages', defaultLabel: '语言能力' },
-  { key: 'certificates', labelKey: 'importDialog.pdf.sections.certificates', defaultLabel: '证书' },
-];
-
-// ease-out-expo — natural deceleration, no bounce (per design language).
-const EASE_OUT_EXPO = [0.16, 1, 0.3, 1] as const;
-
-/**
- * Smoothly counts the displayed number toward `value` (ease-out-cubic over 300ms).
- * A quiet liveness signal while parsing; jumps instantly under reduced motion.
- */
-function CountUp({ value, animate }: { value: number; animate: boolean }) {
-  const [display, setDisplay] = useState(value);
-  const fromRef = useRef(value);
-
-  useEffect(() => {
-    const from = fromRef.current;
-    const to = value;
-    if (from === to) return;
-    if (!animate) {
-      fromRef.current = to;
-      setDisplay(to);
-      return;
-    }
-    const start = performance.now();
-    const duration = 300;
-    let raf = 0;
-    const tick = (now: number) => {
-      const p = Math.min(1, (now - start) / duration);
-      const eased = 1 - Math.pow(1 - p, 3);
-      setDisplay(Math.round(from + (to - from) * eased));
-      if (p < 1) raf = requestAnimationFrame(tick);
-      else fromRef.current = to;
-    };
-    raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
-  }, [value, animate]);
-
-  return <>{display.toLocaleString()}</>;
-}
-
-/** A checkmark that draws itself in a single stroke when a section lights up. */
-function SectionCheck({ draw, delay }: { draw: boolean; delay: number }) {
-  return (
-    <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" aria-hidden>
-      <motion.path
-        d="M5 13l4 4L19 7"
-        stroke="currentColor"
-        strokeWidth={3}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        initial={draw ? { pathLength: 0 } : false}
-        animate={{ pathLength: 1 }}
-        transition={{ duration: 0.24, ease: 'easeOut', delay }}
-      />
-    </svg>
-  );
-}
-
-/**
- * PDF parse progress, "scanline" style: a sky band rides the active section (the
- * frontier of what's been parsed) while each section lights up — sky node + a
- * drawn check — as its data streams in. No spinner; the scan *is* the progress.
- */
-function PdfScanProgress({
-  phase,
-  charCount,
-  litFields,
-  complete,
-}: {
-  phase: PdfPhase;
-  charCount: number;
-  litFields: Set<string>;
-  complete: boolean;
-}) {
-  const { t } = useTranslation();
-  const reduceMotion = useReducedMotion();
-  // The active row is the frontier: first section not yet lit. Anchored to real
-  // progress — never a constant-speed fake sweep.
-  const activeIndex = complete
-    ? -1
-    : PDF_SECTIONS.findIndex((s) => !litFields.has(s.key));
-
-  const heading = complete
-    ? t('importDialog.pdf.done', { defaultValue: '解析完成' })
-    : phase === 'analyzing'
-      ? t('importDialog.pdf.analyzing', { defaultValue: '解析中' })
-      : t('importDialog.pdf.extracting', { defaultValue: '读取 PDF' });
-
-  return (
-    <div className="text-left">
-      <div className="mb-4 flex items-baseline justify-between">
-        <span className="text-sm font-medium text-neutral-100">{heading}</span>
-        {phase === 'analyzing' && !complete && charCount > 0 && (
-          <span className="text-xs tabular-nums text-neutral-500">
-            <CountUp value={charCount} animate={!reduceMotion} />{' '}
-            {t('importDialog.pdf.charUnit', { defaultValue: '字' })}
-          </span>
-        )}
-      </div>
-
-      <ul className="relative flex flex-col gap-0.5">
-        {/* Completion sweep: a single sky band runs down the whole list and fades. */}
-        {complete && !reduceMotion && (
-          <motion.div
-            aria-hidden
-            className="pointer-events-none absolute inset-x-0 top-0 h-full rounded-lg bg-gradient-to-b from-transparent via-sky-500/10 to-transparent"
-            initial={{ y: '-110%', opacity: 0.9 }}
-            animate={{ y: '110%', opacity: 0 }}
-            transition={{ duration: 0.6, ease: 'easeOut' }}
-          />
-        )}
-        {PDF_SECTIONS.map((section, i) => {
-          const lit = litFields.has(section.key) || complete;
-          const active = i === activeIndex;
-          return (
-            <li
-              key={section.key}
-              className="relative flex h-10 items-center gap-3 rounded-lg px-3"
-            >
-              {active && !complete && (
-                <motion.div
-                  layoutId="pdf-scanband"
-                  className="absolute inset-0 rounded-lg bg-sky-500/[0.08] ring-1 ring-inset ring-sky-500/25"
-                  transition={{ duration: 0.32, ease: EASE_OUT_EXPO }}
-                >
-                  {!reduceMotion && (
-                    <motion.span
-                      className="absolute inset-x-3 bottom-0 h-px bg-sky-400"
-                      animate={{ opacity: [0.25, 0.75, 0.25] }}
-                      transition={{ duration: 1.6, repeat: Infinity, ease: 'easeInOut' }}
-                    />
-                  )}
-                </motion.div>
-              )}
-              <span
-                className={`relative z-10 flex h-5 w-5 shrink-0 items-center justify-center rounded-full transition-colors duration-200 ${
-                  lit
-                    ? 'bg-sky-500 text-neutral-950'
-                    : active
-                      ? 'border border-sky-500/60'
-                      : 'border border-neutral-700'
-                }`}
-                style={complete ? { transitionDelay: `${i * 45}ms` } : undefined}
-              >
-                {lit && <SectionCheck draw={!reduceMotion} delay={complete ? i * 0.045 : 0} />}
-              </span>
-              <span
-                className={`relative z-10 text-sm transition-colors duration-200 ${
-                  lit ? 'text-neutral-100' : active ? 'text-sky-200' : 'text-neutral-500'
-                }`}
-                style={complete ? { transitionDelay: `${i * 45}ms` } : undefined}
-              >
-                {t(section.labelKey, { defaultValue: section.defaultLabel })}
-              </span>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  );
-}
 
 type ImportResumeDialogProps = {
   open: boolean;
@@ -318,9 +148,9 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
 
     // Completion beat: light every section, run the finishing sweep, and hold on
     // "解析完成" briefly so the user sees the parse land before the dialog closes.
-    setPdfLitFields(new Set(PDF_SECTIONS.map((s) => s.key)));
+    setPdfLitFields(getCompletePdfSectionSet());
     setPdfComplete(true);
-    await new Promise((r) => setTimeout(r, 600));
+    await new Promise((r) => setTimeout(r, PDF_SCAN_TIMING.completionHoldMs));
 
     return validateAndNormalizeImportedResume(resume);
   }, [apiKey, baseUrl, model, maxTokens, t, resetPdfProgress]);

--- a/apps/web/src/app/dashboard/_components/PdfScanProgress.tsx
+++ b/apps/web/src/app/dashboard/_components/PdfScanProgress.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useRef, useState } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { useTranslation } from 'react-i18next';
+import { AnimatedCheckIcon } from '@/components/icons/AnimatedCheckIcon';
+
+export type PdfPhase = 'extracting' | 'analyzing' | null;
+
+export type PdfImportSection = {
+  key: string;
+  labelKey: string;
+  defaultLabel: string;
+};
+
+const SECTION_STAGGER_MS = 45;
+
+export const PDF_SCAN_TIMING = {
+  countUpDurationMs: 300,
+  checkDrawDurationSec: 0.24,
+  completionSweepDurationSec: 0.6,
+  activeBandLayoutDurationSec: 0.32,
+  scanlinePulseDurationSec: 1.6,
+  sectionStaggerMs: SECTION_STAGGER_MS,
+  sectionStaggerSec: SECTION_STAGGER_MS / 1000,
+  completionHoldMs: 600,
+} as const;
+
+/**
+ * Resume sections lit up as the parser streams them, in the order their anchors
+ * appear in the model's JSON (kept in sync with agent-service
+ * `document/lib/pdf-field-progress.ts`). The `key` matches the backend field key.
+ */
+export const PDF_IMPORT_SECTIONS: PdfImportSection[] = [
+  { key: 'info', labelKey: 'importDialog.pdf.sections.info', defaultLabel: '个人信息' },
+  { key: 'experience', labelKey: 'importDialog.pdf.sections.experience', defaultLabel: '工作经历' },
+  { key: 'education', labelKey: 'importDialog.pdf.sections.education', defaultLabel: '教育经历' },
+  { key: 'projects', labelKey: 'importDialog.pdf.sections.projects', defaultLabel: '项目经历' },
+  { key: 'skills', labelKey: 'importDialog.pdf.sections.skills', defaultLabel: '技能' },
+  { key: 'languages', labelKey: 'importDialog.pdf.sections.languages', defaultLabel: '语言能力' },
+  { key: 'certificates', labelKey: 'importDialog.pdf.sections.certificates', defaultLabel: '证书' },
+];
+
+export const PDF_IMPORT_SECTION_KEYS = PDF_IMPORT_SECTIONS.map((section) => section.key);
+
+// ease-out-expo — natural deceleration, no bounce (per design language).
+const EASE_OUT_EXPO = [0.16, 1, 0.3, 1] as const;
+
+export function getCompletePdfSectionSet() {
+  return new Set(PDF_IMPORT_SECTION_KEYS);
+}
+
+/**
+ * Smoothly counts the displayed number toward `value` (ease-out-cubic).
+ * A quiet liveness signal while parsing; jumps instantly under reduced motion.
+ */
+function CountUp({ value, animate }: { value: number; animate: boolean }) {
+  const [display, setDisplay] = useState(value);
+  const fromRef = useRef(value);
+
+  useEffect(() => {
+    const from = fromRef.current;
+    const to = value;
+    if (from === to) return;
+    if (!animate) {
+      fromRef.current = to;
+      setDisplay(to);
+      return;
+    }
+    const start = performance.now();
+    let raf = 0;
+    const tick = (now: number) => {
+      const p = Math.min(1, (now - start) / PDF_SCAN_TIMING.countUpDurationMs);
+      const eased = 1 - Math.pow(1 - p, 3);
+      setDisplay(Math.round(from + (to - from) * eased));
+      if (p < 1) raf = requestAnimationFrame(tick);
+      else fromRef.current = to;
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [value, animate]);
+
+  return <>{display.toLocaleString()}</>;
+}
+
+type PdfScanProgressSectionProps = {
+  section: PdfImportSection;
+  index: number;
+  active: boolean;
+  lit: boolean;
+  complete: boolean;
+  reduceMotion: boolean;
+};
+
+export function PdfScanProgressSection({
+  section,
+  index,
+  active,
+  lit,
+  complete,
+  reduceMotion,
+}: PdfScanProgressSectionProps) {
+  const { t } = useTranslation();
+  const completionDelay = complete
+    ? { transitionDelay: `${index * PDF_SCAN_TIMING.sectionStaggerMs}ms` }
+    : undefined;
+
+  return (
+    <li
+      key={section.key}
+      className="relative flex h-10 items-center gap-3 rounded-lg px-3"
+    >
+      {active && !complete && (
+        <motion.div
+          layoutId="pdf-scanband"
+          className="absolute inset-0 rounded-lg bg-sky-500/[0.08] ring-1 ring-inset ring-sky-500/25"
+          transition={{ duration: PDF_SCAN_TIMING.activeBandLayoutDurationSec, ease: EASE_OUT_EXPO }}
+        >
+          {!reduceMotion && (
+            <motion.span
+              className="absolute inset-x-3 bottom-0 h-px bg-sky-400"
+              animate={{ opacity: [0.25, 0.75, 0.25] }}
+              transition={{
+                duration: PDF_SCAN_TIMING.scanlinePulseDurationSec,
+                repeat: Infinity,
+                ease: 'easeInOut',
+              }}
+            />
+          )}
+        </motion.div>
+      )}
+      <span
+        className={`relative z-10 flex h-5 w-5 shrink-0 items-center justify-center rounded-full transition-colors duration-200 ${
+          lit
+            ? 'bg-sky-500 text-neutral-950'
+            : active
+              ? 'border border-sky-500/60'
+              : 'border border-neutral-700'
+        }`}
+        style={completionDelay}
+      >
+        {lit && (
+          <AnimatedCheckIcon
+            draw={!reduceMotion}
+            delay={complete ? index * PDF_SCAN_TIMING.sectionStaggerSec : 0}
+            duration={PDF_SCAN_TIMING.checkDrawDurationSec}
+          />
+        )}
+      </span>
+      <span
+        className={`relative z-10 text-sm transition-colors duration-200 ${
+          lit ? 'text-neutral-100' : active ? 'text-sky-200' : 'text-neutral-500'
+        }`}
+        style={completionDelay}
+      >
+        {t(section.labelKey, { defaultValue: section.defaultLabel })}
+      </span>
+    </li>
+  );
+}
+
+/**
+ * PDF parse progress, "scanline" style: a sky band rides the active section (the
+ * frontier of what's been parsed) while each section lights up — sky node + a
+ * drawn check — as its data streams in. No spinner; the scan *is* the progress.
+ */
+export function PdfScanProgress({
+  phase,
+  charCount,
+  litFields,
+  complete,
+}: {
+  phase: PdfPhase;
+  charCount: number;
+  litFields: Set<string>;
+  complete: boolean;
+}) {
+  const { t } = useTranslation();
+  const reduceMotion = useReducedMotion() ?? false;
+  // The active row is the frontier: first section not yet lit. Anchored to real
+  // progress — never a constant-speed fake sweep.
+  const activeIndex = complete
+    ? -1
+    : PDF_IMPORT_SECTIONS.findIndex((section) => !litFields.has(section.key));
+
+  const heading = complete
+    ? t('importDialog.pdf.done', { defaultValue: '解析完成' })
+    : phase === 'analyzing'
+      ? t('importDialog.pdf.analyzing', { defaultValue: '解析中' })
+      : t('importDialog.pdf.extracting', { defaultValue: '读取 PDF' });
+
+  return (
+    <div className="text-left">
+      <div className="mb-4 flex items-baseline justify-between">
+        <span className="text-sm font-medium text-neutral-100">{heading}</span>
+        {phase === 'analyzing' && !complete && charCount > 0 && (
+          <span className="text-xs tabular-nums text-neutral-500">
+            <CountUp value={charCount} animate={!reduceMotion} />{' '}
+            {t('importDialog.pdf.charUnit', { defaultValue: '字' })}
+          </span>
+        )}
+      </div>
+
+      <ul className="relative flex flex-col gap-0.5">
+        {/* Completion sweep: a single sky band runs down the whole list and fades. */}
+        {complete && !reduceMotion && (
+          <motion.div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 h-full rounded-lg bg-gradient-to-b from-transparent via-sky-500/10 to-transparent"
+            initial={{ y: '-110%', opacity: 0.9 }}
+            animate={{ y: '110%', opacity: 0 }}
+            transition={{ duration: PDF_SCAN_TIMING.completionSweepDurationSec, ease: 'easeOut' }}
+          />
+        )}
+        {PDF_IMPORT_SECTIONS.map((section, index) => {
+          const lit = litFields.has(section.key) || complete;
+          const active = index === activeIndex;
+          return (
+            <PdfScanProgressSection
+              key={section.key}
+              section={section}
+              index={index}
+              active={active}
+              lit={lit}
+              complete={complete}
+              reduceMotion={reduceMotion}
+            />
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/edit/_components/ai/lib/services/agentClient.ts
+++ b/apps/web/src/app/dashboard/edit/_components/ai/lib/services/agentClient.ts
@@ -20,20 +20,12 @@ async function readError(res: Response): Promise<string> {
 }
 
 /**
- * Stream a normalized agent run. Yields typed {@link AgentSseEvent}s parsed from the
- * `data: {json}\n\n` frames. Foundation for the streaming skills (not used by P0).
+ * Parse an SSE response body into typed {@link AgentSseEvent}s. Shared by every
+ * streaming caller (JSON-bodied chat and FormData-bodied PDF parse), so the frame
+ * handling lives in one place. Throws (via {@link readError}) on a non-stream error
+ * response — e.g. a pre-stream 401/422/429 the backend emits before it starts SSE.
  */
-export async function* streamAgent(
-  url: string,
-  body: unknown,
-  signal?: AbortSignal
-): AsyncGenerator<AgentSseEvent> {
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-    signal,
-  });
+export async function* consumeSseFrames(res: Response): AsyncGenerator<AgentSseEvent> {
   if (!res.ok || !res.body) throw new Error(await readError(res));
 
   const reader = res.body.getReader();
@@ -42,7 +34,7 @@ export async function* streamAgent(
 
   // Line-based: each AgentSseEvent is a single `data: {json}` line. This tolerates
   // both real `\n\n`-framed SSE (graph/translate — blank lines just skip) and the
-  // chat-agent proxy that collapses `\n\n` → `\n`.
+  // route-handler proxy that collapses `\n\n` → `\n`.
   const parse = (raw: string): AgentSseEvent | null => {
     const line = raw.trim();
     if (!line.startsWith('data:')) return null;
@@ -68,6 +60,41 @@ export async function* streamAgent(
   }
   const tail = parse(buffer);
   if (tail) yield tail;
+}
+
+/**
+ * Stream a normalized agent run. Yields typed {@link AgentSseEvent}s parsed from the
+ * `data: {json}\n\n` frames. Foundation for the streaming skills (not used by P0).
+ */
+export async function* streamAgent(
+  url: string,
+  body: unknown,
+  signal?: AbortSignal
+): AsyncGenerator<AgentSseEvent> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    signal,
+  });
+  yield* consumeSseFrames(res);
+}
+
+/**
+ * Stream the PDF-import parse. FormData body (file + `config`), so we deliberately
+ * omit `Content-Type` — the browser sets the multipart boundary itself. The route
+ * handler streams `pdf_progress` (`tool_result`) ticks and a final `resume_update`.
+ */
+export async function* streamPdfParse(
+  formData: FormData,
+  signal?: AbortSignal
+): AsyncGenerator<AgentSseEvent> {
+  const res = await fetch(WEB_AGENT_ROUTES.pdfParse, {
+    method: 'POST',
+    body: formData,
+    signal,
+  });
+  yield* consumeSseFrames(res);
 }
 
 export interface ChatStreamParams {

--- a/apps/web/src/components/icons/AnimatedCheckIcon.tsx
+++ b/apps/web/src/components/icons/AnimatedCheckIcon.tsx
@@ -1,0 +1,42 @@
+import type { SVGProps } from 'react';
+import { motion } from 'framer-motion';
+
+const CHECK_ICON_VIEW_BOX = '0 0 24 24';
+const CHECK_ICON_PATH = 'M5 13l4 4L19 7';
+const CHECK_ICON_STROKE_WIDTH = 3;
+export const DEFAULT_ANIMATED_CHECK_DURATION_SEC = 0.24;
+
+type AnimatedCheckIconProps = SVGProps<SVGSVGElement> & {
+  draw?: boolean;
+  delay?: number;
+  duration?: number;
+};
+
+export function AnimatedCheckIcon({
+  draw = true,
+  delay = 0,
+  duration = DEFAULT_ANIMATED_CHECK_DURATION_SEC,
+  className = 'h-3 w-3',
+  ...props
+}: AnimatedCheckIconProps) {
+  return (
+    <svg
+      viewBox={CHECK_ICON_VIEW_BOX}
+      className={className}
+      fill="none"
+      aria-hidden
+      {...props}
+    >
+      <motion.path
+        d={CHECK_ICON_PATH}
+        stroke="currentColor"
+        strokeWidth={CHECK_ICON_STROKE_WIDTH}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        initial={draw ? { pathLength: 0 } : false}
+        animate={{ pathLength: 1 }}
+        transition={{ duration, ease: 'easeOut', delay }}
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/lib/api/routes.ts
+++ b/apps/web/src/lib/api/routes.ts
@@ -55,4 +55,5 @@ export const WEB_AGENT_ROUTES = {
   chatApprove:      '/api/chat-agent/approve',
   chatSession:      '/api/chat-agent/session',
   chatEdit:         '/api/chat-agent/edit',
+  pdfParse:         '/api/pdf/parse',
 } as const;

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -978,10 +978,21 @@
     "importing": "Importing and syncing...",
     "defaultName": "Imported Resume",
     "pdf": {
-      "extracting": "Extracting text from PDF...",
-      "analyzing": "AI is analyzing your resume...",
+      "extracting": "Reading PDF",
+      "analyzing": "Parsing",
+      "done": "Parsed",
+      "charUnit": "chars",
       "success": "PDF resume imported successfully!",
-      "hint": "PDF files will be parsed with AI"
+      "hint": "PDF files will be parsed with AI",
+      "sections": {
+        "info": "Basics",
+        "experience": "Experience",
+        "education": "Education",
+        "projects": "Projects",
+        "skills": "Skills",
+        "languages": "Languages",
+        "certificates": "Certificates"
+      }
     }
   },
   "dynamicForm": {

--- a/apps/web/src/locales/zh/translation.json
+++ b/apps/web/src/locales/zh/translation.json
@@ -978,10 +978,21 @@
     "importing": "正在导入并同步...",
     "defaultName": "导入的简历",
     "pdf": {
-      "extracting": "正在从 PDF 中提取文本...",
-      "analyzing": "AI 正在分析您的简历...",
+      "extracting": "读取 PDF",
+      "analyzing": "解析中",
+      "done": "解析完成",
+      "charUnit": "字",
       "success": "PDF 简历导入成功！",
-      "hint": "PDF 文件将通过 AI 智能解析"
+      "hint": "PDF 文件将通过 AI 智能解析",
+      "sections": {
+        "info": "个人信息",
+        "experience": "工作经历",
+        "education": "教育经历",
+        "projects": "项目经历",
+        "skills": "技能",
+        "languages": "语言能力",
+        "certificates": "证书"
+      }
     }
   },
   "dynamicForm": {


### PR DESCRIPTION
## 背景

配套 [Magic-Core PDF import PR](https://github.com/LinMoQC/Magic-Core/pull/29)。后端把 PDF 解析改成端到端 SSE 后，前端从「阻塞请求 + 转圈」升级为实时进度。

## 改动

- **`agentClient`**：抽出共享 `consumeSseFrames`；新增 `streamPdfParse(formData, signal)`（FormData body，不设 `Content-Type`，交给浏览器带 boundary）。
- **`/api/pdf/parse` route**：由「await JSON」改为 **SSE 透传**（镜像 `chat-agent`），带 `X-Accel-Buffering: no` 与 `req.signal` 取消；流开始前的错误仍走 JSON。
- **`ImportResumeDialog`**：新 `PdfScanProgress` 组件消费流事件。

## 「扫描解析 Scanline」动效

（经 `/impeccable:shape` 定向）替换掉转圈：

- 单列 7 板块；一条 sky 光带用 `layoutId` 共享布局**平移锚定真实解析前沿**（不匀速假扫）。
- 板块点亮：节点 sky 实心 + 勾选 SVG `pathLength` 一笔描出（非缩放弹跳）。
- 实时字数 ticker（ease-out-cubic 补间）；完成时全列点亮 + 贯穿收尾扫过 + 「解析完成」定格 ~600ms 再关窗。
- 仅 transform/opacity；`prefers-reduced-motion` 降级为交叉淡入、数字直跳。
- 关窗即 `AbortController` 取消，后端停生成。

## 文案 / i18n

- `importDialog.pdf` 状态文案更简短（`读取 PDF` / `解析中` / `解析完成`），新增 `charUnit` 与 `sections.*`，zh/en 双语。
- `i18n:check` 通过；pre-commit 全量 build 通过。

## 验证

- ESLint clean、`tsc` 0 error、`pnpm build` 8/8 通过。
- 动效建议本地跑一眼：`pnpm --filter @magic-resume/web dev` → 导入 PDF。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF imports now show live streaming progress, including reading, parsing, character count, and section-by-section completion.
  * Added support for streamed PDF parsing during resume import, with the final result delivered as soon as it’s ready.
* **Bug Fixes**
  * Improved cancel behavior so in-progress PDF imports stop cleanly when closed or aborted.
  * Better error handling for PDF parsing failures, with clearer messages surfaced to the user.
* **Style**
  * Updated PDF import text in English and Chinese to match the new step-based progress flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->