### PR TITLE
:bug: fix(web): 解析失败要说人话；扫描件要说明在逐页识别

### DIFF
--- a/apps/web/src/app/dashboard/_components/ImportResumeDialog.tsx
+++ b/apps/web/src/app/dashboard/_components/ImportResumeDialog.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from 'react-i18next';
 import { motion, AnimatePresence } from 'framer-motion';
 import { appLifecycle } from '@/lib/extensions/app-lifecycle';
 import { getFileSizeBucket } from '@/lib/utils/fileSize';
+import { agentErrorMessage } from '@/lib/utils/agentErrorMessage';
 import {
   formatResumeImportError,
   validateAndNormalizeImportedResume,
@@ -55,6 +56,8 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
   const [pdfCharCount, setPdfCharCount] = useState(0);
   const [pdfLitFields, setPdfLitFields] = useState<Set<string>>(new Set());
   const [pdfComplete, setPdfComplete] = useState(false);
+  // >0 when the PDF had no readable text and is being read as page images.
+  const [pdfVisionPages, setPdfVisionPages] = useState(0);
   const pdfAbortRef = useRef<AbortController | null>(null);
   const { t } = useTranslation();
   const resetPdfProgress = useCallback(() => {
@@ -62,6 +65,7 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
     setPdfCharCount(0);
     setPdfLitFields(new Set());
     setPdfComplete(false);
+    setPdfVisionPages(0);
   }, []);
 
   const handleClose = useCallback((open: boolean) => {
@@ -127,10 +131,22 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
     for await (const ev of streamPdfParse(formData, controller.signal)) {
       if (ev.type === 'tool_result') {
         const payload = ev.payload as
-          | { kind?: string; phase?: PdfPhase; charCount?: number; fields?: string[] }
+          | {
+              kind?: string;
+              phase?: PdfPhase;
+              charCount?: number;
+              fields?: string[];
+              mode?: string;
+              pageCount?: number;
+            }
           | undefined;
         if (payload?.kind !== 'pdf_progress') continue;
         if (payload.phase) setPdfPhase(payload.phase);
+        // The scan path reads page images instead of text, which takes long
+        // enough that not saying so reads as a hang.
+        if (payload.mode === 'vision' && payload.pageCount) {
+          setPdfVisionPages(payload.pageCount);
+        }
         if (typeof payload.charCount === 'number') setPdfCharCount(payload.charCount);
         if (payload.fields?.length) {
           setPdfLitFields((prev) => {
@@ -143,7 +159,11 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
         // Final product: prefer `data`, fall back to the chat-shaped `payload.resume`.
         resume = ev.data ?? (ev.payload as { resume?: unknown } | undefined)?.resume ?? null;
       } else if (ev.type === 'error' || ev.type === 'run_failed') {
-        throw new Error(ev.error || t('importDialog.errors.parseFailed'));
+        // `ev.error` is a machine code — it was going straight into the toast,
+        // so a failed parse read "agent_run_failed".
+        throw new Error(
+          agentErrorMessage(ev, t, t('importDialog.errors.parseFailed')),
+        );
       }
     }
 
@@ -353,6 +373,7 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
                           charCount={pdfCharCount}
                           litFields={pdfLitFields}
                           complete={pdfComplete}
+                          visionPages={pdfVisionPages}
                         />
                       ) : isImporting ? (
                         <div className="flex flex-col items-center justify-center text-sky-500">

--- a/apps/web/src/app/dashboard/_components/PdfScanProgress.tsx
+++ b/apps/web/src/app/dashboard/_components/PdfScanProgress.tsx
@@ -167,11 +167,18 @@ export function PdfScanProgress({
   charCount,
   litFields,
   complete,
+  visionPages,
 }: {
   phase: PdfPhase;
   charCount: number;
   litFields: Set<string>;
   complete: boolean;
+  /**
+   * Pages being read as images, when the PDF carried no text. Reading pictures
+   * takes visibly longer than reading text, and an unexplained pause looks like
+   * a hang — so say which path this is on.
+   */
+  visionPages?: number;
 }) {
   const { t } = useTranslation();
   const reduceMotion = useReducedMotion() ?? false;
@@ -184,14 +191,26 @@ export function PdfScanProgress({
   const heading = complete
     ? t('importDialog.pdf.done', { defaultValue: '解析完成' })
     : phase === 'analyzing'
-      ? t('importDialog.pdf.analyzing', { defaultValue: '解析中' })
+      ? visionPages
+        ? t('importDialog.pdf.analyzingScan', {
+            defaultValue: '这份 PDF 没有可复制的文字，正在逐页识别',
+          })
+        : t('importDialog.pdf.analyzing', { defaultValue: '解析中' })
       : t('importDialog.pdf.extracting', { defaultValue: '读取 PDF' });
 
   return (
     <div className="text-left">
       <div className="mb-4 flex items-baseline justify-between">
         <span className="text-sm font-medium text-neutral-100">{heading}</span>
-        {phase === 'analyzing' && !complete && charCount > 0 && (
+        {phase === 'analyzing' && !complete && visionPages ? (
+          <span className="text-xs tabular-nums text-neutral-500">
+            {t('importDialog.pdf.pageUnit', {
+              defaultValue: '{{count}} 页',
+              count: visionPages,
+            })}
+          </span>
+        ) : null}
+        {phase === 'analyzing' && !complete && !visionPages && charCount > 0 && (
           <span className="text-xs tabular-nums text-neutral-500">
             <CountUp value={charCount} animate={!reduceMotion} />{' '}
             {t('importDialog.pdf.charUnit', { defaultValue: '字' })}

--- a/apps/web/src/lib/utils/agentErrorMessage.ts
+++ b/apps/web/src/lib/utils/agentErrorMessage.ts
@@ -1,0 +1,38 @@
+/**
+ * Turn an agent SSE `error` event into something a person can act on.
+ *
+ * The stream carries a machine code in `error` (`agent_run_failed`,
+ * `insufficient_quota`, …) and — only when the failure was raised deliberately
+ * for a user to read — a sentence in `payload.message`. Throwing `ev.error`
+ * straight into a toast is how "agent_run_failed" ended up on screen: it is an
+ * identifier for logs and branching, never copy.
+ *
+ * Order matters. A server-authored message is the most specific thing we have,
+ * so it wins; a known code gets localised copy; anything else falls back rather
+ * than leaking an identifier we did not anticipate.
+ */
+export function agentErrorMessage(
+  event: { error?: string | null; payload?: unknown },
+  translate: (key: string, options?: { defaultValue?: string }) => string,
+  fallback: string,
+): string {
+  const payload = event.payload as { message?: unknown; code?: unknown } | undefined;
+
+  const authored = typeof payload?.message === 'string' ? payload.message.trim() : '';
+  if (authored) return authored;
+
+  const code =
+    (typeof payload?.code === 'string' && payload.code) ||
+    (typeof event.error === 'string' && event.error) ||
+    '';
+  if (!code) return fallback;
+
+  const key = `agentErrors.${code}`;
+  const copy = translate(key, { defaultValue: '' });
+  // i18next returns the key itself when a namespace is missing, so treat that
+  // as "no copy" too — otherwise the user reads `agentErrors.agent_run_failed`,
+  // which is worse than the raw code.
+  if (copy && copy !== key) return copy;
+
+  return fallback;
+}

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -1135,8 +1135,15 @@
         "skills": "Skills",
         "languages": "Languages",
         "certificates": "Certificates"
-      }
+      },
+      "analyzingScan": "This PDF has no selectable text — reading it page by page",
+      "pageUnit": "{{count}} page(s)"
     }
+  },
+  "agentErrors": {
+    "agent_run_failed": "The parse did not finish. Try again; if it keeps failing, try another PDF or check your model settings.",
+    "insufficient_quota": "Your account is out of credits. Top up or finish your custom model settings, then try again.",
+    "model_unavailable": "The configured model is unavailable. Check the model name and base URL in settings."
   },
   "dynamicForm": {
     "fields": {

--- a/apps/web/src/locales/zh/translation.json
+++ b/apps/web/src/locales/zh/translation.json
@@ -1135,8 +1135,15 @@
         "skills": "技能",
         "languages": "语言能力",
         "certificates": "证书"
-      }
+      },
+      "analyzingScan": "这份 PDF 没有可复制的文字，正在逐页识别",
+      "pageUnit": "{{count}} 页"
     }
+  },
+  "agentErrors": {
+    "agent_run_failed": "解析没能完成，请稍后重试；如果反复失败，换一份 PDF 或检查大模型配置。",
+    "insufficient_quota": "账户额度不足，请先充值或完善自定义大模型配置后再试。",
+    "model_unavailable": "当前配置的模型不可用，请到设置里检查模型名称与 Base URL。"
   },
   "dynamicForm": {
     "fields": {


### PR DESCRIPTION
配套 `Magic-Core#85`。

## 报错

`ev.error` 是机器码（`agent_run_failed`、`insufficient_quota`），之前被直接塞进 toast——所以导入失败时用户看到的就是 `agent_run_failed`。

`agentErrorMessage` 按最具体优先取：服务端为人写的句子 → 已知 code 的本地化文案 → 兜底。任何情况下都不渲染裸标识符，包括 i18next 在找不到 key 时把 key 原样吐回来那种。

新增 `agentErrors.*` 中英文案（`agent_run_failed` / `insufficient_quota` / `model_unavailable`）。

## 扫描件的进度提示

没有可提取文字的 PDF 现在走逐页识别，比读文字明显慢。那段时间里没有任何说明会像卡死，所以进度面板改成说明当前在走哪条路、一共几页，而不是去数一个永远不会到来的字符数。

## 验收

`tsc --noEmit` 干净；privacy scan + 单测通过；两侧 locale key 集合一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)