### PR TITLE
:green_heart: ci: fix Docker build (Node 22) and release repositoryUrl

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,5 @@
 ### STAGE 1: DEPENDENCIES ###
-FROM node:20-alpine AS deps
+FROM node:22-alpine AS deps
 WORKDIR /app
 
 RUN corepack enable
@@ -18,7 +18,7 @@ COPY packages/utils/package.json packages/utils/package.json
 RUN pnpm install --frozen-lockfile
 
 ### STAGE 2: BUILDER ###
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 
 RUN corepack enable
@@ -38,7 +38,7 @@ ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 RUN pnpm --filter @magic-resume/web... build
 
 ### STAGE 3: RUNNER ###
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/LinMoQC/Magic-Resume.git"
+    "url": "https://github.com/Magic-Resume/Magic-Resume.git"
   },
   "packageManager": "pnpm@10.28.1",
   "engines": {


### PR DESCRIPTION
## 背景
master 上两个 CI 都在挂（commit f8c01f4）：

- **Build and Push Docker Image** — `pnpm install --frozen-lockfile` 报 `ERR_PNPM_UNSUPPORTED_ENGINE`（Expected `>=22.13.0`, Got `v20.20.2`）。`apps/web/Dockerfile` 三个 stage 都还是 `node:20-alpine`，而仓库锁定的 `pnpm@10.28.1` 要求 Node ≥22.13.0。
- **Release (semantic-release)** — `EMISMATCHGITHUBURL`：`repository.url` 指向旧的 `LinMoQC/Magic-Resume.git`，但仓库已迁到组织 `Magic-Resume/Magic-Resume`。

## 改动
- `apps/web/Dockerfile`: `node:20-alpine` → `node:22-alpine`（deps / builder / runner 三处）。
- `package.json`: `repository.url` → `https://github.com/Magic-Resume/Magic-Resume.git`。

> `engines.node` 在 master 上已是 `>=22.13.0`，无需再动。

合并后两个 workflow 应恢复绿色（Release 会正常校验通过；本 commit 为 `:green_heart: ci`，不触发版本发布）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)