### PR TITLE
:construction_worker: ci: 自动化 release + changelog(semantic-release + gitmoji)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Release
+
+# Auto-release on push to master via semantic-release + gitmoji.
+# Version bump is derived from the gitmoji of each commit since the last tag:
+#   💥 :boom: → major   ✨ :sparkles: → minor   🐛/♻️/💄/… → patch   (docs/chore/ci → no release)
+# Produces: git tag vX.Y.Z, GitHub Release with notes, and an updated CHANGELOG.md.
+
+on:
+  push:
+    branches: [master]
+
+# Least-privilege token: create releases/tags, comment on issues/PRs, push the changelog commit.
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Skip the repo's Husky hooks — this job commits the changelog itself.
+    env:
+      HUSKY: "0"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # semantic-release needs full history + tags
+          persist-credentials: true
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # Install the release toolchain in an isolated dir so it never touches the
+      # pnpm workspace (avoids workspace-protocol install friction + frozen lockfile).
+      - name: Install semantic-release toolchain
+        run: |
+          mkdir -p "$RUNNER_TEMP/sr" && cd "$RUNNER_TEMP/sr"
+          npm init -y >/dev/null 2>&1
+          npm install --no-audit --no-fund \
+            semantic-release@24 \
+            semantic-release-gitmoji@1 \
+            @semantic-release/changelog@6 \
+            @semantic-release/git@10 \
+            @semantic-release/github@11
+
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: "$RUNNER_TEMP/sr/node_modules/.bin/semantic-release"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,49 @@
+{
+  "branches": ["master"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    [
+      "semantic-release-gitmoji",
+      {
+        "releaseRules": {
+          "major": [":boom:"],
+          "minor": [":sparkles:"],
+          "patch": [
+            ":bug:",
+            ":ambulance:",
+            ":lock:",
+            ":zap:",
+            ":art:",
+            ":recycle:",
+            ":wrench:",
+            ":lipstick:",
+            ":globe_with_meridians:",
+            ":pencil2:",
+            ":goal_net:",
+            ":wheelchair:",
+            ":children_crossing:",
+            ":speech_balloon:",
+            ":alien:",
+            ":fire:",
+            ":rewind:"
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog\n\nAll notable changes to Magic Resume are documented in this file."
+      }
+    ],
+    "@semantic-release/github",
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["CHANGELOG.md"],
+        "message": ":bookmark: chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
+  ]
+}

--- a/docs/reference/release-automation.md
+++ b/docs/reference/release-automation.md
@@ -1,0 +1,65 @@
+# Release automation (semantic-release + gitmoji)
+
+Releases are cut automatically from the gitmoji of commits merged to `master`.
+No manual version bumping or changelog editing is required.
+
+## How it works
+
+On every push to `master`, `.github/workflows/release.yml` runs
+[`semantic-release`](https://semantic-release.gitbook.io/) with the
+[`semantic-release-gitmoji`](https://github.com/momocow/semantic-release-gitmoji)
+plugin. It reads all commits since the last `vX.Y.Z` tag, derives the next
+version from their gitmoji, and — if a release is warranted — produces:
+
+- a git tag `vX.Y.Z`,
+- a GitHub Release with generated notes (grouped by gitmoji),
+- an updated `CHANGELOG.md`, committed back as
+  `:bookmark: chore(release): X.Y.Z [skip ci]`.
+
+Because it keys off **gitmoji**, our existing emoji-first commit convention
+(`✨ feat(web): …`) works as-is — no change to how commits are written.
+
+## Version rules
+
+Configured in `.releaserc.json` (`releaseRules`):
+
+| Bump  | Gitmoji |
+|-------|---------|
+| major | 💥 `:boom:` |
+| minor | ✨ `:sparkles:` |
+| patch | 🐛 `:bug:` · 🚑 `:ambulance:` · 🔒 `:lock:` · ⚡ `:zap:` · 🎨 `:art:` · ♻️ `:recycle:` · 🔧 `:wrench:` · 💄 `:lipstick:` · 🌐 `:globe_with_meridians:` · ✏️ `:pencil2:` · 🥅 `:goal_net:` · ♿ `:wheelchair:` · 🚸 `:children_crossing:` · 💬 `:speech_balloon:` · 👽 `:alien:` · 🔥 `:fire:` · ⏪ `:rewind:` |
+
+Anything else (📝 docs, 🔨 chore, 👷 ci, ✅ test, 🚧 wip, …) does **not** trigger a
+release on its own — it only shows up in the notes when it ships alongside a
+release-worthy commit. Adjust the lists in `.releaserc.json` to taste.
+
+## Prerequisites / caveats
+
+- **The toolchain is installed isolated** (in `$RUNNER_TEMP`) so it never touches
+  the pnpm workspace or the frozen lockfile. It is intentionally **not** a
+  `devDependency`.
+- **Branch protection on `master`**: `@semantic-release/git` pushes the changelog
+  commit + tag directly to `master`. If `master` requires PRs / status checks,
+  the push is rejected. Fixes, pick one:
+  - allow the `github-actions[bot]` (or a dedicated bot) to bypass protection, **or**
+  - use a Personal Access Token / GitHub App token with bypass rights as
+    `GITHUB_TOKEN` in the workflow, **or**
+  - drop the `@semantic-release/git` plugin — you still get the tag + GitHub
+    Release (via `@semantic-release/github`), just no in-repo `CHANGELOG.md` update.
+- **`package.json` version is not auto-bumped** (the app is private and unpublished);
+  the source of truth for the version is the git tag + GitHub Release. Add
+  `@semantic-release/npm` (`npmPublish: false`) if you want `package.json` synced too.
+- The workflow sets `HUSKY: 0` so the repo's local git hooks don't run in CI.
+
+## Verifying / dry-run
+
+Locally, against the real history (needs a `GITHUB_TOKEN` env for the github plugin,
+or run with `--dry-run` which skips publishing):
+
+```bash
+npx -p semantic-release@24 -p semantic-release-gitmoji@1 \
+  -p @semantic-release/changelog@6 -p @semantic-release/git@10 \
+  -p @semantic-release/github@11 semantic-release --dry-run
+```
+
+It prints the next version and the notes it would publish, without changing anything.


### PR DESCRIPTION
## 目的

自动化 **release / tag / GitHub Release / CHANGELOG**,零手工。**保留 emoji-first 的 gitmoji 提交约定**(按 emoji 定级,无需改任何人的提交习惯)。

## 机制

push 到 `master` 时,`release.yml` 跑 `semantic-release` + `semantic-release-gitmoji`,读取上个 tag 以来的提交,按 gitmoji 定级并发布:
- git tag `vX.Y.Z`
- GitHub Release(按 emoji 分组的 notes)
- 更新 `CHANGELOG.md`,以 `:bookmark: chore(release): X.Y.Z [skip ci]` 回提交

## 定级(`.releaserc.json`)

| bump | gitmoji |
|---|---|
| major | 💥 `:boom:` |
| minor | ✨ `:sparkles:` |
| patch | 🐛 `:bug:` · ♻️ `:recycle:` · 💄 `:lipstick:` · ⚡ `:zap:` · 🔒 `:lock:` … |

docs/chore/ci 不单独触发发布。

## 注意(见 `docs/reference/release-automation.md`)

- 工具链**隔离安装**在 `$RUNNER_TEMP`,不碰 pnpm workspace / frozen lockfile,不进 devDependencies。
- **分支保护**:`@semantic-release/git` 会直推 `master`(changelog 提交 + tag)。若 `master` 需 PR/检查,直推会被拒——需给 `github-actions[bot]` 放行,或用有 bypass 权限的 token,或去掉 `@semantic-release/git`(仍有 tag + Release,只是不回写仓库内 CHANGELOG)。
- `package.json` 版本不自动 bump(应用私有未发布,版本以 tag/Release 为准)。

## 生效时机

合并本 PR 后不会立刻发布(ci 提交不定级)。**下一次 `:sparkles:`/`:bug:` 类提交合到 master 时**触发首个自动 release —— 比如那个浅色主题 PR(`:sparkles: feat`)合并后会自动出 `v2.1.0`。

可先本地 `--dry-run` 预览(命令见 doc)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)