### PR TITLE
feat(web): runtime API origin (window.__ENV) — one image runs in any environment

### DIFF
--- a/apps/web/src/lib/api/routes.ts
+++ b/apps/web/src/lib/api/routes.ts
@@ -1,11 +1,35 @@
 /**
  * The single API origin — the whole frontend talks to ONE configured address.
- * ONE variable only (`NEXT_PUBLIC_API_URL`, resolved identically in browser +
- * server); no legacy per-service fallback.
+ * Resolved at RUNTIME so one build can target any backend:
+ *   - browser → `window.__ENV.apiOrigin`, injected by CommercialRuntimeProvider
+ *   - server  → `process.env.APP_API_ORIGIN` (container env, read per request)
+ *   - fallback → build-time `NEXT_PUBLIC_API_URL` / dev default
+ * The runtime var is deliberately WITHOUT the `NEXT_PUBLIC_` prefix: Next inlines
+ * `NEXT_PUBLIC_*` at build time into BOTH client and server bundles, which would
+ * freeze the address into the image. A prefix-less var is read from the container
+ * env at runtime (server), then shipped to the browser via `window.__ENV`.
  * Lives in this dep-free module so both client and server can import it without
  * pulling axios in via httpClient.
  */
-export const API_ORIGIN = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3110';
+type CommercialRuntime = { apiOrigin?: string };
+declare global {
+  interface Window {
+    __ENV?: CommercialRuntime;
+  }
+}
+
+function resolveApiOrigin(): string {
+  if (typeof window !== 'undefined') {
+    return window.__ENV?.apiOrigin || 'http://localhost:3110';
+  }
+  return (
+    process.env.APP_API_ORIGIN ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    'http://localhost:3110'
+  );
+}
+
+export const API_ORIGIN = resolveApiOrigin();
 
 /**
  * Product API routes.

--- a/apps/web/src/lib/commercial/runtime.tsx
+++ b/apps/web/src/lib/commercial/runtime.tsx
@@ -1,5 +1,37 @@
 import type { ReactNode } from 'react';
+import { headers } from 'next/headers';
 
-export function CommercialRuntimeProvider({ children }: { children: ReactNode }) {
-  return children;
+/**
+ * Runtime env → browser. Reads the API origin from the container env at REQUEST
+ * time and hands it to the client via `window.__ENV` (consumed lazily by
+ * lib/api/routes.ts). The var is deliberately WITHOUT the `NEXT_PUBLIC_` prefix:
+ * Next inlines `NEXT_PUBLIC_*` at build time into both client AND server bundles,
+ * which would freeze the address into the image; a prefix-less var is read from
+ * the container env at runtime, so one image targets any backend via docker
+ * compose `environment:`.
+ *
+ * `headers()` opts this subtree into dynamic rendering so the injected value
+ * reflects the runtime env, not a build-time snapshot. (This app is auth-heavy /
+ * already dynamic; if a page needs static generation, inject via a route handler
+ * fetched on the client instead.)
+ */
+export async function CommercialRuntimeProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  await headers();
+  const apiOrigin =
+    process.env.APP_API_ORIGIN || process.env.NEXT_PUBLIC_API_URL || '';
+  const runtime = { apiOrigin };
+  return (
+    <>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `window.__ENV = ${JSON.stringify(runtime).replace(/</g, '\\u003c')};`,
+        }}
+      />
+      {children}
+    </>
+  );
 }


### PR DESCRIPTION
## What
`NEXT_PUBLIC_API_URL` is build-time inlined by Next into BOTH client and server bundles, so the API origin froze into the image and couldn't be overridden at runtime (verified: the built server chunk emitted `apiOrigin:"http://localhost:3110"` as a literal). Switch to a prefix-less `APP_API_ORIGIN` that the server reads at runtime and ships to the browser via `window.__ENV`.

## Changes
- `lib/commercial/runtime.tsx`: `CommercialRuntimeProvider` (server component, dynamic via `headers()`) reads `process.env.APP_API_ORIGIN` and injects `window.__ENV`.
- `lib/api/routes.ts`: `API_ORIGIN` resolved at runtime — `window.__ENV` (client) / `process.env.APP_API_ORIGIN` (server) / `NEXT_PUBLIC_API_URL` build fallback.

## Verified
`build` passes; the rebuilt server chunk now emits `apiOrigin` as a runtime expression (`process.env.APP_API_ORIGIN || …`), not a build-inlined literal.

## Deploy note
Server `.env` for the commercial-web stack must set **`APP_API_ORIGIN`** (prefix-less — `NEXT_PUBLIC_*` cannot be overridden at runtime).

Paired PRs: Magic-Core #52, Magic-Deploy-Config #2, Magic-Resume-Admin #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)