### PR TITLE
:green_heart: ci(release): 修复自动发布(master 分支保护导致 push 被拒)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,15 @@ name: Release
 # Auto-release on push to master via semantic-release + gitmoji.
 # Version bump is derived from the gitmoji of each commit since the last tag:
 #   💥 :boom: → major   ✨ :sparkles: → minor   🐛/♻️/💄/… → patch   (docs/chore/ci → no release)
-# Produces: git tag vX.Y.Z, GitHub Release with notes, and an updated CHANGELOG.md.
+# Produces: git tag vX.Y.Z + a GitHub Release with generated notes (the living
+# changelog). It does NOT commit CHANGELOG.md back — master is protected and
+# rejects direct pushes; the tag/Release are created via the API instead.
 
 on:
   push:
     branches: [master]
 
-# Least-privilege token: create releases/tags, comment on issues/PRs, push the changelog commit.
+# Least-privilege token: create releases/tags and comment on released issues/PRs.
 permissions:
   contents: write
   issues: write
@@ -44,8 +46,6 @@ jobs:
           npm install --no-audit --no-fund \
             semantic-release@24 \
             semantic-release-gitmoji@1 \
-            @semantic-release/changelog@6 \
-            @semantic-release/git@10 \
             @semantic-release/github@11
 
       - name: Release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -30,20 +30,6 @@
         }
       }
     ],
-    [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md",
-        "changelogTitle": "# Changelog\n\nAll notable changes to Magic Resume are documented in this file."
-      }
-    ],
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md"],
-        "message": ":bookmark: chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ]
+    "@semantic-release/github"
   ]
 }

--- a/docs/reference/release-automation.md
+++ b/docs/reference/release-automation.md
@@ -12,9 +12,13 @@ plugin. It reads all commits since the last `vX.Y.Z` tag, derives the next
 version from their gitmoji, and — if a release is warranted — produces:
 
 - a git tag `vX.Y.Z`,
-- a GitHub Release with generated notes (grouped by gitmoji),
-- an updated `CHANGELOG.md`, committed back as
-  `:bookmark: chore(release): X.Y.Z [skip ci]`.
+- a **GitHub Release** with generated notes grouped by gitmoji.
+
+The **GitHub Releases page is the living changelog.** The workflow does not commit
+`CHANGELOG.md` back to `master`, because `master` is protected ("Changes must be
+made through a pull request") and rejects direct pushes. The tag and Release are
+created through the API, which branch protection does not block. `CHANGELOG.md`
+remains the curated historical record (≤ v2.0.0); newer entries live in Releases.
 
 Because it keys off **gitmoji**, our existing emoji-first commit convention
 (`✨ feat(web): …`) works as-is — no change to how commits are written.
@@ -38,28 +42,30 @@ release-worthy commit. Adjust the lists in `.releaserc.json` to taste.
 - **The toolchain is installed isolated** (in `$RUNNER_TEMP`) so it never touches
   the pnpm workspace or the frozen lockfile. It is intentionally **not** a
   `devDependency`.
-- **Branch protection on `master`**: `@semantic-release/git` pushes the changelog
-  commit + tag directly to `master`. If `master` requires PRs / status checks,
-  the push is rejected. Fixes, pick one:
-  - allow the `github-actions[bot]` (or a dedicated bot) to bypass protection, **or**
-  - use a Personal Access Token / GitHub App token with bypass rights as
-    `GITHUB_TOKEN` in the workflow, **or**
-  - drop the `@semantic-release/git` plugin — you still get the tag + GitHub
-    Release (via `@semantic-release/github`), just no in-repo `CHANGELOG.md` update.
 - **`package.json` version is not auto-bumped** (the app is private and unpublished);
   the source of truth for the version is the git tag + GitHub Release. Add
   `@semantic-release/npm` (`npmPublish: false`) if you want `package.json` synced too.
 - The workflow sets `HUSKY: 0` so the repo's local git hooks don't run in CI.
 
+### Want `CHANGELOG.md` auto-updated in the repo too?
+
+That needs a way to land a commit on protected `master`. Pick one, then re-add
+`@semantic-release/changelog` + `@semantic-release/git` to `.releaserc.json`:
+
+- allow `github-actions[bot]` to **bypass** the branch ruleset (repo → Rules), **or**
+- give the workflow a **PAT / GitHub App token** with bypass rights as `GITHUB_TOKEN`, **or**
+- keep `@semantic-release/changelog` (no git plugin) and add a
+  `peter-evans/create-pull-request` step to open a changelog PR — this also needs
+  "Allow GitHub Actions to create and approve pull requests" enabled in settings.
+
 ## Verifying / dry-run
 
-Locally, against the real history (needs a `GITHUB_TOKEN` env for the github plugin,
-or run with `--dry-run` which skips publishing):
+Locally, against the real history (`--dry-run` skips publishing; use `--no-ci` to
+run off a feature branch):
 
 ```bash
 npx -p semantic-release@24 -p semantic-release-gitmoji@1 \
-  -p @semantic-release/changelog@6 -p @semantic-release/git@10 \
-  -p @semantic-release/github@11 semantic-release --dry-run
+  -p @semantic-release/github@11 semantic-release --dry-run --no-ci
 ```
 
 It prints the next version and the notes it would publish, without changing anything.


### PR DESCRIPTION
## 问题

合并自动化后第一次 **Release 工作流失败**([run](https://github.com/LinMoQC/Magic-Resume/actions))。根因:`master` 开了分支保护规则(*Changes must be made through a pull request*),`@semantic-release/git` 想把 CHANGELOG 提交直推 `master` 被拒:

```
remote: error: GH013: Repository rule violations found for refs/heads/master.
remote: - Changes must be made through a pull request.
```

好消息:gitmoji 解析、版本计算(→ v2.1.0)、release notes 都正常跑了,**只有最后回写 master 这步被挡**,没有产生残缺的 tag/release。

## 修复

去掉 `@semantic-release/git` 和 `@semantic-release/changelog`,让 **GitHub Release 成为活的 changelog** —— tag 与 Release 通过 **API 创建,不受分支保护限制**。`CHANGELOG.md` 保留为 ≤v2.0.0 的人工历史记录,之后的版本记录看 Releases 页。

- `.releaserc.json`:插件精简为 `semantic-release-gitmoji` + `@semantic-release/github`
- `release.yml`:安装列表同步精简;注释更新
- `docs/reference/release-automation.md`:说明现状 + 若想**继续自动回写 CHANGELOG.md** 的三种可选路径(给 bot 放行 ruleset / 用有 bypass 的 PAT / 加 create-pull-request 步骤)

## 合并后

本 PR 用 `:green_heart:`(修 CI)本身不定级;但自 v2.0.0 以来已积压 ✨ 提交(浅色主题 + PDF),**合并后 Release 工作流会用修好的配置成功跑出 `v2.1.0`** + GitHub Release。

🤖 Generated with [Claude Code](https://claude.com/claude-code)