### PR TITLE
:wrench: chore: add repository field to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "magic-resume",
   "version": "0.1.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LinMoQC/Magic-Resume.git"
+  },
   "packageManager": "pnpm@10.28.1",
   "engines": {
     "node": ">=20.0.0",


### PR DESCRIPTION
Adds the `repository` field so release/npm tooling can resolve the repo without inference.

Also serves as the first **release-worthy** commit since `v2.1.0` — merging it exercises the new pipeline end-to-end: it should cut **v2.1.1** (patch, `:wrench:`), publish a GitHub Release, and auto-open a `:memo: docs(changelog)` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)