### PR TITLE
:sparkles: feat(web): default system theme + credit-free monthly quota UI

### DIFF
--- a/apps/web/src/app/dashboard/edit/_components/ai/AiChatShell.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ai/AiChatShell.tsx
@@ -1492,17 +1492,12 @@ function HeaderQuota() {
     d
       ? new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }).format(new Date(d))
       : '';
-  const remainingText = (used: number, limit: number) =>
-    !limit || limit <= 0
-      ? t('account.subscription.unlimited')
-      : t('account.subscription.remaining', { count: Math.max(0, limit - used) });
-
-  const rows = data
-    ? [
-        { label: t('account.subscription.today'), used: data.usage.dailyUsed, limit: data.usage.dailyLimit, resetAt: data.usage.dailyResetAt },
-        { label: t('account.subscription.week'), used: data.usage.weeklyUsed, limit: data.usage.weeklyLimit, resetAt: data.usage.weeklyResetAt },
-      ]
-    : [];
+  // Monthly allowance remaining as a single percentage from the API. Credits are
+  // our internal billing unit, so the client never receives raw balances — only
+  // this percentage. null = unlimited (no credit cap).
+  const credit = data
+    ? { percent: data.remainingPercent, resetAt: data.resetAt ?? null }
+    : null;
 
   return (
     <div className="relative">
@@ -1547,31 +1542,27 @@ function HeaderQuota() {
                       {data.currentPlan?.name ?? '—'}
                     </span>
                   </div>
-                  <div className="mt-3 space-y-3">
-                    {rows.map((row) => {
-                      const unlimited = !row.limit || row.limit <= 0;
-                      const pct = unlimited ? 100 : Math.min(100, Math.round((row.used / row.limit) * 100));
-                      return (
-                        <div key={row.label}>
-                          <div className="flex items-center justify-between gap-3 text-[11px]">
-                            <span className="text-neutral-400">{row.label}</span>
-                            <span className="tabular-nums text-neutral-300">{remainingText(row.used, row.limit)}</span>
-                          </div>
-                          <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-white/[0.06]">
-                            <div
-                              className={cn('h-full rounded-full bg-gradient-to-r from-sky-500 to-sky-400', unlimited && 'opacity-60')}
-                              style={{ width: `${pct}%` }}
-                            />
-                          </div>
-                          {row.resetAt && (
-                            <div className="mt-1 text-[10px] text-neutral-600">
-                              {t('account.subscription.resetAt', { time: fmtReset(row.resetAt) })}
-                            </div>
-                          )}
+                  {credit && (
+                    <div className="mt-3">
+                      <div className="flex items-center justify-between gap-3 text-[11px]">
+                        <span className="text-neutral-400">{t('account.subscription.monthly')}</span>
+                        <span className="tabular-nums text-neutral-300">
+                          {credit.percent === null ? t('account.subscription.unlimited') : `${credit.percent}%`}
+                        </span>
+                      </div>
+                      <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-white/[0.06]">
+                        <div
+                          className={cn('h-full rounded-full bg-gradient-to-r from-sky-500 to-sky-400', credit.percent === null && 'opacity-60')}
+                          style={{ width: `${credit.percent === null ? 100 : Math.max(0, Math.min(100, credit.percent))}%` }}
+                        />
+                      </div>
+                      {credit.resetAt && (
+                        <div className="mt-1 text-[10px] text-neutral-600">
+                          {t('account.subscription.resetAt', { time: fmtReset(credit.resetAt) })}
                         </div>
-                      );
-                    })}
-                  </div>
+                      )}
+                    </div>
+                  )}
                 </>
               )}
             </motion.div>

--- a/apps/web/src/components/providers/ThemeProvider.tsx
+++ b/apps/web/src/components/providers/ThemeProvider.tsx
@@ -23,7 +23,10 @@ export type ThemePreference = "light" | "dark" | "system";
 export type ResolvedTheme = "light" | "dark";
 
 export const THEME_STORAGE_KEY = "mr-theme";
-const DEFAULT_PREFERENCE: ThemePreference = "dark";
+// New users default to following the OS appearance; an explicit choice (stored
+// under THEME_STORAGE_KEY) always wins. The anti-FOUC init script + the effect
+// below resolve "system" to the OS preference before first paint.
+const DEFAULT_PREFERENCE: ThemePreference = "system";
 
 interface ThemeContextValue {
   /** 用户的选择(可为 system) */

--- a/apps/web/src/lib/auth/AccountModal.tsx
+++ b/apps/web/src/lib/auth/AccountModal.tsx
@@ -442,14 +442,8 @@ function SideCopy({
 
 type TFn = (k: string, o?: Record<string, unknown>) => string;
 
-function remainingLabel(used: number, limit: number, t: TFn) {
-  if (!limit || limit <= 0) return t('account.subscription.unlimited');
-  return t('account.subscription.remaining', { count: Math.max(0, limit - used) });
-}
-
-function MiniBar({ used, limit }: { used: number; limit: number }) {
-  const unlimited = !limit || limit <= 0;
-  const pct = unlimited ? 100 : Math.min(100, Math.round((used / limit) * 100));
+function MiniBar({ percent, unlimited }: { percent: number; unlimited?: boolean }) {
+  const pct = Math.max(0, Math.min(100, percent));
   return (
     <div className="h-1.5 min-w-0 flex-1 overflow-hidden rounded-full bg-white/[0.06]">
       <div
@@ -474,13 +468,11 @@ function UsageCluster({
   fmtDateTime: (d?: Date | number | string | null) => string;
   t: TFn;
 }) {
-  const { usage, currentPlan } = entitlement;
-  const rows = [
-    { label: t('account.subscription.today'), used: usage.dailyUsed, limit: usage.dailyLimit, resetAt: usage.dailyResetAt },
-    { label: t('account.subscription.week'), used: usage.weeklyUsed, limit: usage.weeklyLimit, resetAt: usage.weeklyResetAt },
-  ];
+  const { remainingPercent, resetAt, currentPlan } = entitlement;
+  const unlimited = remainingPercent === null;
   // Horizontal, header-height layout — the card must stay roughly as tall as the
   // avatar block or the whole header inflates and the left side looks stranded.
+  // Credits are internal, so we show only the monthly allowance remaining (%).
   return (
     <button
       type="button"
@@ -495,18 +487,20 @@ function UsageCluster({
         </span>
       </div>
       <div className="w-px self-stretch bg-white/[0.08]" />
-      <div className="w-48 space-y-2">
-        {rows.map((row) => (
-          <div
-            key={row.label}
-            className="flex items-center gap-2 text-[11px]"
-            title={row.resetAt ? t('account.subscription.resetAt', { time: fmtDateTime(row.resetAt) }) : undefined}
-          >
-            <span className="shrink-0 text-neutral-400">{row.label}</span>
-            <MiniBar used={row.used} limit={row.limit} />
-            <span className="shrink-0 tabular-nums text-neutral-300">{remainingLabel(row.used, row.limit, t)}</span>
-          </div>
-        ))}
+      {/* Stacked to mirror the plan column: label ("本月额度") on the top row —
+          level with "当前计划" — and the bar + % on the second row, level with
+          the plan badge. */}
+      <div
+        className="flex w-48 flex-col gap-1"
+        title={resetAt ? t('account.subscription.resetAt', { time: fmtDateTime(resetAt) }) : undefined}
+      >
+        <span className="whitespace-nowrap text-[11px] text-neutral-500">{t('account.subscription.monthly')}</span>
+        <div className="flex h-5 items-center gap-2 text-[11px]">
+          <MiniBar percent={unlimited ? 100 : (remainingPercent ?? 0)} unlimited={unlimited} />
+          <span className="shrink-0 tabular-nums text-neutral-300">
+            {unlimited ? t('account.subscription.unlimited') : `${remainingPercent}%`}
+          </span>
+        </div>
       </div>
     </button>
   );

--- a/apps/web/src/lib/billing/types.ts
+++ b/apps/web/src/lib/billing/types.ts
@@ -8,12 +8,13 @@ export interface PlanSummary {
   kind: PlanKind;
   priceCents: number;
   currency: string;
-  includedCredits: string;
   modelAllowlist: string[];
   dailyLimit: number;
   weeklyLimit: number;
   interval?: string | null;
   isDefault: boolean;
+  // `includedCredits` intentionally omitted: credits are the internal billing
+  // unit and are never sent to the client — the API exposes only a percentage.
 }
 
 export interface SubscriptionSummary {
@@ -34,19 +35,24 @@ export interface UsageSummary {
   weeklyResetAt: string;
 }
 
-/** Response of GET /api/billing/ai-entitlement (usage + plan + subscription). */
+/**
+ * Response of GET /api/billing/ai-entitlement. Credit-free by design: the client
+ * only learns the plan type, whether internal AI is usable right now
+ * (`canUseInternal` + `reason`), and how much of the monthly allowance is left
+ * (`remainingPercent`). Raw credit balances/caps and day/week counts never leave
+ * the server (credits are our internal billing unit).
+ */
 export interface Entitlement {
   mode: 'internal' | 'byok_required';
+  /** Whether internal AI can be used right now (credits + day/week caps). */
   canUseInternal: boolean;
   reason?: string | null;
-  balanceCredits: string;
-  currency: string;
-  checkedAt: string;
+  /** 计划类型 — no credit fields. */
   currentPlan: PlanSummary | null;
-  subscription: SubscriptionSummary | null;
-  usage: UsageSummary;
-  overDailyLimit: boolean;
-  overWeeklyLimit: boolean;
+  /** 还剩百分之多少 (0-100) of the monthly allowance; null = unlimited. */
+  remainingPercent: number | null;
+  /** When the monthly allowance refreshes (ISO). */
+  resetAt?: string | null;
   /** Supported models the composer can offer for internal runs (allowlist-filtered). */
   availableModels?: string[];
 }

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -80,6 +80,7 @@
     },
     "subscription": {
       "currentPlan": "Current plan",
+      "monthly": "This month",
       "today": "Today",
       "week": "This week",
       "usage": "Usage this period",
@@ -152,7 +153,7 @@
       "general": {
         "description": "Preferences stay quiet and focused on choices that affect everyday editing.",
         "appearance": "Appearance",
-        "appearanceDescription": "Dark is the default workbench for long editing sessions. Switch to light, or follow your system.",
+        "appearanceDescription": "Follows your system appearance by default. Pin it to dark (easier on the eyes for long editing sessions) or light.",
         "appearanceDark": "Dark",
         "appearanceLight": "Light",
         "appearanceSystem": "System",

--- a/apps/web/src/locales/zh/translation.json
+++ b/apps/web/src/locales/zh/translation.json
@@ -80,6 +80,7 @@
     },
     "subscription": {
       "currentPlan": "当前计划",
+      "monthly": "本月额度",
       "today": "今日",
       "week": "本周",
       "usage": "本期用量",
@@ -152,7 +153,7 @@
       "general": {
         "description": "偏好设置保持克制，只保留会影响日常创作的选项。",
         "appearance": "外观",
-        "appearanceDescription": "深色是长时段编辑的默认工作台。可切换为浅色，或跟随系统。",
+        "appearanceDescription": "默认跟随系统外观。也可固定为深色（长时段编辑更护眼）或浅色。",
         "appearanceDark": "深色",
         "appearanceLight": "浅色",
         "appearanceSystem": "跟随系统",


### PR DESCRIPTION
## Appearance
- Default appearance is now **follow system** (was dark). An explicit choice still wins (stored under `mr-theme`); the anti-FOUC init script + effect resolve `system` before first paint. Updated the settings description (zh/en).

## Quota UI — credits are internal
- The quota popover (AI header) and the account panel now show a single **本月额度 {percent}%** progress bar, from the API's `remainingPercent`, instead of raw credit numbers. Today/week rows removed (they read `无限制` on credit plans).
- `Entitlement` / `PlanSummary` types trimmed to the credit-free API shape (`remainingPercent` + `resetAt`; no `balanceCredits`/`includedCredits`/`usage`).

Pairs with the backend credit-privacy change in Magic-Core PR #55 (`/billing/ai-entitlement` etc. no longer return raw credits).

**Verification:** `turbo lint` + `next build` green (ran via pre-commit); web tsc 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165uGjmCxPNspoeq7tiDkKR