### PR TITLE
fix(web): unbreak master docker build & Vercel build (2 fixes)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -6,7 +6,6 @@ RUN corepack enable
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json .npmrc ./
 COPY patches ./patches
-COPY apps/docs/package.json apps/docs/package.json
 COPY apps/web/package.json apps/web/package.json
 COPY packages/env/package.json packages/env/package.json
 COPY packages/mcp/package.json packages/mcp/package.json

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "installCommand": "cd ../.. && pnpm install",
+  "installCommand": "cd ../.. && corepack enable && pnpm install",
   "buildCommand": "cd ../.. && pnpm turbo build --filter=@magic-resume/web",
   "outputDirectory": ".next"
 }


### PR DESCRIPTION
Two build fixes for master, both surfaced after today's release landed.

## 1. Docker: drop stale `apps/docs` COPY
`Build and Push Docker Image` fails on master with `"/apps/docs/package.json": not found`. The Mintlify docs migration removed `apps/docs/package.json` (apps/docs is now README + content, no longer a pnpm package), but `apps/web/Dockerfile` still COPYs it. → drop that line.

## 2. Vercel: enable corepack so it uses pnpm@10.28.1
Vercel deploys (`magic-resume`, `magic-resume-web`) fail with `ERR_PNPM_UNSUPPORTED_ENGINE … Got: 6.35.1`. Vercel doesn't activate corepack by default, so it ignored the `packageManager` field and fell back to corepack's pinned default pnpm 6.35.1 — failing `engine-strict` (project requires pnpm >=10.28.1). → add `corepack enable` to `apps/web/vercel.json`'s installCommand so pnpm resolves from the packageManager field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)