### PR TITLE
:construction_worker: ci(release): 让 CHANGELOG.md 通过自动 PR 保持同步

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,14 @@ name: Release
 # Auto-release on push to master via semantic-release + gitmoji.
 # Version bump is derived from the gitmoji of each commit since the last tag:
 #   💥 :boom: → major   ✨ :sparkles: → minor   🐛/♻️/💄/… → patch   (docs/chore/ci → no release)
-# Produces: git tag vX.Y.Z + a GitHub Release with generated notes (the living
-# changelog). It does NOT commit CHANGELOG.md back — master is protected and
-# rejects direct pushes; the tag/Release are created via the API instead.
+# Produces: git tag vX.Y.Z + a GitHub Release with generated notes. master is
+# protected (direct pushes rejected), so the tag/Release are created via the API,
+# and the CHANGELOG.md update is landed through an auto-opened PR (not a push).
 
 on:
   push:
     branches: [master]
 
-# Least-privilege token: create releases/tags and comment on released issues/PRs.
 permissions:
   contents: write
   issues: write
@@ -24,7 +23,6 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # Skip the repo's Husky hooks — this job commits the changelog itself.
     env:
       HUSKY: "0"
     steps:
@@ -46,9 +44,40 @@ jobs:
           npm install --no-audit --no-fund \
             semantic-release@24 \
             semantic-release-gitmoji@1 \
+            @semantic-release/changelog@6 \
             @semantic-release/github@11
 
+      # Runs semantic-release: creates the tag + GitHub Release (via API) and writes
+      # the CHANGELOG.md update into the working tree (the @semantic-release/git plugin
+      # is intentionally absent — we don't push to protected master). Capture the new
+      # version so the next step can title the changelog PR.
       - name: Release
+        id: sr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: "$RUNNER_TEMP/sr/node_modules/.bin/semantic-release"
+        run: |
+          set -eo pipefail
+          "$RUNNER_TEMP/sr/node_modules/.bin/semantic-release" 2>&1 | tee "$RUNNER_TEMP/sr.log"
+          v="$(grep -oE 'next release version is [0-9]+\.[0-9]+\.[0-9]+' "$RUNNER_TEMP/sr.log" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tail -1 || true)"
+          if [ -n "$v" ]; then
+            echo "version=$v" >> "$GITHUB_OUTPUT"
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Land the CHANGELOG.md change through a PR (respects branch protection).
+      # Skipped when no release was cut.
+      - name: Open CHANGELOG pull request
+        if: steps.sr.outputs.published == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: CHANGELOG.md
+          base: master
+          branch: chore/changelog-v${{ steps.sr.outputs.version }}
+          delete-branch: true
+          commit-message: ":memo: docs(changelog): update for v${{ steps.sr.outputs.version }}"
+          title: ":memo: docs(changelog): v${{ steps.sr.outputs.version }}"
+          body: |
+            Automated `CHANGELOG.md` update for **v${{ steps.sr.outputs.version }}**.
+            Full notes are on the [GitHub Release](../../releases/tag/v${{ steps.sr.outputs.version }}).
+            Merge to keep the in-repo changelog in sync — this PR is `:memo: docs`, so it does not trigger another release.

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -30,6 +30,13 @@
         }
       }
     ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog\n\nAll notable changes to Magic Resume are documented in this file."
+      }
+    ],
     "@semantic-release/github"
   ]
 }

--- a/docs/reference/release-automation.md
+++ b/docs/reference/release-automation.md
@@ -12,16 +12,20 @@ plugin. It reads all commits since the last `vX.Y.Z` tag, derives the next
 version from their gitmoji, and — if a release is warranted — produces:
 
 - a git tag `vX.Y.Z`,
-- a **GitHub Release** with generated notes grouped by gitmoji.
+- a **GitHub Release** with generated notes grouped by gitmoji,
+- an **auto-opened PR** (`:memo: docs(changelog): vX.Y.Z`) that updates `CHANGELOG.md`.
 
-The **GitHub Releases page is the living changelog.** The workflow does not commit
-`CHANGELOG.md` back to `master`, because `master` is protected ("Changes must be
-made through a pull request") and rejects direct pushes. The tag and Release are
-created through the API, which branch protection does not block. `CHANGELOG.md`
-remains the curated historical record (≤ v2.0.0); newer entries live in Releases.
+Because `master` is protected ("Changes must be made through a pull request"), the
+workflow never pushes to it directly: the tag + Release are created through the
+API, and the `CHANGELOG.md` update is landed as a normal PR you merge. That
+changelog PR is `:memo: docs`, so merging it does **not** trigger another release.
 
 Because it keys off **gitmoji**, our existing emoji-first commit convention
 (`✨ feat(web): …`) works as-is — no change to how commits are written.
+
+> **One-time setting:** the changelog PR is opened via `peter-evans/create-pull-request`
+> with `GITHUB_TOKEN`, which requires **Settings → Actions → General → "Allow GitHub
+> Actions to create and approve pull requests"** to be enabled.
 
 ## Version rules
 
@@ -46,17 +50,10 @@ release-worthy commit. Adjust the lists in `.releaserc.json` to taste.
   the source of truth for the version is the git tag + GitHub Release. Add
   `@semantic-release/npm` (`npmPublish: false`) if you want `package.json` synced too.
 - The workflow sets `HUSKY: 0` so the repo's local git hooks don't run in CI.
-
-### Want `CHANGELOG.md` auto-updated in the repo too?
-
-That needs a way to land a commit on protected `master`. Pick one, then re-add
-`@semantic-release/changelog` + `@semantic-release/git` to `.releaserc.json`:
-
-- allow `github-actions[bot]` to **bypass** the branch ruleset (repo → Rules), **or**
-- give the workflow a **PAT / GitHub App token** with bypass rights as `GITHUB_TOKEN`, **or**
-- keep `@semantic-release/changelog` (no git plugin) and add a
-  `peter-evans/create-pull-request` step to open a changelog PR — this also needs
-  "Allow GitHub Actions to create and approve pull requests" enabled in settings.
+- **`CHANGELOG.md` lands via a PR, not a direct push** — see the note above. If you
+  ever want it committed straight to `master` instead (no changelog PR), grant
+  `github-actions[bot]` bypass on the branch ruleset and swap the
+  `create-pull-request` step for the `@semantic-release/git` plugin.
 
 ## Verifying / dry-run
 


### PR DESCRIPTION
## 背景

自动发布已经能跑(v2.1.0 已出),但 `CHANGELOG.md` **文件**没更新 —— 因为上个修复为了绕过 master 分支保护,去掉了写文件的插件,只留了 GitHub Release。你希望文件也自动同步。

## 方案(不弱化分支保护)

- 重新加回 `@semantic-release/changelog`(把版本条目写进 `CHANGELOG.md`);
- 发布后用 `peter-evans/create-pull-request` **自动开一个 `:memo: docs(changelog): vX.Y.Z` 的 PR**,你合并即更新文件;
- 该 changelog PR 是 `:memo: docs`,**不会再触发发布**(无循环);
- 一切仍走 PR —— **不给任何人/bot 开直推 master 的口子**。

## 流程

```
功能 PR 合并 → master
      ↓ Release 工作流
  tag vX.Y.Z + GitHub Release (API)
      ↓
  机器人开 PR:📝 docs(changelog): vX.Y.Z
      ↓ 你合并
  CHANGELOG.md 同步
```

## 已配套

- 已通过 API 开启 **Settings → Actions → "Allow GitHub Actions to create and approve pull requests"**(create-pull-request 用 `GITHUB_TOKEN` 开 PR 所必需);同时把仓库默认 workflow 权限保持在 `read`(本工作流在 job 级自声明 `contents/pull-requests: write`)。
- 文档同步更新:`docs/reference/release-automation.md`。

## 生效时机

本 PR 用 `:construction_worker:` 自身不发版。合并后**下一次 `:sparkles:`/`:bug:` 类提交发版时**,会自动出 tag + Release + 一个 changelog PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)