### PR TITLE
release-2026-07-29 → master：给转化链路上的页面打标记

### DIFF
--- a/apps/landing/src/components/sections/CallToAction.astro
+++ b/apps/landing/src/components/sections/CallToAction.astro
@@ -1,6 +1,6 @@
 ---
 import type { Copy } from '@/i18n/ui';
-import { APP_LINKS } from '@/consts';
+import { dashboardLink } from '@/consts';
 import Icon from '@/components/Icon.astro';
 
 interface Props {
@@ -25,7 +25,7 @@ const c = copy.cta;
     </p>
     <div class="mt-9 flex flex-col items-center gap-4">
       <a
-        href={APP_LINKS.dashboard}
+        href={dashboardLink('cta_section')}
         class="group flex items-center gap-2 rounded-lg bg-ink px-7 py-3 text-[15px] font-semibold text-workbench transition-opacity hover:opacity-85"
       >
         {c.button}

--- a/apps/landing/src/components/sections/Footer.astro
+++ b/apps/landing/src/components/sections/Footer.astro
@@ -1,6 +1,6 @@
 ---
 import type { Copy } from '@/i18n/ui';
-import { APP_LINKS, GITHUB } from '@/consts';
+import { dashboardLink, GITHUB } from '@/consts';
 import { interpolate } from '@/i18n/ui';
 
 interface Props {
@@ -34,7 +34,7 @@ const year = new Date().getFullYear();
       <div class="grid grid-cols-2 gap-12 sm:gap-16">
         <div class="flex flex-col gap-3">
           <h3 class="text-[13px] font-semibold text-ink">{f.product}</h3>
-          <a class="text-[13px] text-faint transition-colors hover:text-ink" href={APP_LINKS.dashboard}>
+          <a class="text-[13px] text-faint transition-colors hover:text-ink" href={dashboardLink('footer')}>
             {f.builder}
           </a>
         </div>

--- a/apps/landing/src/components/sections/Header.astro
+++ b/apps/landing/src/components/sections/Header.astro
@@ -1,6 +1,6 @@
 ---
 import type { Copy } from '@/i18n/ui';
-import { APP_LINKS, GITHUB } from '@/consts';
+import { dashboardLink, GITHUB } from '@/consts';
 import { formatStars } from '@/lib/github';
 import Icon from '@/components/Icon.astro';
 import LangSwitcher from '@/components/LangSwitcher.astro';
@@ -54,7 +54,7 @@ const nav = copy.nav;
       </a>
       <LangSwitcher />
       <a
-        href={APP_LINKS.dashboard}
+        href={dashboardLink('header')}
         class="flex items-center gap-1 rounded-md bg-ink px-3 py-1.5 text-[13px] font-semibold text-workbench transition-opacity hover:opacity-85"
       >
         {nav.goToApp}

--- a/apps/landing/src/components/sections/Hero.astro
+++ b/apps/landing/src/components/sections/Hero.astro
@@ -1,6 +1,6 @@
 ---
 import type { Copy, Locale } from '@/i18n/ui';
-import { APP_LINKS, GITHUB } from '@/consts';
+import { dashboardLink, GITHUB } from '@/consts';
 import Icon from '@/components/Icon.astro';
 import EditorMockup from '@/components/islands/EditorMockup';
 
@@ -39,7 +39,7 @@ const post = idx >= 0 ? h.title.slice(idx + h.titleAccent.length) : '';
 
       <div class="reveal mt-8 flex flex-wrap items-center justify-center gap-3" style="--reveal-delay:3">
         <a
-          href={APP_LINKS.dashboard}
+          href={dashboardLink('hero')}
           class="group flex items-center gap-2 rounded-lg bg-ink px-5 py-2.5 text-[14px] font-semibold text-workbench transition-opacity hover:opacity-85"
         >
           {h.ctaPrimary}

--- a/apps/landing/src/consts.ts
+++ b/apps/landing/src/consts.ts
@@ -12,6 +12,31 @@ export const APP_LINKS = {
   dashboard: `${WEB_ORIGIN}/dashboard`,
 } as const;
 
+/** Where on the page a visitor started their way into the app. */
+export type CtaPlacement = 'header' | 'hero' | 'cta_section' | 'footer';
+
+/**
+ * A link into the app that says where it was clicked.
+ *
+ * The landing site is a static Astro build with no analytics of its own, so a
+ * click here is invisible until the visitor arrives on the other side. Carrying
+ * the origin in the query string is what lets the app attribute a sign-up to
+ * this page — and to which button on it — without the public marketing site
+ * having to load an SDK.
+ *
+ * Only reachable clicks are covered: a visitor who leaves for GitHub, or who
+ * never finishes loading the app, is not counted. That is the tradeoff of doing
+ * this from the destination rather than the source.
+ */
+export function dashboardLink(placement: CtaPlacement): string {
+  const params = new URLSearchParams({
+    utm_source: 'landing',
+    utm_medium: 'cta',
+    utm_content: placement,
+  });
+  return `${APP_LINKS.dashboard}?${params.toString()}`;
+}
+
 export const GITHUB = {
   repo: 'https://github.com/LinMoQC/Magic-Resume',
   issues: 'https://github.com/LinMoQC/Magic-Resume/issues',

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,41 @@
+import path from "node:path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  // Magic-Resume commercial overlay alias. Roots are provided only by private commercial builds.
+  webpack: (config, { webpack }) => {
+    const runtimeRoot = process.env.MAGIC_RESUME_COMMERCIAL_RUNTIME_ROOT;
+    const billingRoot = process.env.MAGIC_RESUME_COMMERCIAL_BILLING_ROOT;
+    if (!runtimeRoot && !billingRoot) return config;
+
+    const slots: Record<string, string> = {};
+    if (runtimeRoot) {
+      slots['@/lib/commercial/runtime'] = path.join(runtimeRoot, 'src/runtime.tsx');
+      slots['@/lib/extensions/app-lifecycle'] = path.join(runtimeRoot, 'src/app-lifecycle.ts');
+    }
+    if (billingRoot) {
+      slots['@/lib/extensions/billing-client'] = path.join(billingRoot, 'src/billing-client.ts');
+      slots['@/lib/extensions/billing-ui'] = path.join(billingRoot, 'src/billing-ui.tsx');
+      slots['@/lib/extensions/billing-proxy'] = path.join(billingRoot, 'src/billing-proxy.ts');
+    }
+
+    // Replacement at the module-factory stage, not `resolve.alias`. These
+    // requests start with `@/`, which tsconfig `paths` already claims, and
+    // Next's JsConfigPathsPlugin resolves it during `described-resolve` —
+    // before AliasPlugin ever runs. An alias keyed on `@/lib/...` is therefore
+    // dead code: it never matches, and the slot silently stays on its
+    // open-source stub.
+    config.plugins.push(
+      new webpack.NormalModuleReplacementPlugin(
+        /^@\/lib\/(commercial\/runtime|extensions\/(app-lifecycle|billing-client|billing-ui|billing-proxy))$/,
+        (resource: { request: string }) => {
+          const target = slots[resource.request];
+          if (target) resource.request = target;
+        }
+      )
+    );
+    return config;
+  },
   output: "standalone",
   transpilePackages: ['@magic-resume/resume-templates'],
   

--- a/apps/web/src/app/dashboard/_components/ImportResumeDialog.tsx
+++ b/apps/web/src/app/dashboard/_components/ImportResumeDialog.tsx
@@ -243,6 +243,7 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
               animate={{ opacity: 1, scale: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.95, y: 20 }}
               className="w-full max-w-lg bg-raised border border-neutral-800 rounded-3xl shadow-2xl p-8 pointer-events-auto"
+              data-magic-import-panel
             >
               {/* Header */}
               <div className="flex items-center justify-between mb-2">

--- a/apps/web/src/app/dashboard/_components/NewResumeDialog.tsx
+++ b/apps/web/src/app/dashboard/_components/NewResumeDialog.tsx
@@ -32,6 +32,7 @@ export default function NewResumeDialog({ open, onOpenChange, newName, setNewNam
               animate={{ opacity: 1, scale: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.95, y: 20 }}
               className="w-full max-w-md bg-raised border border-neutral-800 rounded-3xl shadow-2xl p-8 pointer-events-auto"
+              data-magic-new-resume-panel
             >
               <div className="flex items-center justify-between mb-4">
                 <h2 className="text-xl font-bold text-white">{t('newResumeDialog.title')}</h2>

--- a/apps/web/src/app/dashboard/_components/ResumeList.tsx
+++ b/apps/web/src/app/dashboard/_components/ResumeList.tsx
@@ -121,6 +121,7 @@ function CreatePanel({ onClick }: { onClick: () => void }) {
   return (
     <motion.button
       type="button"
+      data-magic-dashboard-create
       onClick={onClick}
       whileHover={{ y: -2 }}
       whileTap={{ scale: 0.99 }}
@@ -157,6 +158,7 @@ function ImportPanel({ onClick }: { onClick: () => void }) {
   return (
     <motion.button
       type="button"
+      data-magic-dashboard-import
       onClick={onClick}
       whileHover={{ y: -2 }}
       whileTap={{ scale: 0.99 }}
@@ -228,7 +230,7 @@ const ResumeCard = React.memo(
           // Which resume a click inside this card refers to. Anything reported
           // from within picks these up, so individual controls don't each have
           // to carry them. Ids only — the collector drops anything else.
-          data-track-context={JSON.stringify({
+          data-magic-context={JSON.stringify({
             resumeId: resume.id,
             templateId: resume.template,
           })}

--- a/apps/web/src/app/dashboard/edit/[id]/@modal/(.)json/page.tsx
+++ b/apps/web/src/app/dashboard/edit/[id]/@modal/(.)json/page.tsx
@@ -5,7 +5,6 @@ import JsonModal from '@/app/dashboard/edit/_components/modals/JsonModal';
 import { useInterceptModalRoute } from '@/hooks/useInterceptModalRoute';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { appLifecycle } from '@/lib/extensions/app-lifecycle';
 
 export default function JsonModalPage() {
   const { open, close } = useInterceptModalRoute();
@@ -13,9 +12,6 @@ export default function JsonModalPage() {
   const { t } = useTranslation();
 
   const handleDownloadJson = () => {
-    if (activeResume) {
-      appLifecycle.resumeJsonDownloaded({ source: 'json_modal' });
-    }
     if (!activeResume) return;
     const sanitized = getSanitizedResume(activeResume);
     const jsonString = JSON.stringify(sanitized, null, 2);

--- a/apps/web/src/app/dashboard/edit/[id]/json/page.tsx
+++ b/apps/web/src/app/dashboard/edit/[id]/json/page.tsx
@@ -5,7 +5,6 @@ import { useResumeStore, getSanitizedResume } from '@/store/useResumeStore';
 import JsonModal from '@/app/dashboard/edit/_components/modals/JsonModal';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
-import { appLifecycle } from '@/lib/extensions/app-lifecycle';
 import { useEffect } from 'react';
 
 export default function JsonModalPage() {
@@ -25,9 +24,6 @@ export default function JsonModalPage() {
   const handleClose = () => router.push(`/dashboard/edit/${id}`);
 
   const handleDownloadJson = () => {
-    if (activeResume) {
-      appLifecycle.resumeJsonDownloaded({ source: 'json_page' });
-    }
     if (!activeResume) return;
     const sanitized = getSanitizedResume(activeResume);
     const jsonString = JSON.stringify(sanitized, null, 2);

--- a/apps/web/src/app/dashboard/edit/_components/ResumeEdit.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ResumeEdit.tsx
@@ -143,9 +143,6 @@ export default function ResumeEdit({ id }: ResumeEditProps) {
   );
 
   const handleDownloadJson = () => {
-    if (activeResume) {
-      appLifecycle.resumeJsonDownloaded({ source: 'editor' });
-    }
     if (!activeResume) return;
     const sanitized = getSanitizedResume(activeResume);
     const jsonString = JSON.stringify(sanitized, null, 2);
@@ -217,12 +214,6 @@ export default function ResumeEdit({ id }: ResumeEditProps) {
   }, [id, loadResumeForEdit, isStoreLoading, resumes, router]); // resumes 依然保留，但靠内部 activeResume?.id === id 熔断
 
   // 编辑器查看生命周期
-  useEffect(() => {
-    if (activeResume && !isStoreLoading) {
-      appLifecycle.editorViewed({ templateId: activeResume.template });
-    }
-  }, [activeResume?.id, activeResume?.template, isStoreLoading]); // eslint-disable-line react-hooks/exhaustive-deps
-
   // 同步activeResume的template到currentTemplateId
   useEffect(() => {
     if (activeResume?.template && activeResume.template !== currentTemplateId) {
@@ -521,10 +512,11 @@ export default function ResumeEdit({ id }: ResumeEditProps) {
   return (
     <>
       <main
+        data-magic-editor-canvas
         // Which resume is being edited. Everything reported from inside the
         // editor — including the AI panel and the share dialog — picks this up
         // without each control carrying it. Ids only; other keys are dropped.
-        data-track-context={JSON.stringify({
+        data-magic-context={JSON.stringify({
           resumeId: activeResume.id,
           templateId: currentTemplateId,
         })}

--- a/apps/web/src/app/dashboard/edit/_components/ai/AiChatShell.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ai/AiChatShell.tsx
@@ -58,7 +58,7 @@ const CLOSED_CANVAS: CanvasState = { open: false, skillId: null, view: 'preview'
  * this is the only place a start is announced.
  */
 function reportSkillStarted(id: SkillId) {
-  if (id === 'optimize') appLifecycle.aiOptimizationStarted(false);
+  if (id === 'optimize') appLifecycle.aiOptimizationStarted();
   else if (id === 'analyze') appLifecycle.aiAnalysisStarted();
   else if (id === 'create') appLifecycle.aiCreateStarted();
   else if (id === 'interview') appLifecycle.aiInterviewStarted();

--- a/apps/web/src/app/dashboard/edit/_components/ai/conversation/Composer.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ai/conversation/Composer.tsx
@@ -193,8 +193,10 @@ export default function Composer({
                     key={s.id}
                     type="button"
                     // Neutral marker: which catalog event this maps to is decided
-                    // in the tracking manifest, not here.
-                    data-track-id={`ai-skill-${s.id}`}
+                    // in the tracking manifest, not here. The attribute name is
+                    // the mark — spread because the skill id decides which one,
+                    // and the set is closed (five skills, five manifest entries).
+                    {...{ [`data-magic-ai-skill-${s.id}`]: '' }}
                     onMouseEnter={() => setHighlight(i)}
                     onClick={() => chooseSkill(s.id)}
                     className={cn(

--- a/apps/web/src/app/dashboard/edit/_components/mobile/MobileResumEdit.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/mobile/MobileResumEdit.tsx
@@ -138,6 +138,7 @@ export default function MobileResumEdit({
         >
             <div className="relative">
                 <button
+                    data-magic-json-download
                     onClick={handleCopyJson}
                     className="absolute top-3 right-3 p-2 text-gray-400 rounded-md hover:bg-neutral-700 hover:text-white transition-colors"
                     aria-label={t('mobileEdit.copyJson')}

--- a/apps/web/src/app/dashboard/edit/_components/modals/AIModal.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/modals/AIModal.tsx
@@ -55,6 +55,7 @@ export default function AIModal({
               animate={{ opacity: 1, scale: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.97, y: 12 }}
               className="w-full h-full max-w-[1500px] bg-desk border border-neutral-800 rounded-3xl shadow-[0_8px_28px_rgba(0,0,0,0.14)] overflow-hidden focus:outline-none pointer-events-auto"
+              data-magic-ai-lab
             >
               <AiChatShell
                 resumeData={resumeData}

--- a/apps/web/src/app/dashboard/edit/_components/modals/JsonModal.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/modals/JsonModal.tsx
@@ -48,6 +48,7 @@ export default function JsonModal({ isJsonModalOpen, closeJsonModal, handleDownl
                             </div>
                             <div className="flex items-center gap-1">
                                 <button
+                                    data-magic-json-download
                                     onClick={handleDownloadJson}
                                     className="flex h-8 items-center gap-1.5 rounded-lg px-2.5 text-[13px] text-neutral-400 hover:bg-white/5 hover:text-sky-300 transition-colors cursor-pointer"
                                     aria-label={t('common.ui.downloadJson')}

--- a/apps/web/src/app/dashboard/edit/_components/modals/ShareModal.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/modals/ShareModal.tsx
@@ -91,6 +91,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({ isOpen, onClose }) => {
               exit={{ opacity: 0, scale: 0.98, y: 12 }}
               transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
               className="w-full max-w-md rounded-2xl bg-desk p-6 shadow-[0_24px_70px_-20px_rgb(0_0_0/0.8)] ring-1 ring-white/[0.07] pointer-events-auto"
+              data-magic-share-panel
             >
             <div className="flex items-start justify-between mb-6">
               <div className="flex items-center gap-3">
@@ -198,7 +199,7 @@ export const ShareModal: React.FC<ShareModalProps> = ({ isOpen, onClose }) => {
                             />
                         </div>
                         <button
-                            data-track-id="share-link-copy"
+                            data-magic-share-link-copy
                             className="absolute right-1.5 top-1.5 flex h-8 w-8 items-center justify-center rounded-md text-neutral-400 hover:bg-white/5 hover:text-white transition-colors cursor-pointer"
                             onClick={copyToClipboard}
                         >

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -7,7 +7,6 @@ import { useResumeStore } from '@/store/useResumeStore';
 import { useSettingStore } from '@/store/useSettingStore';
 import ResumeList from './_components/ResumeList';
 import RenameResumeDialog from './_components/RenameResumeDialog';
-import { appLifecycle } from '@/lib/extensions/app-lifecycle';
 
 export default function Dashboard() {
   const router = useRouter();
@@ -29,8 +28,6 @@ export default function Dashboard() {
       try {
         setIsLoading(true);
         await Promise.all([loadResumes(), loadSettings()]);
-        const currentResumes = useResumeStore.getState().resumes;
-        appLifecycle.dashboardViewed({ resumeCount: currentResumes.length });
       } catch (error) {
         console.error('Failed to initialize dashboard:', error);
       } finally {
@@ -55,13 +52,14 @@ export default function Dashboard() {
     }
   }, [resumeToRename, newName, renameResume]);
 
+  // 这两个按钮不再手动上报：`data-magic-dashboard-create` /
+  // `data-magic-dashboard-import` 加上清单映射就是全部，事件名和要不要收都在
+  // 清单里改。它们是纯粹的点击意图，没有任何只有代码知道的东西要一起带走。
   const handleAdd = useCallback(() => {
-    appLifecycle.resumeCreateRequested();
     router.push('/dashboard/new');
   }, [router]);
 
   const handleImport = useCallback(() => {
-    appLifecycle.resumeImportRequested();
     router.push('/dashboard/import');
   }, [router]);
 
@@ -74,7 +72,7 @@ export default function Dashboard() {
   }, [duplicateResume]);
 
   return (
-    <main className="flex flex-col h-full">
+    <main className="flex flex-col h-full" data-magic-dashboard-list>
       <RenameResumeDialog
         open={renameDialogOpen}
         onOpenChange={setRenameDialogOpen}

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { AlertCircle, RotateCcw, Home } from 'lucide-react';
 import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
+import { appLifecycle } from '@/lib/extensions/app-lifecycle';
 
 export default function Error({
   error,
@@ -18,6 +19,16 @@ export default function Error({
   useEffect(() => {
     // Log the error to an error reporting service
     console.error('Global Error Boundary caught:', error);
+    // A render-time crash never reaches `window.onerror` — React catches it and
+    // hands it to this boundary instead. Without this call the most severe
+    // failure the app has (a blank screen) is the one failure it never reports.
+    appLifecycle.reactErrorCaught({
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+      digest: error.digest,
+      component: 'app',
+    });
   }, [error]);
 
   return (

--- a/apps/web/src/app/s/[shareId]/_components/SharedResumeClient.tsx
+++ b/apps/web/src/app/s/[shareId]/_components/SharedResumeClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useMemo, useEffect, useRef, useState } from 'react';
+import React, { useMemo, useEffect, useState } from 'react';
 import { Loader2, ZoomIn, ZoomOut, MessageSquare, RotateCcw, Eye, Wand2 } from 'lucide-react';
 import { AnimatePresence, motion } from "motion/react";
 import { useRouter } from 'next/navigation';
@@ -8,7 +8,6 @@ import { useTranslation } from 'react-i18next';
 
 import { FloatingDock } from "@/components/ui/floating-dock";
 import { useSharedResume } from '../_hooks/useSharedResume';
-import { appLifecycle } from '@/lib/extensions/app-lifecycle';
 import { SharedResumeHeader } from './SharedResumeHeader';
 import { CommentLayer } from './CommentLayer';
 import { ResumeTransformView } from './ResumeTransformView';
@@ -47,18 +46,6 @@ export default function SharedResumeClient() {
     currentUserId,
     isSaving
   } = useSharedResume();
-
-  // Reported once the shared resume actually resolved, not on mount: a dead or
-  // private link renders this same component, and counting those as views would
-  // overstate how often sharing works. Note this fires in the *visitor's*
-  // browser — usually a signed-out person who is not the owner — so it counts a
-  // different population than the owner-side sharing events.
-  const shareViewReported = useRef(false);
-  useEffect(() => {
-    if (loading || !resume || shareViewReported.current) return;
-    shareViewReported.current = true;
-    appLifecycle.sharedResumeViewed();
-  }, [loading, resume]);
 
   // Filter Toolbar Configuration based on permissions
   const dockItems = useMemo(() => [
@@ -207,7 +194,10 @@ export default function SharedResumeClient() {
 
         <SharedResumeHeader />
 
-        <div className="flex-1 flex overflow-hidden relative">
+        {/* The resume body a visitor came for. A dead or private link takes an
+            earlier return, so reaching here already means the share resolved —
+            and the exposure adds that it was on screen long enough to be read. */}
+        <div className="flex-1 flex overflow-hidden relative" data-magic-shared-resume>
             <ResumeTransformView
                 transformComponentRef={transformComponentRef}
                 initialScale={initialScale}

--- a/apps/web/src/components/auth/AuthShell.tsx
+++ b/apps/web/src/components/auth/AuthShell.tsx
@@ -16,12 +16,21 @@ export function AuthShell({
   switchPrompt,
   switchHref,
   switchLabel,
+  mark,
   children,
 }: {
   title: string;
   switchPrompt: string;
   switchHref: string;
   switchLabel: string;
+  /**
+   * Neutral marker id placed on the shell as `data-magic-<mark>`.
+   *
+   * Sign-in and sign-up share this component, so the id has to come from the
+   * caller. It says nothing about what is measured — that lives in the tracking
+   * manifest.
+   */
+  mark?: string;
   children: React.ReactNode;
 }) {
   const reduce = useReducedMotion();
@@ -32,7 +41,10 @@ export function AuthShell({
   };
 
   return (
-    <main className="relative flex min-h-screen items-center justify-center bg-desk px-6 py-16">
+    <main
+      className="relative flex min-h-screen items-center justify-center bg-desk px-6 py-16"
+      {...(mark ? { [`data-magic-${mark}`]: '' } : {})}
+    >
       {/* 深色下一抹极淡 sky 辉光,呼应「黑工作台上的一点光」;浅色下不显。 */}
       <div
         aria-hidden

--- a/apps/web/src/components/auth/SignInCard.tsx
+++ b/apps/web/src/components/auth/SignInCard.tsx
@@ -168,6 +168,7 @@ export default function SignInCard() {
 
   return (
     <AuthShell
+      mark="sign-in-form"
       title={t("auth.signIn.title")}
       switchPrompt={t("auth.signIn.switchPrompt")}
       switchHref="/sign-up"

--- a/apps/web/src/components/auth/SignUpCard.tsx
+++ b/apps/web/src/components/auth/SignUpCard.tsx
@@ -114,6 +114,7 @@ export default function SignUpCard() {
 
   return (
     <AuthShell
+      mark="sign-up-form"
       title={t("auth.signUp.title")}
       switchPrompt={t("auth.signUp.switchPrompt")}
       switchHref="/sign-in"

--- a/apps/web/src/components/settings/SettingsModal.tsx
+++ b/apps/web/src/components/settings/SettingsModal.tsx
@@ -73,13 +73,6 @@ export function SettingsModal() {
     if (settingsOpen) loadSettings();
   }, [settingsOpen, loadSettings]);
 
-  // Reported here rather than at the buttons that open it: settings can be
-  // reached from several places (the sidebar, the cloud-sync prompt on the
-  // dashboard), and only this component knows it actually opened.
-  useEffect(() => {
-    if (settingsOpen) appLifecycle.settingsViewed();
-  }, [settingsOpen]);
-
   const categories = useMemo(() => CATEGORIES.filter((c) => !c.cloudOnly || isCloudMode), []);
   const active = categories.some((c) => c.key === settingsSection) ? settingsSection : "general";
   const currentLang = i18n.language.startsWith("en") ? "en" : "zh";
@@ -119,6 +112,7 @@ export function SettingsModal() {
 
   return (
     <ModalShell
+      mark="settings-panel"
       open={settingsOpen}
       onOpenChange={(open) => !open && closeSettings()}
       title={t("account.settings.title")}

--- a/apps/web/src/components/ui/ModalShell.tsx
+++ b/apps/web/src/components/ui/ModalShell.tsx
@@ -14,6 +14,14 @@ interface ModalShellProps {
   className?: string;
   /** Extra controls rendered left of the close button in the header. */
   headerRight?: React.ReactNode;
+  /**
+   * Neutral marker id placed on the panel as `data-magic-<mark>`.
+   *
+   * Several dialogs share this shell, so the id comes from the caller. It names
+   * the element and nothing else — what gets measured is decided in the
+   * tracking manifest.
+   */
+  mark?: string;
   children: React.ReactNode;
 }
 
@@ -23,7 +31,7 @@ interface ModalShellProps {
  * top-seam is the instrument-signature detail (see design spec). Body is a flex
  * column that fills remaining height — callers own the inner layout.
  */
-export function ModalShell({ open, onOpenChange, title, className, headerRight, children }: ModalShellProps) {
+export function ModalShell({ open, onOpenChange, title, className, headerRight, mark, children }: ModalShellProps) {
   const reduce = useReducedMotion();
 
   return (
@@ -56,6 +64,7 @@ export function ModalShell({ open, onOpenChange, title, className, headerRight, 
                     "relative flex min-h-0 min-w-0 flex-col overflow-hidden rounded-2xl border border-white/[0.06] bg-desk shadow-2xl shadow-black/60",
                     className,
                   )}
+                  {...(mark ? { [`data-magic-${mark}`]: '' } : {})}
                 >
                   {/* sky top-seam — reuses the via-sky rule motif from the settings page */}
                   <div className="pointer-events-none absolute inset-x-0 top-0 z-10 h-px bg-gradient-to-r from-transparent via-sky-500/40 to-transparent" />

--- a/apps/web/src/lib/extensions/app-lifecycle.ts
+++ b/apps/web/src/lib/extensions/app-lifecycle.ts
@@ -1,12 +1,5 @@
 import type { FileSizeBucket } from '@/lib/utils/fileSize';
 
-export type GithubStarLocation =
-  | 'footer'
-  | 'hero'
-  | 'hero_glass_button'
-  | 'hero_macbook_badge'
-  | 'footer_mobile';
-
 export type ResumeImportSource = 'json' | 'pdf';
 
 export type ResumeImportCompletedPayload = {
@@ -15,20 +8,19 @@ export type ResumeImportCompletedPayload = {
   sizeBucket?: FileSizeBucket;
 };
 
-export type DashboardViewedPayload = {
-  resumeCount: number;
-};
-
-export type EditorViewedPayload = {
-  templateId?: string;
-};
-
 export type ResumeSaveRequestedPayload = {
   source: 'manual' | 'auto';
 };
 
-export type ResumeJsonDownloadedPayload = {
-  source: 'editor' | 'json_page' | 'json_modal';
+/** A render-time crash caught by a React error boundary. */
+export type ReactErrorPayload = {
+  message: string;
+  name?: string;
+  stack?: string;
+  /** Next's digest id for a server-side exception. */
+  digest?: string;
+  /** Which boundary caught it, e.g. `app/dashboard`. */
+  component?: string;
 };
 
 export type ResumeTemplateSelectedPayload = {
@@ -63,43 +55,28 @@ const ignore = <T,>(value: T) => {
   void value;
 };
 
+/**
+ * Seam the commercial overlay implements. Anything a *marker* covers is absent
+ * here on purpose: a `data-magic-*` attribute plus a line of tracking manifest
+ * already reports it, and routing it through this object as well would double
+ * count. Page-level impressions (dashboard, editor, settings, a shared resume)
+ * are all markers now.
+ */
 export const appLifecycle = {
-  getStartedClicked: noop,
-  githubStarClicked: (location: GithubStarLocation) => {
-    ignore(location);
-  },
-  dashboardViewed: (payload: DashboardViewedPayload) => {
-    ignore(payload);
-  },
-  resumeCreateRequested: noop,
   resumeCreated: noop,
-  resumeImportRequested: noop,
   resumeImportCompleted: (payload: ResumeImportCompletedPayload) => {
-    ignore(payload);
-  },
-  editorViewed: (payload: EditorViewedPayload) => {
     ignore(payload);
   },
   resumeSaveRequested: (payload: ResumeSaveRequestedPayload) => {
     ignore(payload);
   },
-  resumeJsonDownloaded: (payload: ResumeJsonDownloadedPayload) => {
-    ignore(payload);
-  },
   resumeTemplateSelected: (payload: ResumeTemplateSelectedPayload) => {
     ignore(payload);
   },
-  settingsViewed: noop,
   settingsSaved: (payload: LifecyclePayload) => {
     ignore(payload);
   },
-  aiCreateViewed: noop,
-  aiOptimizeViewed: noop,
-  aiAnalyzeViewed: noop,
-  aiInterviewViewed: noop,
-  aiOptimizationStarted: (hasInputContext: boolean) => {
-    ignore(hasInputContext);
-  },
+  aiOptimizationStarted: noop,
   aiOptimizationApplied: (payload: LifecyclePayload) => {
     ignore(payload);
   },
@@ -124,8 +101,6 @@ export const appLifecycle = {
     ignore(payload);
   },
   shareLinkCreated: noop,
-  shareLinkCopied: noop,
-  sharedResumeViewed: noop,
   editorSectionAdded: (payload: EditorSectionPayload) => {
     ignore(payload);
   },
@@ -148,6 +123,9 @@ export const appLifecycle = {
   },
   reportApiError: (error: unknown) => {
     ignore(error);
+  },
+  reactErrorCaught: (payload: ReactErrorPayload) => {
+    ignore(payload);
   },
 };
 


### PR DESCRIPTION
今天集成分支的出口。

## 内容

- [#153](https://github.com/Magic-Resume/Magic-Resume/pull/153) `feat(web): mark the pages a conversion passes through`

## 这是什么

只给元素起名字的埋点：`<main data-magic-dashboard-list>` 说的是这个元素**是什么**，至于要不要测它、测成什么事件，由服务端下发的埋点清单决定。

两个后果：这个仓里不会出现任何商业事件名；以及**改埋点不再需要在这个仓发版**。

## 十个曝光标记

覆盖转化链路上的每一个页面：简历列表、编辑器画布、设置面板、分享页简历主体、AI 面板、分享面板、登录表单、注册表单、导入面板、新建面板。

其中几个弹窗共用壳组件（`ModalShell` / `AuthShell`），所以壳接一个中性的 `mark` prop 往下透，而不是每个调用方各自往里塞属性。

它们**取代了原先挂载即上报**的写法，这个区别不是形式上的：挂载只能证明「组件渲染了」，而曝光额外要求内容真的进入视口并停留过。加载失败或一秒即走不算「用户看到了这一页」，漏斗的第一步不该把它算进去。

## 三个点击

新建、导入、JSON 下载。JSON 下载原本带一个 `source` 区分三个调用点，但其中两个共用同一个按钮、只是路由不同 —— 而 `page.path` 每条事件都带着，所以一个标记覆盖三处，参数删掉。

## 清理

- `has_input_context`：唯一调用点写死传 `false`，一个永远只有一种取值的维度，不能分组也不能筛，却每行都存
- 删掉 6 个 lifecycle 方法，其中 4 个是页面级事件改为曝光标记后失效的。一个事实两处上报比一处更糟：读代码的人分不清哪个是活的，改错那个还没有任何反馈

## 什么继续手动

点击本身不知道的那些：导出的成功与耗时、AI 运行的结果、敲 Enter（而不是点技能条）启动的技能、可能停在免责声明上的云同步开关。

## 合并方式

**请用普通合并（merge commit），不要 squash。** squash 会让 master 拿到内容却没有历史，release 分支与 master 血缘断开，下一条分支一开出来就整体冲突。目前 `release-2026-07-29` 是 master 的直系后代。

## 上线耦合（要紧）

**这条单独上线不会产生任何数据。** 它给的是 DOM 属性，而能识别 `data-magic-*` 的解析层在商业化仓 —— [Magic-Resume-Commercial #18](https://github.com/Magic-Resume/Magic-Resume-Commercial/pull/18)。反过来单独上商业化仓也一样：有解析能力但没有属性可读。

**这两条要同一批上。** 再加上 [Magic-Core #79](https://github.com/Magic-Resume/Magic-Core/pull/79)（清单 seed 合并 + ETag 改内容哈希），标记才真正开始出事件 —— 没有 Core 那条，新标记到不了任何编辑过一次清单的环境。

## 验证

- `next lint` 无警告、`turbo build` 通过、`tsc --noEmit` 干净
- 端到端：`/sign-in`、`/sign-up` 的真实 DOM 标记产出 `auth.sign_in_viewed`、`auth.sign_up_viewed` 并落库

## 已知未验

8 个登录后的曝光标记（dashboard / editor / settings / share-panel / ai-lab / import / new-resume / shared-resume）与 5 个 `ai-skill-*` 点击标记没有用真实账号走过 —— 机制验过了，但这些元素在真实页面上的可见比例和渲染时机没实测。曝光要求 ≥50% 可见并停留，某个面板高度不足视口一半就不会触发，代码和测试都发现不了。上线后建议先查一次这 13 个事件有没有落库。

🤖 Generated with [Claude Code](https://claude.com/claude-code)