### PR TITLE
:bug: fix(web): 商业化镜像 window.__ENV 未注入 → 客户端 fallback 到 localhost

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -21,6 +21,7 @@ import StructuredData from "@/components/shared/StructuredData";
 import I18nProvider from "@/components/providers/I18nProvider";
 import { HttpClientProvider } from "@/components/providers/HttpClientProvider";
 import { CommercialRuntimeProvider } from "@/lib/commercial/runtime";
+import { RuntimeEnvScript } from "@/lib/commercial/runtime-env";
 import { CloudAuthBridge } from "@/lib/auth";
 
 export const metadata: Metadata = {
@@ -55,6 +56,10 @@ export default function RootLayout({
               />
             </head>
             <body className={`font-sans ${brandFont.variable}`}>
+              {/* Runtime API origin → window.__ENV, injected before any client
+                  bundle reads it. Kept OUT of CommercialRuntimeProvider because
+                  the commercial overlay replaces that module — see runtime-env.tsx. */}
+              <RuntimeEnvScript />
               <CommercialRuntimeProvider>
                 <I18nProvider>
                   <ThemeProvider>

--- a/apps/web/src/lib/api/routes.ts
+++ b/apps/web/src/lib/api/routes.ts
@@ -1,7 +1,7 @@
 /**
  * The single API origin — the whole frontend talks to ONE configured address.
  * Resolved at RUNTIME so one build can target any backend:
- *   - browser → `window.__ENV.apiOrigin`, injected by CommercialRuntimeProvider
+ *   - browser → `window.__ENV.apiOrigin`, injected by RuntimeEnvScript (layout)
  *   - server  → `process.env.APP_API_ORIGIN` (container env, read per request)
  *   - fallback → build-time `NEXT_PUBLIC_API_URL` / dev default
  * The runtime var is deliberately WITHOUT the `NEXT_PUBLIC_` prefix: Next inlines

--- a/apps/web/src/lib/commercial/runtime-env.tsx
+++ b/apps/web/src/lib/commercial/runtime-env.tsx
@@ -1,0 +1,38 @@
+import { headers } from 'next/headers';
+
+/**
+ * Runtime env → browser. Reads the API origin from the container env at REQUEST
+ * time and hands it to the client via `window.__ENV` (consumed lazily by
+ * lib/api/routes.ts). The var is deliberately WITHOUT the `NEXT_PUBLIC_` prefix:
+ * Next inlines `NEXT_PUBLIC_*` at build time into both client AND server bundles,
+ * which would freeze the address into the image; a prefix-less var is read from
+ * the container env at runtime, so one image targets any backend via docker
+ * compose `environment:`.
+ *
+ * `headers()` opts this subtree into dynamic rendering so the injected value
+ * reflects the runtime env, not a build-time snapshot. (This app is auth-heavy /
+ * already dynamic; if a page needs static generation, inject via a route handler
+ * fetched on the client instead.)
+ *
+ * WHY THIS LIVES IN ITS OWN MODULE (not in ./runtime): the commercial build
+ * overlays `@/lib/commercial/runtime` with an analytics-only provider
+ * (Magic-Resume-Commercial `next-config-overlay.mjs` webpack alias). If the
+ * `window.__ENV` injection lived there, the overlay would strip it and the
+ * commercial image would fall back to the localhost default. This module is NOT
+ * in the overlay's alias list, so the injection survives in both builds. Keep it
+ * that way — do not fold it back into ./runtime, and do not add it to the
+ * overlay alias.
+ */
+export async function RuntimeEnvScript() {
+  await headers();
+  const apiOrigin =
+    process.env.APP_API_ORIGIN || process.env.NEXT_PUBLIC_API_URL || '';
+  const runtime = { apiOrigin };
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `window.__ENV = ${JSON.stringify(runtime).replace(/</g, '\\u003c')};`,
+      }}
+    />
+  );
+}

--- a/apps/web/src/lib/commercial/runtime.tsx
+++ b/apps/web/src/lib/commercial/runtime.tsx
@@ -1,37 +1,20 @@
 import type { ReactNode } from 'react';
-import { headers } from 'next/headers';
 
 /**
- * Runtime env → browser. Reads the API origin from the container env at REQUEST
- * time and hands it to the client via `window.__ENV` (consumed lazily by
- * lib/api/routes.ts). The var is deliberately WITHOUT the `NEXT_PUBLIC_` prefix:
- * Next inlines `NEXT_PUBLIC_*` at build time into both client AND server bundles,
- * which would freeze the address into the image; a prefix-less var is read from
- * the container env at runtime, so one image targets any backend via docker
- * compose `environment:`.
+ * Commercial runtime slot. In the open-source build this is a no-op passthrough.
+ * The commercial build overlays this module (Magic-Resume-Commercial
+ * `next-config-overlay.mjs` aliases `@/lib/commercial/runtime` → the analytics
+ * runtime provider), so the alias target owns analytics init + SPA page-view
+ * tracking.
  *
- * `headers()` opts this subtree into dynamic rendering so the injected value
- * reflects the runtime env, not a build-time snapshot. (This app is auth-heavy /
- * already dynamic; if a page needs static generation, inject via a route handler
- * fetched on the client instead.)
+ * NOTE: the `window.__ENV` runtime-env injection deliberately lives in the
+ * sibling `./runtime-env` module (NOT here) because the overlay replaces this
+ * one — see runtime-env.tsx for the full rationale.
  */
-export async function CommercialRuntimeProvider({
+export function CommercialRuntimeProvider({
   children,
 }: {
   children: ReactNode;
 }) {
-  await headers();
-  const apiOrigin =
-    process.env.APP_API_ORIGIN || process.env.NEXT_PUBLIC_API_URL || '';
-  const runtime = { apiOrigin };
-  return (
-    <>
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `window.__ENV = ${JSON.stringify(runtime).replace(/</g, '\\u003c')};`,
-        }}
-      />
-      {children}
-    </>
-  );
+  return <>{children}</>;
 }


### PR DESCRIPTION
## 问题
商业化镜像里，客户端请求全打到 `http://localhost:3110` —— 因为 `window.__ENV.apiOrigin` 从没被注入到 SSR HTML。SSR/API routes 读 `APP_API_ORIGIN` 正常，只有浏览器侧拿不到。

## 验证
- `next build` 通过（pre-commit hook 全量构建 7 tasks 绿）、eslint + `tsc --noEmit` 干净。
- **合并后需重建商业化镜像**（它拿 OSS 源码 + overlay 构建）。