### PR TITLE
:bug: fix(web): 额度「没查出来」时不该把用户挡在门外

### DIFF
--- a/apps/web/src/app/dashboard/edit/_components/ai/lib/services/aiAccess.ts
+++ b/apps/web/src/app/dashboard/edit/_components/ai/lib/services/aiAccess.ts
@@ -24,6 +24,20 @@ export async function resolveAiAccessConfig(
   const hasByok = settings.hasLlmConfig();
   const pref = settings.preferredSource;
 
+  /**
+   * Internal AI without a confirmed entitlement, for when the check could not
+   * reach a verdict. No `entitlement` on the result: nothing downstream should
+   * read a balance we never received.
+   */
+  const unverifiedInternalConfig = (): AiAccessResult => ({
+    ok: true,
+    config: {
+      source: "internal",
+      ...(settings.selectedModel ? { modelName: settings.selectedModel } : {}),
+      effort: settings.strength,
+    },
+  });
+
   const byokConfig = (entitlement?: AiEntitlement): AiAccessResult => ({
     ok: true,
     config: {
@@ -46,9 +60,18 @@ export async function resolveAiAccessConfig(
   try {
     entitlement = await getAiEntitlement(options.forceRefresh);
   } catch (error) {
-    // Entitlement check failed — degrade to the user's own key if they have one,
-    // otherwise surface the error.
+    // Entitlement check failed — degrade to the user's own key if they have one.
     if (hasByok) return byokConfig();
+
+    // Otherwise it depends on *what* failed. A timeout, a dead connection or a
+    // 5xx means we could not find out whether this user is entitled — which is
+    // not the same as finding out they are not. Blocking on it takes a paying
+    // user's import away because a hop was slow, while the server enforces the
+    // quota regardless and answers `insufficient_quota` with copy of its own if
+    // they really have none. So let it through and let the answer come from the
+    // side that actually knows.
+    if (isInconclusive(error)) return unverifiedInternalConfig();
+
     const message = error instanceof Error ? error.message : "账户额度检查失败";
     return { ok: false, reason: "entitlement_unavailable", message };
   }
@@ -80,6 +103,22 @@ export async function resolveAiAccessConfig(
 
 export function invalidateAiEntitlement() {
   invalidateEntitlementCache();
+}
+
+/**
+ * True when a failed entitlement check tells us nothing about entitlement.
+ *
+ * Read structurally rather than by class: the check itself lives in the
+ * commercial overlay, and this module must not import from it — the same
+ * duck-typed contract `httpStatus` uses on the server. An unmarked error is
+ * treated as an answer, so a build whose entitlement client predates the
+ * marker keeps failing closed rather than silently opening up.
+ */
+function isInconclusive(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error as { inconclusive?: unknown }).inconclusive === true
+  );
 }
 
 export function isQuotaOrCustomConfigError(error: unknown) {


### PR DESCRIPTION
配套 `Magic-Resume-Commercial#23`。

一次超时/连不上的额度检查，和一次明确回答「不行」的检查，之前被同等对待。于是一个有额度的用户，只因为某一跳慢，就看到「账户额度检查超时」并且完全无法导入简历——而后端本来就会真正校验额度，真没有的话会返回 `insufficient_quota` 并带自己的文案。

现在：**查不出结果的失败放行**，让答案来自真正知道的那一侧。明确的失败（401、其他 4xx）仍然挡住；配了自己 key 的用户仍然优先降级到 BYOK，这条没变。

标记按结构读取而不是按类判断——额度客户端在商业 overlay 里，这个模块不能 import 它。没有标记的错误保持失败关闭，所以一个客户端版本较旧的构建不会因此静默放开。

## 这个问题是怎么找到的

现象是导入 PDF 时弹「账户额度检查超时」。后端日志显示 `/api/billing/ai-entitlement` 200、124ms，一切正常。实测下来差额全在 Next dev 的按需编译：同一个接口直连 Core 20ms，经 route handler 首次 9.5 秒、之后 60ms。客户端 6 秒的 abort 就卡在这中间。

dev 首次编译本身不是 bug（刷新即可，生产路由是预构建的），但它暴露了底下这条：一个没查出结果的检查不该被当作否定答案。

`tsc --noEmit` 干净；单测通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)