### PR TITLE
:memo: docs(changelog): sync v2.2.1 + v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Magic Resume are documented in this file.
 
+# [v2.3.0](https://github.com/Magic-Resume/Magic-Resume/compare/v2.2.1...v2.3.0) (2026-07-23)
+
+## ✨ New Features
+- [`ce42675`](https://github.com/Magic-Resume/Magic-Resume/commit/ce42675)  feat(web): default system theme + credit-free monthly quota UI (#149) (Issues: [`#149`](https://github.com/Magic-Resume/Magic-Resume/issues/149))
+
 # [v2.2.0](https://github.com/Magic-Resume/Magic-Resume/compare/v2.1.1...v2.2.0) (2026-07-13)
 
 ## ✨ New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to Magic Resume are documented in this file.
 ## ✨ New Features
 - [`ce42675`](https://github.com/Magic-Resume/Magic-Resume/commit/ce42675)  feat(web): default system theme + credit-free monthly quota UI (#149) (Issues: [`#149`](https://github.com/Magic-Resume/Magic-Resume/issues/149))
 
+# [v2.2.1](https://github.com/Magic-Resume/Magic-Resume/compare/v2.2.0...v2.2.1) (2026-07-23)
+
+## 🐛 Bug Fixes
+- [`52b6533`](https://github.com/Magic-Resume/Magic-Resume/commit/52b6533)  fix(web): move window.__ENV injection out of the commercial-overlaid runtime module (#147) (Issues: [`#147`](https://github.com/Magic-Resume/Magic-Resume/issues/147))
+
 # [v2.2.0](https://github.com/Magic-Resume/Magic-Resume/compare/v2.1.1...v2.2.0) (2026-07-13)
 
 ## ✨ New Features


### PR DESCRIPTION
Backfills the in-repo `CHANGELOG.md` for the two releases whose auto-PR never opened (the org-level "Actions may create PRs" toggle was off; now enabled, so future releases self-open this):

- **v2.3.0** — feat(web): default system theme + credit-free monthly quota UI (#149)
- **v2.2.1** — fix(web): move window.__ENV injection out of the commercial-overlaid runtime module (#147)

Entries are ordered newest-first above v2.2.0. This PR is `:memo: docs`, so it does not trigger another release.