### PR TITLE
:memo: docs(changelog): v2.2.0

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,7 +11,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: linmoqc/magic-resume
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build_and_push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Magic Resume are documented in this file.
 
+# [v2.2.0](https://github.com/Magic-Resume/Magic-Resume/compare/v2.1.1...v2.2.0) (2026-07-13)
+
+## ✨ New Features
+- [`5d9cf3f`](https://github.com/Magic-Resume/Magic-Resume/commit/5d9cf3f)  feat(web): render resume preview with PDF canvas (#120) (Issues: [`#120`](https://github.com/Magic-Resume/Magic-Resume/issues/120))
+
 # [v2.1.1](https://github.com/LinMoQC/Magic-Resume/compare/v2.1.0...v2.1.1) (2026-07-07)
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),


### PR DESCRIPTION
Automated `CHANGELOG.md` update for **v2.2.0**.
Full notes are on the [GitHub Release](../../releases/tag/v2.2.0).
Merge to keep the in-repo changelog in sync — this PR is `:memo: docs`, so it does not trigger another release.

（Release 工作流已自动切出 v2.2.0，但仓库禁用了「Actions 创建 PR」，故本 changelog PR 由手动补建。）