### PR TITLE
:sparkles: feat(web): 自定义 section 成为一等公民；修好导入的字段与 id

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -27,3 +27,14 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # Prod: the public gateway origin (nginx terminates TLS in front).
 # NEXT_PUBLIC_API_URL=http://localhost:3110
 
+# ------ Cloudflare R2 (avatar upload, cloud mode) ---------------------
+# Server-side only — used by /api/uploads/avatar to store avatars in R2.
+# Create an R2 API Token (Object Read & Write) in the Cloudflare dashboard to
+# get the Access Key ID / Secret. Self-hosted mode never uses these (it embeds
+# the avatar as a data: URL instead).
+# R2_ACCOUNT_ID=
+# R2_ACCESS_KEY_ID=
+# R2_SECRET_ACCESS_KEY=
+# R2_BUCKET=magic-resume-assets
+# R2_PUBLIC_BASE_URL=https://pub-xxxx.r2.dev
+

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -59,6 +59,13 @@ const nextConfig: NextConfig = {
         hostname: 'img.clerk.com',
         port: '',
         pathname: '/**',
+      },
+      {
+        // Cloudflare R2 头像:public dev URL(*.r2.dev)。绑自定义域名后再加一条。
+        protocol: 'https',
+        hostname: 'pub-ca5e6f293e274c1b9298cf78d112e0be.r2.dev',
+        port: '',
+        pathname: '/**',
       }
     ],
     // 优化图片格式

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "test:unit": "tsx src/app.test.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1100.0",
     "@clerk/nextjs": "^6.22.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,7 +15,9 @@
     "build:standalone": "next build && next export",
     "i18n:check": "tsx scripts/i18n-check.ts",
     "privacy:scan": "node scripts/privacy-scan.mjs",
-    "test": "npm run privacy:scan"
+    "test": "npm run privacy:scan && npm run test:unit && npm run verify:sections",
+    "verify:sections": "tsx scripts/verify-custom-sections.tsx",
+    "test:unit": "tsx src/app.test.ts"
   },
   "dependencies": {
     "@clerk/nextjs": "^6.22.0",
@@ -94,6 +96,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@next/bundle-analyzer": "^15.3.3",
+    "@react-pdf/renderer": "4.5.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20.19.31",
     "@types/react": "^19.1.6",

--- a/apps/web/scripts/verify-custom-sections.tsx
+++ b/apps/web/scripts/verify-custom-sections.tsx
@@ -1,0 +1,167 @@
+/**
+ * Does a custom section actually reach the page?
+ *
+ * The bug this guards against is not a crash — it is silence. A section key no
+ * template declares used to render nowhere at all, and item `customFields`
+ * were dropped by any fieldMap that did not name them. Both survived every
+ * layer above the renderer, so nothing failed; the content simply was not
+ * there. That is only catchable by rendering and looking.
+ *
+ * Run: node scripts/verify-custom-sections.mjs
+ */
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Font, renderToBuffer } from '@react-pdf/renderer';
+import type { DocumentProps } from '@react-pdf/renderer';
+import { join } from 'node:path';
+
+import { templateRegistry } from '../../../packages/resume-templates/src/registry';
+import { MagicResumeRenderer } from '../../../packages/resume-templates/src/renderer/MagicResumeRenderer';
+import { MagicResumePdfDocument } from '../../../packages/resume-templates/src/pdf/MagicResumePdfDocument';
+
+const CUSTOM_HEADING = '个人优势';
+const ITEM_NAME = '综合能力';
+const CUSTOM_FIELD_NAME = '获奖等级';
+const CUSTOM_FIELD_VALUE = '国赛三等奖';
+
+/** A resume shaped like the one that exposed all of this. */
+const resume = {
+  id: 'verify-1',
+  name: 'verify',
+  updatedAt: 1,
+  info: {
+    fullName: '黄凯',
+    headline: '高级前端工程师',
+    email: 'a@b.c',
+    phoneNumber: '13800000000',
+    address: '上海',
+    website: '',
+    avatar: '',
+  },
+  sections: {
+    experience: [
+      { id: 'e1', visible: true, company: '某公司', position: '前端', date: '2021 - 2024', summary: '<p>正文</p>' },
+    ],
+    // The section the app never defined.
+    personalStrengths: [
+      {
+        id: 'ps1',
+        visible: true,
+        name: ITEM_NAME,
+        summary: '<ul><li>熟练使用 Claude Code、Cursor、Codex</li><li>英语 CET-4、CET-6</li></ul>',
+        customFields: [
+          { id: 'cf1', name: CUSTOM_FIELD_NAME, value: CUSTOM_FIELD_VALUE },
+        ],
+      },
+    ],
+  },
+  sectionOrder: [
+    { key: 'basics', label: 'Basics' },
+    { key: 'experience', label: '工作经历' },
+    { key: 'personalStrengths', label: CUSTOM_HEADING, icon: 'trophy' },
+  ],
+  template: 'classic',
+  themeColor: '#f97316',
+  typography: 'inter',
+};
+
+const stripTags = (html: string) => html.replace(/<[^>]*>/g, '');
+
+let failures = 0;
+const check = (label: string, ok: boolean, detail = '') => {
+  if (ok) {
+    console.log(`  ✓ ${label}`);
+  } else {
+    failures += 1;
+    console.log(`  ✗ ${label}${detail ? ` — ${detail}` : ''}`);
+  }
+};
+
+async function main() {
+  console.log('HTML renderer, every template:');
+  for (const [id, manifest] of Object.entries(templateRegistry)) {
+    const html = renderToStaticMarkup(
+      React.createElement(MagicResumeRenderer, {
+        template: manifest.template,
+        data: { ...resume, template: id },
+        locale: 'zh-CN',
+      }),
+    );
+    const text = stripTags(html);
+
+    const problems = [];
+    if (!text.includes(CUSTOM_HEADING)) problems.push('缺标题');
+    if (!text.includes(ITEM_NAME)) problems.push('缺条目');
+    if (!text.includes(CUSTOM_FIELD_NAME)) problems.push('缺自定义字段名');
+    if (!text.includes(CUSTOM_FIELD_VALUE)) problems.push('缺自定义字段值');
+    // The section it always had must not have been disturbed.
+    if (!text.includes('某公司')) problems.push('内置段落丢失');
+    // Rich text (`summary`) is deliberately not asserted here: WysiwygContent
+    // returns an empty div when there is no DOM, because DOMPurify needs one.
+    // That is true of every section, built-in or custom, so it says nothing
+    // about this change — and asserting it would need jsdom in a package that
+    // otherwise has no test runner.
+
+    check(id, problems.length === 0, problems.join('、'));
+  }
+
+  // The app registers these at runtime from `public/fonts` (see pdf/browser.tsx),
+  // which needs `window.location`. Register the same files from disk so the
+  // exporter can lay out a page here.
+  const FONT_DIR = join(import.meta.dirname, '..', 'public', 'fonts');
+  for (const family of ['Source Han Serif SC', 'Source Han Sans SC']) {
+    const file = family.includes('Serif')
+      ? 'SourceHanSerifSC-Regular.woff2'
+      : 'SourceHanSansSC-Regular.woff2';
+    Font.register({ family, src: join(FONT_DIR, file) });
+  }
+
+  console.log('\nPDF exporter (classic):');
+  const buffer = await renderToBuffer(
+    React.createElement(MagicResumePdfDocument, {
+      data: resume,
+      template: templateRegistry.classic.template,
+      locale: 'zh-CN',
+      // Latin-only: the CJK stack is registered by `pdf/browser.tsx` at runtime,
+      // which fetches font files. The question here is whether the section is in
+      // the document at all, not how its glyphs are shaped.
+      cjkFallback: false,
+      // `MagicResumePdfDocument` renders a <Document>, but its own props type is
+      // not `DocumentProps` — which is all `renderToBuffer`'s signature knows.
+    }) as React.ReactElement<DocumentProps>,
+  );
+  // Read the text back out rather than trusting the byte count: a document that
+  // merely grew could have grown for any reason, and the failure this guards
+  // against is content quietly missing.
+  const pdfjs = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  const doc = await pdfjs.getDocument({ data: new Uint8Array(buffer) }).promise;
+  let pdfText = '';
+  for (let i = 1; i <= doc.numPages; i += 1) {
+    const content = await (await doc.getPage(i)).getTextContent();
+    pdfText += content.items.map((item: unknown) =>
+    item && typeof item === 'object' && 'str' in item ? String((item as { str: unknown }).str) : '',
+  ).join('');
+  }
+  pdfText = pdfText.replace(/\s/g, '');
+
+  check('heading is in the export', pdfText.includes(CUSTOM_HEADING));
+  check('item is in the export', pdfText.includes(ITEM_NAME));
+  check(
+    'custom fields are in the export',
+    pdfText.includes(CUSTOM_FIELD_NAME) && pdfText.includes(CUSTOM_FIELD_VALUE),
+  );
+  check('built-in sections still export', pdfText.includes('某公司'));
+
+  console.log(
+    failures === 0
+      ? '\n全部通过'
+      : `\n${failures} 项失败`,
+  );
+  process.exit(failures === 0 ? 0 : 1);
+
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/apps/web/src/app.test.ts
+++ b/apps/web/src/app.test.ts
@@ -20,6 +20,7 @@ import {
   normalizeCloudResumes,
   shellQuote,
 } from '@/lib/settings/mcpAccess';
+import { migrateResume } from '@/lib/utils/resumeMigrations';
 import { shallowEqualArray } from '@/lib/utils/array';
 import { hexToRgb, rgbToHex } from '@/lib/utils/color';
 import { parseCssPixelValue } from '@/lib/utils/css';
@@ -289,7 +290,11 @@ function testImportResumeValidation() {
   assert.equal(normalized.sections.experience[0].visible, true);
   assert.equal(normalized.sections.experience[0].extraBackendField, 'kept');
   assert.deepEqual(normalized.sections.education, []);
-  assert.deepEqual(normalized.sections.customSection, [{ id: 'custom-1', title: 'Notes' }]);
+  // A custom section survives with its content. The id is reissued — imported
+  // ids are whatever the source said, and the app mints its own with nanoid.
+  assert.equal(normalized.sections.customSection.length, 1);
+  assert.equal(normalized.sections.customSection[0].title, 'Notes');
+  assert.match(normalized.sections.customSection[0].id, /^[A-Za-z0-9_-]{21}$/);
   assert.deepEqual(normalized.sectionOrder.map(({ key }) => key), [
     'basics',
     'experience',
@@ -493,12 +498,83 @@ function testAiLib() {
   assert.equal(translatePatchBatch.lang, 'English');
 }
 
+function testImportedItemIds() {
+  // An imported id used to be whatever the source said — for a PDF, whatever
+  // the model wrote, and the model copies the prompt example, so real resumes
+  // arrived full of `skill-1` / `exp-1`. Nothing deduplicated them either, so a
+  // model numbering two sections from 1 produced colliding React keys and a
+  // drag list that reordered the wrong row.
+  const normalized = validateAndNormalizeImportedResume({
+    info: {},
+    sections: {
+      experience: [{ id: 'exp-1' }, { id: 'exp-1' }],
+      skills: [{ id: 'skill-1' }],
+      personalStrengths: [{ id: 'skill-1' }],
+    },
+    sectionOrder: [{ key: 'experience', label: 'Experience' }],
+  });
+
+  const ids = Object.values(normalized.sections).flatMap((items) =>
+    (items as { id: string }[]).map((i) => i.id),
+  );
+  assert.equal(ids.length, 4);
+  // Same shape the app mints for itself (nanoid, 21 URL-safe chars).
+  for (const id of ids) assert.match(id, /^[A-Za-z0-9_-]{21}$/);
+  assert.equal(new Set(ids).size, ids.length, 'ids must be unique');
+  // A custom section survives the reissue, keys and all.
+  assert.ok(normalized.sections.personalStrengths);
+}
+
+function testResumeMigrations() {
+  // `summary` is the only rich-text field the editor edits and twelve of the
+  // thirteen templates render. Prose stranded in `description` by an older
+  // import is stored, invisible and un-editable.
+  const migrated = migrateResume({
+    id: 'r1',
+    sectionOrder: [{ key: 'basics', label: 'Basics' }],
+    sections: {
+      skills: [
+        { id: 'a', visible: true, description: '<p>正文</p>' },
+        { id: 'b', visible: true, summary: '<p>已有</p>', description: '次要' },
+        { id: 'c', visible: true, summary: '   ', description: '<p>空白也算空</p>' },
+      ],
+    },
+  } as never);
+
+  assert.equal(migrated.sections.skills[0].summary, '<p>正文</p>');
+  // Never overwrite a summary the resume already had.
+  assert.equal(migrated.sections.skills[1].summary, '<p>已有</p>');
+  assert.equal(migrated.sections.skills[2].summary, '<p>空白也算空</p>');
+  // Left in place — product-ops-focus reads it.
+  assert.equal(migrated.sections.skills[0].description, '<p>正文</p>');
+
+  // `basics` drives the editor's first form; a resume written before it existed
+  // opens without the name/contact fields.
+  const noBasics = migrateResume({
+    id: 'r2',
+    sectionOrder: [{ key: 'experience', label: 'Experience' }],
+    sections: {},
+  } as never);
+  assert.equal(noBasics.sectionOrder[0].key, 'basics');
+
+  // Nothing to repair → the same object back, so callers can skip the write
+  // and avoid a spurious "modified" sync status.
+  const clean = {
+    id: 'r3',
+    sectionOrder: [{ key: 'basics', label: 'Basics' }],
+    sections: { skills: [{ id: 'a', visible: true, summary: '<p>x</p>' }] },
+  } as never;
+  assert.equal(migrateResume(clean), clean);
+}
+
 async function main() {
   await testAiSessionStore();
   testImportResumeValidation();
   testUtilityFunctions();
   testMcpAccessHelpers();
   testAiLib();
+  testImportedItemIds();
+  testResumeMigrations();
 }
 
 main().catch((error) => {

--- a/apps/web/src/app.test.ts
+++ b/apps/web/src/app.test.ts
@@ -21,6 +21,11 @@ import {
   shellQuote,
 } from '@/lib/settings/mcpAccess';
 import { migrateResume } from '@/lib/utils/resumeMigrations';
+import {
+  customSectionKey,
+  isCustomSection,
+  normalizeResumeSectionOrder,
+} from '@/lib/utils/resumeSectionOrder';
 import { shallowEqualArray } from '@/lib/utils/array';
 import { hexToRgb, rgbToHex } from '@/lib/utils/color';
 import { parseCssPixelValue } from '@/lib/utils/css';
@@ -292,9 +297,10 @@ function testImportResumeValidation() {
   assert.deepEqual(normalized.sections.education, []);
   // A custom section survives with its content. The id is reissued — imported
   // ids are whatever the source said, and the app mints its own with nanoid.
-  assert.equal(normalized.sections.customSection.length, 1);
-  assert.equal(normalized.sections.customSection[0].title, 'Notes');
-  assert.match(normalized.sections.customSection[0].id, /^[A-Za-z0-9_-]{21}$/);
+  const customItems = normalized.sections.customSection as { id: string; title: string }[];
+  assert.equal(customItems.length, 1);
+  assert.equal(customItems[0].title, 'Notes');
+  assert.match(customItems[0].id, /^[A-Za-z0-9_-]{21}$/);
   assert.deepEqual(normalized.sectionOrder.map(({ key }) => key), [
     'basics',
     'experience',
@@ -567,6 +573,42 @@ function testResumeMigrations() {
   assert.equal(migrateResume(clean), clean);
 }
 
+function testCustomSections() {
+  // Only sections the app did not define can be renamed or deleted. A built-in's
+  // label is an i18n key (`sections.skills`), so renaming one would swap a
+  // translated string for a literal and break every other language; deleting one
+  // would remove a form the editor expects to exist.
+  for (const builtin of ['basics', 'experience', 'education', 'projects', 'skills', 'languages', 'certificates']) {
+    assert.equal(isCustomSection(builtin), false, `${builtin} must be protected`);
+  }
+  assert.equal(isCustomSection('personalStrengths'), true);
+  assert.equal(isCustomSection('个人优势'), true);
+
+  // Keys are derived from the title for readable JSON, but never trusted to be
+  // unique or even expressible in ascii.
+  assert.equal(customSectionKey('Personal Highlights', []), 'personal-highlights');
+  assert.equal(customSectionKey('  Awards!  ', []), 'awards');
+  // A Chinese title slugs to nothing — it still needs a key.
+  assert.equal(customSectionKey('个人优势', []), 'section');
+  assert.equal(customSectionKey('个人优势', ['section']), 'section-2');
+  assert.equal(customSectionKey('Awards', ['awards', 'awards-2']), 'awards-3');
+
+  // A custom section survives order normalisation with its label intact, which
+  // is what the editor and the renderer both title it from.
+  const order = normalizeResumeSectionOrder(
+    [{ key: 'personalStrengths', label: '个人优势' }],
+    { personalStrengths: [], skills: [] },
+  );
+  assert.deepEqual(
+    order.find((s) => s.key === 'personalStrengths'),
+    { key: 'personalStrengths', label: '个人优势' },
+  );
+  // …and the built-ins are still all present, so no form disappears.
+  for (const builtin of ['basics', 'skills', 'experience']) {
+    assert.ok(order.some((s) => s.key === builtin), `${builtin} missing from order`);
+  }
+}
+
 async function main() {
   await testAiSessionStore();
   testImportResumeValidation();
@@ -575,6 +617,7 @@ async function main() {
   testAiLib();
   testImportedItemIds();
   testResumeMigrations();
+  testCustomSections();
 }
 
 main().catch((error) => {

--- a/apps/web/src/app/api/uploads/avatar/route.ts
+++ b/apps/web/src/app/api/uploads/avatar/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { DeleteObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { getServerUserId } from '@/lib/auth/server';
+import {
+  getR2Client,
+  isR2Configured,
+  ownAvatarKeyFromUrl,
+  publicUrlForKey,
+  R2_BUCKET,
+} from '@/lib/storage/r2';
+
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+
+// 客户端把头像压到 ~120KB JPEG;服务端上限贴合实际产出留足余量即可(512KB),
+// 砍掉「绕过前端直接 POST 大文件」的放大空间(此前 2MB=16 倍太宽)。
+const MAX_AVATAR_BYTES = 512 * 1024;
+
+/** 每个用户每分钟最多上传次数(进程内软限流,防刷 Class A 操作)。 */
+const RATE_LIMIT_PER_MINUTE = 20;
+const rateBuckets = new Map<string, number[]>();
+
+function rateLimited(userId: string): boolean {
+  const now = Date.now();
+  const windowStart = now - 60_000;
+  const hits = (rateBuckets.get(userId) ?? []).filter((t) => t > windowStart);
+  if (hits.length >= RATE_LIMIT_PER_MINUTE) {
+    rateBuckets.set(userId, hits);
+    return true;
+  }
+  hits.push(now);
+  rateBuckets.set(userId, hits);
+  return false;
+}
+
+/** 魔数嗅探:只认真正的位图,SVG / 其它一律拒绝(防 XSS / polyglot)。 */
+function sniffImage(buf: Uint8Array): { ext: string; contentType: string } | null {
+  const b = buf;
+  // PNG: 89 50 4E 47
+  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) {
+    return { ext: 'png', contentType: 'image/png' };
+  }
+  // JPEG: FF D8 FF
+  if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) {
+    return { ext: 'jpg', contentType: 'image/jpeg' };
+  }
+  // GIF: 47 49 46 38
+  if (b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x38) {
+    return { ext: 'gif', contentType: 'image/gif' };
+  }
+  // WEBP: RIFF....WEBP
+  if (
+    b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 &&
+    b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50
+  ) {
+    return { ext: 'webp', contentType: 'image/webp' };
+  }
+  return null;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const userId = await getServerUserId();
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    if (!isR2Configured()) {
+      // 密钥没配好时明确报可用性问题,而不是 500 崩栈。
+      return NextResponse.json({ error: 'Avatar upload is not configured' }, { status: 503 });
+    }
+
+    if (rateLimited(userId)) {
+      return NextResponse.json({ error: 'Too many uploads, slow down' }, { status: 429 });
+    }
+
+    const contentLength = Number(req.headers.get('content-length') ?? 0);
+    if (contentLength > MAX_AVATAR_BYTES + 256 * 1024) {
+      return NextResponse.json({ error: 'File too large' }, { status: 413 });
+    }
+
+    const form = await req.formData();
+    const file = form.get('file');
+    const prevUrl = typeof form.get('prevUrl') === 'string' ? (form.get('prevUrl') as string) : null;
+
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'Missing file' }, { status: 400 });
+    }
+    if (file.size > MAX_AVATAR_BYTES) {
+      return NextResponse.json({ error: 'File too large' }, { status: 413 });
+    }
+
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    const kind = sniffImage(bytes);
+    if (!kind) {
+      return NextResponse.json({ error: 'Unsupported image format' }, { status: 415 });
+    }
+
+    // 每用户固定 key:上传即覆盖 → 存储硬封顶在「每人恒 1 个对象」,即便有人绕过前端
+    // 疯狂上传也堆不出量(防盗刷占存储)。固定扩展名 .jpg 保证不因格式不同产生第二个对象;
+    // 真实 Content-Type 仍按嗅探设置(浏览器按 Content-Type 而非扩展名解析)。
+    const key = `avatars/${userId}.jpg`;
+    const client = getR2Client();
+
+    await client.send(
+      new PutObjectCommand({
+        Bucket: R2_BUCKET,
+        Key: key,
+        Body: bytes,
+        ContentType: kind.contentType,
+        CacheControl: 'public, max-age=31536000, immutable',
+      }),
+    );
+
+    // 固定 key 会命中 CDN/浏览器缓存,靠 ?v=<ts> 破缓存拿到新图。
+    const url = `${publicUrlForKey(key)}?v=${Date.now()}`;
+
+    // 过渡期清理:旧方案(avatars/<userId>/<nanoid>.ext)残留对象,借 prevUrl 尽力删掉。
+    // 仅删自己前缀下的、且非当前固定 key。失败不影响上传结果。
+    const oldKey = ownAvatarKeyFromUrl(prevUrl, userId);
+    if (oldKey && oldKey !== key) {
+      client
+        .send(new DeleteObjectCommand({ Bucket: R2_BUCKET, Key: oldKey }))
+        .catch(() => undefined);
+    }
+
+    return NextResponse.json({ url });
+  } catch (err) {
+    console.error('[avatar-upload] failed', err);
+    return NextResponse.json({ error: 'Upload failed' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/dashboard/edit/_components/ResumeEdit.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ResumeEdit.tsx
@@ -9,7 +9,11 @@ import sidebarMenu from '@/lib/constants/sidebarMenu';
 import SectionListWithModal from './forms/SectionListWithModal';
 import ResumePreviewPanel from './preview/ResumePreviewPanel';
 import FormSection from './forms/FormSection';
-import { dynamicFormFields } from '@/lib/constants/dynamicFormFields';
+import { formFieldsFor } from '@/lib/constants/dynamicFormFields';
+import { isCustomSection } from '@/lib/utils/resumeSectionOrder';
+import CustomSectionDialog from './forms/CustomSectionDialog';
+import ConfirmDialog from '@/components/shared/ConfirmDialog';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
 import {
   DndContext,
   closestCenter,
@@ -56,6 +60,9 @@ export default function ResumeEdit({ id }: ResumeEditProps) {
     updateInfo,
     setSectionOrder: updateSectionOrder,
     updateSectionItems,
+    addCustomSection,
+    updateCustomSection,
+    removeCustomSection,
     updateTemplate,
     rightCollapsed,
     setRightCollapsed,
@@ -79,6 +86,10 @@ export default function ResumeEdit({ id }: ResumeEditProps) {
   const [leftPanelOpen, setLeftPanelOpen] = useState(false);
   const [rightPanelOpen, setRightPanelOpen] = useState(false);
   const [isAnyModalOpen, setIsAnyModalOpen] = useState(false);
+  // Create and rename share one dialog: they differ only in starting values.
+  const [creatingSection, setCreatingSection] = useState(false);
+  const [editingSection, setEditingSection] = useState<{ key: string; label: string; icon?: string } | null>(null);
+  const [deletingSection, setDeletingSection] = useState<{ key: string; label: string } | null>(null);
   const [currentTemplateId, setCurrentTemplateId] = useState(activeResume?.template || 'classic');
   const [resumeNotFound, setResumeNotFound] = useState(false);
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({});
@@ -439,16 +450,43 @@ export default function ResumeEdit({ id }: ResumeEditProps) {
         onDragEnd={handleDragEnd}
       >
         <SortableContext items={sectionOrder?.map(s => s.key) || []} strategy={verticalListSortingStrategy}>
-          {(sectionOrder || []).map(({ key }) => {
-            const meta = sectionMeta(key);
+          {(sectionOrder || []).map(({ key, label, icon: iconName }) => {
+            const meta = sectionMeta(key, iconName);
             const Icon = meta.icon;
-            const title = meta.labelKey ? t(meta.labelKey) : key;
+            // Fall back to the stored label, not the raw key: a custom section
+            // has no i18n key, and `OutlineRail` next to this already reads it
+            // that way — the two disagreeing is what showed `personalStrengths`
+            // as a heading here and 「个人优势」 two panels over.
+            const title = meta.labelKey ? t(meta.labelKey) : label || key;
+            const custom = isCustomSection(key);
             return (
               <FormSection
                 key={key}
                 sectionId={key}
                 icon={<Icon size={15} />}
                 title={title}
+                actions={custom ? (
+                  <>
+                    <button
+                      type="button"
+                      aria-label={t('customSection.rename', { defaultValue: '重命名' })}
+                      title={t('customSection.rename', { defaultValue: '重命名' })}
+                      onClick={() => setEditingSection({ key, label: label || key, icon: iconName })}
+                      className="flex h-7 w-7 items-center justify-center rounded-lg text-neutral-500 transition-colors hover:bg-white/[0.06] hover:text-neutral-200"
+                    >
+                      <Pencil size={13} />
+                    </button>
+                    <button
+                      type="button"
+                      aria-label={t('common.delete', { defaultValue: '删除' })}
+                      title={t('common.delete', { defaultValue: '删除' })}
+                      onClick={() => setDeletingSection({ key, label: label || key })}
+                      className="flex h-7 w-7 items-center justify-center rounded-lg text-neutral-500 transition-colors hover:bg-red-500/10 hover:text-red-400"
+                    >
+                      <Trash2 size={13} />
+                    </button>
+                  </>
+                ) : undefined}
                 open={openSections[key] ?? true}
                 onToggle={() => toggleSection(key)}
                 registerRef={(el) => { sectionRefs.current[key] = el; }}
@@ -466,7 +504,7 @@ export default function ResumeEdit({ id }: ResumeEditProps) {
                     // `label` is an i18n key and shifts with copy changes.
                     sectionKey={key}
                     label={meta.labelKey || key}
-                    fields={(dynamicFormFields[key as keyof typeof dynamicFormFields] || []).map(f => ({ name: f.key, label: t(f.labelKey), placeholder: f.placeholderKey ? t(f.placeholderKey) : '', required: f.required }))}
+                    fields={formFieldsFor(key).map(f => ({ name: f.key, label: t(f.labelKey), placeholder: f.placeholderKey ? t(f.placeholderKey) : '', required: f.required }))}
                     richtextKey="summary"
                     richtextPlaceholder="..."
                     /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -481,6 +519,50 @@ export default function ResumeEdit({ id }: ResumeEditProps) {
             );
           })}
         </SortableContext>
+
+        <button
+          type="button"
+          onClick={() => setCreatingSection(true)}
+          className="mt-1 flex w-full items-center justify-center gap-1.5 rounded-xl border border-dashed border-white/10 py-2.5 text-[13px] text-neutral-500 transition-colors duration-150 hover:border-sky-400/40 hover:text-sky-300"
+        >
+          <Plus size={14} />
+          {t('customSection.add', { defaultValue: '添加自定义模块' })}
+        </button>
+
+        <CustomSectionDialog
+          open={creatingSection || editingSection !== null}
+          initial={editingSection ? { label: editingSection.label, icon: editingSection.icon } : undefined}
+          onOpenChange={(open) => {
+            if (open) return;
+            setCreatingSection(false);
+            setEditingSection(null);
+          }}
+          onSubmit={({ label, icon }) => {
+            if (editingSection) {
+              updateCustomSection(editingSection.key, { label, icon });
+            } else {
+              const key = addCustomSection(label, icon);
+              // Open it straight away — a new section with no visible form
+              // reads as though nothing happened.
+              if (key) setOpenSections(prev => ({ ...prev, [key]: true }));
+            }
+          }}
+        />
+
+        <ConfirmDialog
+          isOpen={deletingSection !== null}
+          onClose={() => setDeletingSection(null)}
+          title={t('customSection.deleteTitle', { defaultValue: '删除模块' })}
+          description={t('customSection.deleteHint', {
+            defaultValue: '「{{name}}」及其中的条目会一并删除，此操作无法撤销。',
+            name: deletingSection?.label ?? '',
+          })}
+          confirmText={t('common.delete', { defaultValue: '删除' })}
+          onConfirm={() => {
+            if (deletingSection) removeCustomSection(deletingSection.key);
+            setDeletingSection(null);
+          }}
+        />
       </DndContext>
     );
   }

--- a/apps/web/src/app/dashboard/edit/_components/ResumeEdit.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ResumeEdit.tsx
@@ -13,7 +13,7 @@ import { formFieldsFor } from '@/lib/constants/dynamicFormFields';
 import { isCustomSection } from '@/lib/utils/resumeSectionOrder';
 import CustomSectionDialog from './forms/CustomSectionDialog';
 import ConfirmDialog from '@/components/shared/ConfirmDialog';
-import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { Plus, SquarePen, Trash2 } from 'lucide-react';
 import {
   DndContext,
   closestCenter,
@@ -474,7 +474,7 @@ export default function ResumeEdit({ id }: ResumeEditProps) {
                       onClick={() => setEditingSection({ key, label: label || key, icon: iconName })}
                       className="flex h-7 w-7 items-center justify-center rounded-lg text-neutral-500 transition-colors hover:bg-white/[0.06] hover:text-neutral-200"
                     >
-                      <Pencil size={13} />
+                      <SquarePen size={13} />
                     </button>
                     <button
                       type="button"

--- a/apps/web/src/app/dashboard/edit/_components/forms/BasicForm.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/forms/BasicForm.tsx
@@ -47,6 +47,7 @@ export default function BasicForm({
         <AvatarField
           value={info.avatar}
           onChange={handleInfoChange}
+          onValueChange={(avatar) => updateInfo({ avatar })}
           alt={t('basicForm.avatarAlt')}
         />
       </div>

--- a/apps/web/src/app/dashboard/edit/_components/forms/BasicForm.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/forms/BasicForm.tsx
@@ -2,8 +2,8 @@
 import React from 'react';
 import type { InfoType } from '@/types/frontend/resume';
 import { useTranslation } from 'react-i18next';
-import { Plus, Trash2 } from 'lucide-react';
-import { TextField, AvatarField, FieldLabel, fieldInputClass } from './fields';
+import { TextField, AvatarField, FieldLabel } from './fields';
+import CustomFieldsEditor from './CustomFieldsEditor';
 
 type BasicFormProps = {
   info: InfoType;
@@ -22,28 +22,6 @@ export default function BasicForm({
 
   const handleInfoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     updateInfo({ [e.target.name]: e.target.value });
-  };
-
-  const handleCustomFieldChange = (id: string, key: 'name' | 'value', value: string) => {
-    const nextCustomFields = customFields.map(field =>
-      field.id === id ? { ...field, [key]: value } : field
-    );
-    updateInfo({ customFields: nextCustomFields });
-  };
-
-  const handleAddCustomField = () => {
-    updateInfo({
-      customFields: [
-        ...customFields,
-        { id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`, name: '', value: '' },
-      ],
-    });
-  };
-
-  const handleRemoveCustomField = (id: string) => {
-    updateInfo({
-      customFields: customFields.filter(field => field.id !== id),
-    });
   };
 
   type BasicField = {
@@ -86,44 +64,11 @@ export default function BasicForm({
       ))}
 
       {enableCustomFields && (
-        <div className="flex flex-col gap-2.5 pt-1">
-          <FieldLabel>{t('basicForm.customFields.title')}</FieldLabel>
-          <div className="flex flex-col gap-2">
-            {customFields.map(field => (
-              <div key={field.id} className="grid grid-cols-[1fr_1fr_auto] items-center gap-2">
-                <input
-                  value={field.name}
-                  onChange={(e) => handleCustomFieldChange(field.id, 'name', e.target.value)}
-                  placeholder={t('basicForm.customFields.namePlaceholder')}
-                  className={fieldInputClass}
-                />
-                <input
-                  value={field.value}
-                  onChange={(e) => handleCustomFieldChange(field.id, 'value', e.target.value)}
-                  placeholder={t('basicForm.customFields.valuePlaceholder')}
-                  className={fieldInputClass}
-                />
-                <button
-                  type="button"
-                  onClick={() => handleRemoveCustomField(field.id)}
-                  aria-label={t('common.delete')}
-                  title={t('common.delete')}
-                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] text-neutral-400 transition-colors duration-150 hover:border-red-500/40 hover:text-red-400"
-                >
-                  <Trash2 size={14} />
-                </button>
-              </div>
-            ))}
-          </div>
-          <button
-            type="button"
-            onClick={handleAddCustomField}
-            className="flex w-fit items-center gap-2 rounded-lg border border-dashed border-white/15 bg-white/[0.02] px-3 py-2 text-[12.5px] font-medium text-neutral-300 transition-colors duration-150 hover:border-sky-400/40 hover:text-white"
-          >
-            <Plus size={14} />
-            {t('basicForm.customFields.addButton')}
-          </button>
-        </div>
+        <CustomFieldsEditor
+          fields={customFields}
+          onChange={(next) => updateInfo({ customFields: next })}
+          title={t('basicForm.customFields.title')}
+        />
       )}
     </div>
   );

--- a/apps/web/src/app/dashboard/edit/_components/forms/CustomFieldsEditor.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/forms/CustomFieldsEditor.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { nanoid } from 'nanoid';
+import type { CustomInfoField } from '@/types/frontend/resume';
+import { FieldLabel, fieldInputClass } from './fields';
+
+type Props = {
+  fields: CustomInfoField[];
+  onChange: (fields: CustomInfoField[]) => void;
+  title: string;
+};
+
+/**
+ * Name/value pairs a user can add to a form.
+ *
+ * Lifted out of `BasicForm`, where it was written inline and gated to a single
+ * template, so item forms can offer the same thing. A custom section is
+ * whatever the candidate wrote — 获奖经历 wants an issuer, 开源贡献 wants stars
+ * — and no fixed field list is going to anticipate that.
+ *
+ * These render through an explicit block in `ListSection` / `DefaultSection`
+ * rather than through a template's fieldMap. That is the point: a key no
+ * fieldMap declares is dropped silently by `getFieldValue`, which is exactly
+ * how prose in `description` became invisible. A field the user typed has to
+ * be a field the user can see.
+ */
+export default function CustomFieldsEditor({ fields, onChange, title }: Props) {
+  const { t } = useTranslation();
+
+  const patch = (id: string, key: 'name' | 'value', value: string) =>
+    onChange(fields.map((f) => (f.id === id ? { ...f, [key]: value } : f)));
+
+  return (
+    <div className="flex flex-col gap-2.5 pt-1">
+      <FieldLabel>{title}</FieldLabel>
+      <div className="flex flex-col gap-2">
+        {fields.map((field) => (
+          <div
+            key={field.id}
+            className="grid grid-cols-[1fr_1fr_auto] items-center gap-2"
+          >
+            <input
+              value={field.name}
+              onChange={(e) => patch(field.id, 'name', e.target.value)}
+              placeholder={t('basicForm.customFields.namePlaceholder')}
+              className={fieldInputClass}
+            />
+            <input
+              value={field.value}
+              onChange={(e) => patch(field.id, 'value', e.target.value)}
+              placeholder={t('basicForm.customFields.valuePlaceholder')}
+              className={fieldInputClass}
+            />
+            <button
+              type="button"
+              onClick={() => onChange(fields.filter((f) => f.id !== field.id))}
+              aria-label={t('common.delete')}
+              title={t('common.delete')}
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-white/10 bg-white/[0.04] text-neutral-400 transition-colors duration-150 hover:border-red-500/40 hover:text-red-400"
+            >
+              <Trash2 size={14} />
+            </button>
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={() => onChange([...fields, { id: nanoid(), name: '', value: '' }])}
+        className="flex w-fit items-center gap-2 rounded-lg border border-dashed border-white/15 bg-white/[0.02] px-3 py-2 text-[12.5px] font-medium text-neutral-300 transition-colors duration-150 hover:border-sky-400/40 hover:text-white"
+      >
+        <Plus size={14} />
+        {t('basicForm.customFields.addButton')}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/app/dashboard/edit/_components/forms/CustomSectionDialog.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/forms/CustomSectionDialog.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { useTranslation } from 'react-i18next';
+import { SECTION_ICON_NAMES, sectionIconByName } from '@magic-resume/resume-templates';
+import { cn } from '@/lib/utils';
+
+type Props = {
+  open: boolean;
+  /** Present when editing; absent when creating. */
+  initial?: { label: string; icon?: string };
+  onSubmit: (value: { label: string; icon?: string }) => void;
+  onOpenChange: (open: boolean) => void;
+};
+
+/**
+ * Create or retitle a custom section.
+ *
+ * One dialog for both because the two differ only in their starting values —
+ * a separate "rename" surface would be the same three controls with a
+ * different heading, and would drift.
+ *
+ * The icon is optional on purpose. Left unset, the renderer still picks one by
+ * matching keywords in the title (`getSectionIcon`), which is right far more
+ * often than not — so the picker offers to override a good guess rather than
+ * demanding a decision before the section can exist.
+ */
+export default function CustomSectionDialog({
+  open,
+  initial,
+  onSubmit,
+  onOpenChange,
+}: Props) {
+  const { t } = useTranslation();
+  const [label, setLabel] = useState('');
+  const [icon, setIcon] = useState<string | undefined>(undefined);
+
+  // Reset on each open so a cancelled edit does not leak into the next one.
+  useEffect(() => {
+    if (!open) return;
+    setLabel(initial?.label ?? '');
+    setIcon(initial?.icon);
+  }, [open, initial?.label, initial?.icon]);
+
+  const trimmed = label.trim();
+  const submit = () => {
+    if (!trimmed) return;
+    onSubmit({ label: trimmed, icon });
+    onOpenChange(false);
+  };
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/70 backdrop-blur-sm" />
+        <DialogPrimitive.Content className="fixed left-1/2 top-1/2 z-50 w-[min(420px,calc(100vw-32px))] -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-white/10 bg-neutral-950 p-5 shadow-2xl">
+          <DialogPrimitive.Title className="text-[15px] font-semibold text-neutral-100">
+            {initial
+              ? t('customSection.renameTitle', { defaultValue: '重命名模块' })
+              : t('customSection.createTitle', { defaultValue: '添加自定义模块' })}
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="mt-1 text-[12px] text-neutral-500">
+            {t('customSection.hint', {
+              defaultValue: '模块标题会原样显示在简历上。',
+            })}
+          </DialogPrimitive.Description>
+
+          <input
+            autoFocus
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') submit();
+            }}
+            placeholder={t('customSection.placeholder', {
+              defaultValue: '例如：个人优势、获奖经历',
+            })}
+            className="mt-4 h-9 w-full rounded-lg border border-white/10 bg-white/[0.04] px-3 text-[13px] text-neutral-100 outline-none transition-colors placeholder:text-neutral-600 focus:border-sky-400/50"
+          />
+
+          <div className="mt-4">
+            <div className="mb-2 text-[12px] text-neutral-500">
+              {t('customSection.iconLabel', { defaultValue: '图标（可选）' })}
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {SECTION_ICON_NAMES.map((name) => {
+                const Icon = sectionIconByName(name);
+                if (!Icon) return null;
+                const active = icon === name;
+                return (
+                  <button
+                    key={name}
+                    type="button"
+                    aria-label={name}
+                    aria-pressed={active}
+                    // Clicking the active one clears it, so "let the app guess"
+                    // stays reachable after a choice has been made.
+                    onClick={() => setIcon(active ? undefined : name)}
+                    className={cn(
+                      'flex h-8 w-8 items-center justify-center rounded-lg border transition-colors duration-150',
+                      active
+                        ? 'border-sky-400/50 bg-sky-400/10 text-sky-300'
+                        : 'border-white/10 bg-white/[0.03] text-neutral-400 hover:text-neutral-100',
+                    )}
+                  >
+                    <Icon size={15} />
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          <div className="mt-5 flex justify-end gap-2">
+            <DialogPrimitive.Close className="h-8 rounded-lg border border-white/10 px-3 text-[13px] text-neutral-400 transition-colors hover:text-neutral-100">
+              {t('common.cancel', { defaultValue: '取消' })}
+            </DialogPrimitive.Close>
+            <button
+              type="button"
+              onClick={submit}
+              disabled={!trimmed}
+              className="h-8 rounded-lg bg-sky-500 px-3 text-[13px] font-medium text-white transition-opacity disabled:opacity-40"
+            >
+              {t('common.confirm', { defaultValue: '确定' })}
+            </button>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}

--- a/apps/web/src/app/dashboard/edit/_components/forms/FormSection.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/forms/FormSection.tsx
@@ -19,6 +19,7 @@ export default function FormSection({
   onToggle,
   registerRef,
   disabled = false,
+  actions,
   children,
 }: {
   sectionId: string;
@@ -28,6 +29,13 @@ export default function FormSection({
   onToggle: () => void;
   registerRef?: (el: HTMLElement | null) => void;
   disabled?: boolean;
+  /**
+   * Header controls, rendered before the chevron. Only custom sections get
+   * any — a built-in cannot be renamed (its label is an i18n key) or deleted
+   * (the editor expects its form to exist), so showing disabled controls for
+   * them would advertise something that is not on offer.
+   */
+  actions?: React.ReactNode;
   children: React.ReactNode;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
@@ -95,6 +103,10 @@ export default function FormSection({
             )}
           />
         </button>
+
+        {actions && (
+          <div className="flex shrink-0 items-center gap-0.5">{actions}</div>
+        )}
       </div>
 
       <AnimatePresence initial={false}>

--- a/apps/web/src/app/dashboard/edit/_components/forms/SectionListWithModal.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/forms/SectionListWithModal.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { nanoid } from 'nanoid';
+import CustomFieldsEditor from './CustomFieldsEditor';
+import type { CustomInfoField } from '@/types/frontend/resume';
 import { Button } from '@/components/ui/button';
 import {
   DndContext,
@@ -359,6 +361,13 @@ export default function SectionListWithModal<T extends BaseItem>({
               ))}
             </div>
           )}
+          <CustomFieldsEditor
+            fields={(currentItem?.customFields as unknown as CustomInfoField[]) || []}
+            onChange={(next) =>
+              currentItem && setCurrentItem({ ...currentItem, customFields: next })
+            }
+            title={t('basicForm.customFields.title')}
+          />
           <div className="space-y-2">
             <Label className="text-[13px] font-medium text-neutral-300">
               {t('modals.dynamicForm.descriptionLabel')}

--- a/apps/web/src/app/dashboard/edit/_components/forms/fields.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/forms/fields.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import React from "react";
-import Image from "next/image";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Upload, Loader2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { processAndStoreAvatar, AvatarError } from "@/lib/api/avatarUpload";
+import { ACCEPTED_IMAGE_ACCEPT_ATTR } from "@/lib/utils/image";
 
 /* ------------------------------------------------------------------ *
  * 左侧表单的统一控件 —— 与右侧自定义面板同一套深色工作台 + sky 风格。
@@ -66,39 +70,106 @@ export function TextField({
 export function AvatarField({
   value,
   onChange,
+  onValueChange,
   name = "avatar",
   alt,
   placeholder = "https://...",
 }: {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  /** 上传 / 清除后直接回写头像值(URL 或 data:URL) */
+  onValueChange?: (value: string) => void;
   name?: string;
   alt: string;
   placeholder?: string;
 }) {
+  const { t } = useTranslation();
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = React.useState(false);
+
+  const openPicker = () => {
+    if (!uploading) fileInputRef.current?.click();
+  };
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = ""; // 允许重复选同一个文件
+    if (!file) return;
+    setUploading(true);
+    try {
+      const next = await processAndStoreAvatar(file, value);
+      onValueChange?.(next);
+      toast.success(t("basicForm.avatarUpload.success"));
+    } catch (err) {
+      const code = err instanceof AvatarError ? err.code : "UPLOAD_FAILED";
+      toast.error(t(`basicForm.avatarUpload.errors.${code}`));
+    } finally {
+      setUploading(false);
+    }
+  };
+
   return (
     <div className="flex items-center gap-3">
-      {value ? (
-        <Image
-          src={value}
-          alt={alt}
-          width={40}
-          height={40}
-          unoptimized
-          className="h-10 w-10 shrink-0 rounded-full border border-white/10 object-cover"
+      <button
+        type="button"
+        onClick={openPicker}
+        disabled={uploading}
+        aria-label={t("basicForm.avatarUpload.button")}
+        title={t("basicForm.avatarUpload.button")}
+        className="group relative h-10 w-10 shrink-0 overflow-hidden rounded-full border border-white/10 bg-white/[0.04] outline-none transition-colors hover:border-sky-400/60 focus-visible:border-sky-400/60"
+      >
+        {value ? (
+          // 用原生 img:头像可能是 data:URL(self-hosted 内嵌),与简历模板保持一致渲染。
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={value} alt={alt} className="h-full w-full object-cover" />
+        ) : null}
+        <span
+          className={cn(
+            "absolute inset-0 flex items-center justify-center bg-black/50 text-white transition-opacity",
+            uploading
+              ? "opacity-100"
+              : value
+                ? "opacity-0 group-hover:opacity-100"
+                : "opacity-60 group-hover:opacity-100",
+          )}
+        >
+          {uploading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Upload className="h-3.5 w-3.5" />
+          )}
+        </span>
+      </button>
+
+      <div className="relative flex-1">
+        <input
+          id={name}
+          name={name}
+          type="text"
+          value={value ?? ""}
+          onChange={onChange}
+          placeholder={placeholder}
+          spellCheck={false}
+          className={cn(fieldInputClass, value && "pr-8")}
         />
-      ) : (
-        <div className="h-10 w-10 shrink-0 rounded-full border border-white/10 bg-white/[0.04]" />
-      )}
+        {value ? (
+          <button
+            type="button"
+            onClick={() => onValueChange?.("")}
+            aria-label={t("basicForm.avatarUpload.clear")}
+            className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-neutral-500 transition-colors hover:text-neutral-200"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        ) : null}
+      </div>
+
       <input
-        id={name}
-        name={name}
-        type="text"
-        value={value ?? ""}
-        onChange={onChange}
-        placeholder={placeholder}
-        spellCheck={false}
-        className={fieldInputClass}
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPTED_IMAGE_ACCEPT_ATTR}
+        onChange={handleFile}
+        className="hidden"
       />
     </div>
   );

--- a/apps/web/src/app/dashboard/edit/_components/layout/OutlineRail.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/layout/OutlineRail.tsx
@@ -14,6 +14,7 @@ import {
   PanelLeft,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { sectionIconByName } from "@magic-resume/resume-templates";
 import { cn } from "@/lib/utils";
 import AccountMenu from "@/components/shared/AccountMenu";
 
@@ -38,7 +39,17 @@ const SECTION_META: Record<string, Meta> = {
   profiles: { icon: Contact, labelKey: "sections.profiles" },
 };
 
-export function sectionMeta(key: string): Meta {
+/**
+ * Icon and label for a section in the editor.
+ *
+ * `iconName` is the user's explicit choice from `sectionOrder.icon`; it
+ * outranks the built-in map so a section wears the same icon in the form as it
+ * does on the rendered page — both resolve through `sectionIconByName`.
+ * `FileText` remains the last resort for a custom section nobody has styled.
+ */
+export function sectionMeta(key: string, iconName?: string): Meta {
+  const chosen = sectionIconByName(iconName);
+  if (chosen) return { ...(SECTION_META[key] ?? {}), icon: chosen };
   return SECTION_META[key] ?? { icon: FileText };
 }
 

--- a/apps/web/src/lib/api/avatarUpload.ts
+++ b/apps/web/src/lib/api/avatarUpload.ts
@@ -1,0 +1,66 @@
+import { isCloudMode } from '@/lib/config/app';
+import { compressAvatarImage, ACCEPTED_IMAGE_TYPES } from '@/lib/utils/image';
+import { WEB_AGENT_ROUTES } from '@/lib/api/routes';
+
+/** 用户选图后的最大原始大小(压缩前)。太离谱的直接拒,连解码都省了。 */
+const MAX_INPUT_BYTES = 15 * 1024 * 1024;
+
+export type AvatarUploadError =
+  | 'UNSUPPORTED_TYPE'
+  | 'TOO_LARGE'
+  | 'PROCESS_FAILED'
+  | 'UPLOAD_FAILED';
+
+export class AvatarError extends Error {
+  code: AvatarUploadError;
+  constructor(code: AvatarUploadError) {
+    super(code);
+    this.code = code;
+  }
+}
+
+/**
+ * 处理并"落地"一张头像,返回可写入 info.avatar 的字符串。
+ *  - cloud 模式:压缩后 POST 到 /api/uploads/avatar → 返回 R2 公开 URL;
+ *  - self-hosted 模式:压缩后返回 data:URL,直接内嵌进简历 JSON(零后端)。
+ *
+ * @param prevUrl 旧头像值(用于 cloud 模式删除旧对象,self-hosted 忽略)
+ */
+export async function processAndStoreAvatar(file: File, prevUrl?: string): Promise<string> {
+  if (!ACCEPTED_IMAGE_TYPES.includes(file.type as (typeof ACCEPTED_IMAGE_TYPES)[number])) {
+    throw new AvatarError('UNSUPPORTED_TYPE');
+  }
+  if (file.size > MAX_INPUT_BYTES) {
+    throw new AvatarError('TOO_LARGE');
+  }
+
+  let compressed;
+  try {
+    compressed = await compressAvatarImage(file);
+  } catch {
+    throw new AvatarError('PROCESS_FAILED');
+  }
+
+  // self-hosted:没有后端,直接内嵌。
+  if (!isCloudMode) {
+    return compressed.dataUrl;
+  }
+
+  // cloud:传 R2。
+  const form = new FormData();
+  form.append('file', compressed.blob, 'avatar.jpg');
+  if (prevUrl) form.append('prevUrl', prevUrl);
+
+  let res: Response;
+  try {
+    res = await fetch(WEB_AGENT_ROUTES.avatarUpload, { method: 'POST', body: form });
+  } catch {
+    throw new AvatarError('UPLOAD_FAILED');
+  }
+  if (!res.ok) {
+    throw new AvatarError(res.status === 413 ? 'TOO_LARGE' : 'UPLOAD_FAILED');
+  }
+  const data = (await res.json()) as { url?: string };
+  if (!data.url) throw new AvatarError('UPLOAD_FAILED');
+  return data.url;
+}

--- a/apps/web/src/lib/api/routes.ts
+++ b/apps/web/src/lib/api/routes.ts
@@ -84,4 +84,5 @@ export const WEB_AGENT_ROUTES = {
   chatSession:      '/api/chat-agent/session',
   chatEdit:         '/api/chat-agent/edit',
   pdfParse:         '/api/pdf/parse',
+  avatarUpload:     '/api/uploads/avatar',
 } as const;

--- a/apps/web/src/lib/constants/dynamicFormFields.ts
+++ b/apps/web/src/lib/constants/dynamicFormFields.ts
@@ -51,6 +51,19 @@ const certificatesFields: FieldConfig[] = [
     { key: 'date', labelKey: 'dynamicForm.fields.certificates.date.label', type: 'input', placeholderKey: 'dynamicForm.fields.certificates.date.placeholder' },
 ];
 
+/**
+ * Fields for a section the app does not know about — one the resume brought
+ * with it, or one the user created.
+ *
+ * Kept to the two that mean the same thing in any section: a heading and a
+ * date. Everything else a custom section wants goes in the rich-text box
+ * (bound to `summary` for every section) or in the item's own custom fields.
+ */
+const customSectionFields: FieldConfig[] = [
+    { key: 'name', labelKey: 'dynamicForm.fields.custom.name.label', type: 'input', placeholderKey: 'dynamicForm.fields.custom.name.placeholder', required: true },
+    { key: 'date', labelKey: 'dynamicForm.fields.custom.date.label', type: 'input', placeholderKey: 'dynamicForm.fields.custom.date.placeholder' },
+];
+
 export const dynamicFormFields: Record<string, FieldConfig[]> = {
     education: educationFields,
     experience: experienceFields,
@@ -60,4 +73,9 @@ export const dynamicFormFields: Record<string, FieldConfig[]> = {
     languages: languagesFields,
     certificates: certificatesFields,
 };
+
+/** Fields for `key`, falling back to the generic set for a custom section. */
+export function formFieldsFor(key: string): FieldConfig[] {
+    return dynamicFormFields[key] ?? customSectionFields;
+}
   

--- a/apps/web/src/lib/constants/sidebarMenu.tsx
+++ b/apps/web/src/lib/constants/sidebarMenu.tsx
@@ -26,8 +26,8 @@ const sidebarMenu: SidebarMenuItem[] = [
     label: 'sections.projects',
     itemRender: (item) => (
       <div className="flex min-w-0 flex-col gap-2">
-        <div className="truncate font-bold text-sm">{item.name}</div>
-        <div className="truncate text-xs text-neutral-400">{item.role}</div>
+        <div className="truncate font-bold text-sm">{String(item.name ?? '')}</div>
+        <div className="truncate text-xs text-neutral-400">{String(item.role ?? '')}</div>
       </div>
     )
   },
@@ -38,8 +38,8 @@ const sidebarMenu: SidebarMenuItem[] = [
     formFields: dynamicFormFields.education,
     itemRender: (item) => (
       <div className="flex min-w-0 flex-col gap-2">
-        <div className="truncate font-bold text-sm">{item.school}</div>
-        <div className="truncate text-xs text-neutral-400">{item.major}</div>
+        <div className="truncate font-bold text-sm">{String(item.school ?? '')}</div>
+        <div className="truncate text-xs text-neutral-400">{String(item.major ?? '')}</div>
       </div>
     )
   },
@@ -48,13 +48,13 @@ const sidebarMenu: SidebarMenuItem[] = [
     icon: Zap,
     label: 'sections.skills',
     // 技能条目的 name 往往是整句描述,限制两行防止卡片被撑高
-    itemRender: (item) => <div className="line-clamp-2 font-bold text-sm">{item.name}</div>
+    itemRender: (item) => <div className="line-clamp-2 font-bold text-sm">{String(item.name ?? '')}</div>
   },
   {
     key: 'languages',
     icon: Globe,
     label: 'sections.languages',
-    itemRender: (item) => <div className="truncate font-bold text-sm">{item.language}</div>
+    itemRender: (item) => <div className="truncate font-bold text-sm">{String(item.language ?? '')}</div>
   },
   {
     key: 'certificates',
@@ -64,8 +64,8 @@ const sidebarMenu: SidebarMenuItem[] = [
     // 不是 certificate——旧写法取不到值,列表行会整行空白。
     itemRender: (item) => (
       <div className="flex min-w-0 flex-col gap-2">
-        <div className="truncate font-bold text-sm">{item.name}</div>
-        <div className="truncate text-xs text-neutral-400">{item.issuer}</div>
+        <div className="truncate font-bold text-sm">{String(item.name ?? '')}</div>
+        <div className="truncate text-xs text-neutral-400">{String(item.issuer ?? '')}</div>
       </div>
     )
   },
@@ -76,8 +76,8 @@ const sidebarMenu: SidebarMenuItem[] = [
     formFields: dynamicFormFields.experience,
     itemRender: (item) => (
       <div className="flex min-w-0 flex-col gap-2">
-        <div className="truncate font-bold text-sm">{item.company}</div>
-        <div className="truncate text-xs text-neutral-400">{item.location}</div>
+        <div className="truncate font-bold text-sm">{String(item.company ?? '')}</div>
+        <div className="truncate text-xs text-neutral-400">{String(item.location ?? '')}</div>
       </div>
     )
   },
@@ -88,8 +88,8 @@ const sidebarMenu: SidebarMenuItem[] = [
   //   formFields: dynamicFormFields.profiles,
   //   itemRender: (item) => (
   //     <div className="flex flex-col gap-2 max-w-[155px] ">
-  //       <div className="font-bold text-sm">{item.platform}</div>
-  //       <div className="text-xs text-neutral-400">{item.url}</div>
+  //       <div className="font-bold text-sm">{String(item.platform ?? '')}</div>
+  //       <div className="text-xs text-neutral-400">{String(item.url ?? '')}</div>
   //     </div>
   //   )
   // }

--- a/apps/web/src/lib/storage/r2.ts
+++ b/apps/web/src/lib/storage/r2.ts
@@ -1,0 +1,58 @@
+import 'server-only';
+import { S3Client } from '@aws-sdk/client-s3';
+
+/**
+ * Cloudflare R2 服务端接入(S3 兼容 API)。密钥只在服务端读,永不出网到浏览器。
+ *
+ * 需要的环境变量(见 .env.example):
+ *  - R2_ACCOUNT_ID          Cloudflare 账号 ID
+ *  - R2_ACCESS_KEY_ID       R2 API Token 的 Access Key ID
+ *  - R2_SECRET_ACCESS_KEY   R2 API Token 的 Secret
+ *  - R2_BUCKET              桶名(magic-resume-assets)
+ *  - R2_PUBLIC_BASE_URL     公开读地址,无尾斜杠(如 https://pub-xxxx.r2.dev 或自定义域名)
+ */
+
+export const R2_BUCKET = process.env.R2_BUCKET ?? '';
+export const R2_PUBLIC_BASE_URL = (process.env.R2_PUBLIC_BASE_URL ?? '').replace(/\/+$/, '');
+
+const accountId = process.env.R2_ACCOUNT_ID ?? '';
+const accessKeyId = process.env.R2_ACCESS_KEY_ID ?? '';
+const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY ?? '';
+
+/** 五个变量齐了才算配好;没配好时上传 route 返回 503 而不是崩。 */
+export function isR2Configured(): boolean {
+  return Boolean(accountId && accessKeyId && secretAccessKey && R2_BUCKET && R2_PUBLIC_BASE_URL);
+}
+
+let client: S3Client | null = null;
+
+export function getR2Client(): S3Client {
+  if (!isR2Configured()) throw new Error('R2_NOT_CONFIGURED');
+  if (!client) {
+    client = new S3Client({
+      region: 'auto',
+      endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+      credentials: { accessKeyId, secretAccessKey },
+    });
+  }
+  return client;
+}
+
+export function publicUrlForKey(key: string): string {
+  return `${R2_PUBLIC_BASE_URL}/${key}`;
+}
+
+/**
+ * 从一个公开 URL 反解出对象 key —— 仅当它确实是本桶公开地址下、
+ * 且落在 `avatars/<userId>/` 前缀里时才返回,否则 null。
+ * 用于「换头像删旧对象」时防止越权删到别人 / 别的路径的对象。
+ */
+export function ownAvatarKeyFromUrl(url: string | undefined | null, userId: string): string | null {
+  if (!url || !R2_PUBLIC_BASE_URL) return null;
+  const prefix = `${R2_PUBLIC_BASE_URL}/`;
+  if (!url.startsWith(prefix)) return null;
+  const key = decodeURIComponent(url.slice(prefix.length).split('?')[0]);
+  const expected = `avatars/${userId}/`;
+  if (!key.startsWith(expected) || key.includes('..')) return null;
+  return key;
+}

--- a/apps/web/src/lib/utils/image.ts
+++ b/apps/web/src/lib/utils/image.ts
@@ -1,0 +1,148 @@
+/**
+ * 客户端头像图片预处理 —— 在上传 / 内嵌前先在浏览器里把图压小。
+ *
+ * 输出 JPEG(不是 webp):头像是照片,JPEG 体积和 webp 接近(~几十 KB),而且
+ * react-pdf 原生支持 JPEG —— webp 会让 PDF 渲染报 "Base64 image invalid format: webp"。
+ *
+ *  - 统一缩到 ≤512px、转 JPEG,循环降质直到 ≤ maxBytes(默认 ~120KB);
+ *  - self-hosted 直接拿 dataUrl 内嵌进简历 JSON,不落任何后端;
+ *  - cloud 拿 blob 传到 R2,单张只占几十 KB,存储与流量都可忽略。
+ */
+
+/** 允许的输入图片类型(魔数/扩展兜底由服务端再校验一次)。SVG 一律拒绝(XSS)。 */
+export const ACCEPTED_IMAGE_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+] as const;
+
+export const ACCEPTED_IMAGE_ACCEPT_ATTR = ACCEPTED_IMAGE_TYPES.join(',');
+
+export type CompressedImage = {
+  /** JPEG 编码后的二进制,用于上传 R2 */
+  blob: Blob;
+  /** data:image/jpeg;base64,... —— 用于 self-hosted 内嵌 */
+  dataUrl: string;
+  width: number;
+  height: number;
+  bytes: number;
+};
+
+export type CompressOptions = {
+  /** 最长边像素上限 */
+  maxDimension?: number;
+  /** 目标字节上限,超了就继续降质/降尺寸 */
+  maxBytes?: number;
+  /** 起始 JPEG 质量 */
+  quality?: number;
+};
+
+const DEFAULTS = {
+  maxDimension: 512,
+  maxBytes: 120 * 1024,
+  quality: 0.9,
+} satisfies Required<CompressOptions>;
+
+function loadImage(file: Blob): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('IMAGE_DECODE_FAILED'));
+    };
+    img.src = url;
+  });
+}
+
+function canvasToJpegBlob(canvas: HTMLCanvasElement, quality: number): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error('CANVAS_ENCODE_FAILED'))),
+      'image/jpeg',
+      quality,
+    );
+  });
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error('BLOB_READ_FAILED'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+function drawScaled(img: HTMLImageElement, maxDimension: number) {
+  const ratio = Math.min(1, maxDimension / Math.max(img.naturalWidth, img.naturalHeight));
+  const width = Math.max(1, Math.round(img.naturalWidth * ratio));
+  const height = Math.max(1, Math.round(img.naturalHeight * ratio));
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('CANVAS_UNAVAILABLE');
+  // JPEG 无 alpha:先铺白底,否则透明 PNG 的透明区在 JPEG 里会变黑。
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, width, height);
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = 'high';
+  ctx.drawImage(img, 0, 0, width, height);
+  return { canvas, width, height };
+}
+
+/**
+ * 把用户选的图压成受控大小的 JPEG。
+ * 先按 maxDimension 缩放,再从 quality 起逐档降质;若最低质量仍超 maxBytes,
+ * 就把尺寸再砍一半重试,直到达标或到最小尺寸。
+ */
+export async function compressAvatarImage(
+  file: File,
+  options: CompressOptions = {},
+): Promise<CompressedImage> {
+  const { maxDimension, maxBytes, quality } = { ...DEFAULTS, ...options };
+
+  const img = await loadImage(file);
+
+  let dimension = maxDimension;
+  let best: Blob | null = null;
+
+  // 外层:尺寸阶梯(512 → 384 → …),内层:质量阶梯。取第一个 ≤ maxBytes 的结果。
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const { canvas } = drawScaled(img, dimension);
+    for (let q = quality; q >= 0.4; q -= 0.15) {
+      const blob = await canvasToJpegBlob(canvas, q);
+      if (!best || blob.size < best.size) best = blob;
+      if (blob.size <= maxBytes) {
+        const dataUrl = await blobToDataUrl(blob);
+        return {
+          blob,
+          dataUrl,
+          width: canvas.width,
+          height: canvas.height,
+          bytes: blob.size,
+        };
+      }
+    }
+    dimension = Math.round(dimension * 0.75);
+    if (dimension < 96) break;
+  }
+
+  // 兜底:即使没压到目标也返回当前最小的(极端图),服务端还有硬上限拦截。
+  const fallback = best ?? (await canvasToJpegBlob(drawScaled(img, dimension).canvas, 0.4));
+  const dataUrl = await blobToDataUrl(fallback);
+  return {
+    blob: fallback,
+    dataUrl,
+    width: 0,
+    height: 0,
+    bytes: fallback.size,
+  };
+}

--- a/apps/web/src/lib/utils/resumeMigrations.ts
+++ b/apps/web/src/lib/utils/resumeMigrations.ts
@@ -1,0 +1,81 @@
+import type { Resume, Section, SectionItem } from '@/types/frontend/resume';
+
+/**
+ * Repairs applied to a resume on its way out of storage.
+ *
+ * Both of these exist because a resume saved by an older build is still a
+ * resume someone is editing today — they cannot be fixed by changing what new
+ * imports write.
+ */
+
+/**
+ * `summary` is the only rich-text field the product uses: the editor binds its
+ * rich-text box to it for every section, and of the thirteen templates only
+ * `product-ops-focus` maps `description`. Imports written before that was
+ * settled put prose in `description`, where it is stored, invisible in twelve
+ * templates, and un-editable in all of them — the resume looks like the import
+ * dropped it.
+ *
+ * `description` is left in place: `product-ops-focus` reads it, and removing a
+ * key gains nothing.
+ */
+function preferSummary(item: SectionItem): SectionItem {
+  const summary = item.summary;
+  const description = item.description;
+  const summaryEmpty = typeof summary !== 'string' || !summary.trim();
+  if (summaryEmpty && typeof description === 'string' && description.trim()) {
+    return { ...item, summary: description };
+  }
+  return item;
+}
+
+function migrateSections(sections: Section | undefined): {
+  sections: Section;
+  changed: boolean;
+} {
+  const source = sections ?? ({} as Section);
+  let changed = false;
+
+  const migrated = Object.fromEntries(
+    Object.entries(source).map(([key, items]) => [
+      key,
+      (items ?? []).map((item) => {
+        const next = preferSummary(item);
+        if (next !== item) changed = true;
+        return next;
+      }),
+    ]),
+  ) as Section;
+
+  return { sections: changed ? migrated : source, changed };
+}
+
+/**
+ * Bring a stored resume up to what the current editor expects.
+ *
+ * Returns the original object when nothing needed changing, so callers can use
+ * identity to avoid a pointless write and a spurious "modified" sync status.
+ *
+ * Replaces the two hand-written copies of the `basics` repair that used to sit
+ * in either branch of `loadResumeForEdit` — one place is also one place to add
+ * the next repair to.
+ */
+export function migrateResume(resume: Resume): Resume {
+  const { sections, changed: sectionsChanged } = migrateSections(
+    resume.sections,
+  );
+
+  // `basics` drives the editor's first form. A resume written before it existed
+  // has no entry for it and opens without the name/contact fields.
+  const hasBasics = (resume.sectionOrder ?? []).some((s) => s.key === 'basics');
+
+  if (!sectionsChanged && hasBasics) return resume;
+
+  return {
+    ...resume,
+    sections,
+    sectionOrder: hasBasics
+      ? resume.sectionOrder
+      : [{ key: 'basics', label: 'Basics' }, ...(resume.sectionOrder ?? [])],
+  };
+}

--- a/apps/web/src/lib/utils/resumeSectionOrder.ts
+++ b/apps/web/src/lib/utils/resumeSectionOrder.ts
@@ -46,3 +46,42 @@ export function normalizeResumeSectionOrder(
 
   return [{ key: 'basics', label: 'Basics' }, ...normalized];
 }
+
+/**
+ * A section the app did not define — imported from a resume, or created by the
+ * user.
+ *
+ * The distinction is load-bearing: only these can be renamed or deleted. A
+ * built-in section's label is an i18n key (`sections.skills`), so renaming one
+ * would replace a translated string with a literal and break every other
+ * language; and deleting one would take away a form the editor expects.
+ */
+export function isCustomSection(key: string): boolean {
+  return key !== 'basics' && !DEFAULT_LABELS.has(key);
+}
+
+/**
+ * A stable, collision-free key for a new custom section.
+ *
+ * Derived from the title so the JSON stays readable, but never trusted to be
+ * unique or even non-empty — a title can be Chinese, punctuation, or a
+ * duplicate of an existing section.
+ */
+export function customSectionKey(
+  title: string,
+  existingKeys: Iterable<string>,
+): string {
+  const taken = new Set(existingKeys);
+  const slug = title
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 24);
+  const base = slug || 'section';
+
+  let key = base;
+  let n = 2;
+  while (taken.has(key)) key = `${base}-${n++}`;
+  return key;
+}

--- a/apps/web/src/lib/validation/importResume.ts
+++ b/apps/web/src/lib/validation/importResume.ts
@@ -1,4 +1,5 @@
 import { z, type ZodError } from 'zod';
+import { nanoid } from 'nanoid';
 import { normalizeResumeSectionOrder } from '@/lib/utils/resumeSectionOrder';
 
 const importedResumeInfoSchema = z.object({
@@ -60,6 +61,31 @@ export const importedResumeSchema = z.object({
 
 export type ImportedResume = z.infer<typeof importedResumeSchema> & Record<string, unknown>;
 
+/**
+ * Give every imported item the same kind of id the app mints for itself.
+ *
+ * An imported id is whatever the source said — for a PDF that is whatever the
+ * model wrote, and the model copies the prompt's example, so real resumes
+ * arrived full of `skill-1` / `exp-1`. Those are not the app's ids (it uses
+ * `nanoid()` in `SectionListWithModal`), and nothing anywhere deduplicated
+ * them: a model that numbers two sections from 1, or repeats itself, produces
+ * colliding React keys and a drag-and-drop list that reorders the wrong row.
+ *
+ * Reissuing here rather than in the backend normalizer puts it on the one path
+ * both imports share — PDF and JSON — and makes the guarantee independent of
+ * whatever produced the file.
+ */
+function reissueItemIds(
+  sections: Record<string, Array<Record<string, unknown>>>,
+): Record<string, Array<Record<string, unknown>>> {
+  return Object.fromEntries(
+    Object.entries(sections).map(([key, items]) => [
+      key,
+      (items ?? []).map((item) => ({ ...item, id: nanoid() })),
+    ]),
+  );
+}
+
 export function validateAndNormalizeImportedResume(data: unknown): ImportedResume {
   const parsed = importedResumeSchema.parse(data);
   const raw = { ...(data as Record<string, unknown>) };
@@ -68,11 +94,15 @@ export function validateAndNormalizeImportedResume(data: unknown): ImportedResum
   delete raw.shareId;
   delete raw.shareRole;
 
+  const sections = reissueItemIds(
+    parsed.sections as Record<string, Array<Record<string, unknown>>>,
+  );
+
   return {
     ...raw,
     info: parsed.info,
-    sections: parsed.sections,
-    sectionOrder: normalizeResumeSectionOrder(parsed.sectionOrder, parsed.sections),
+    sections: sections as typeof parsed.sections,
+    sectionOrder: normalizeResumeSectionOrder(parsed.sectionOrder, sections),
   };
 }
 

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -851,7 +851,18 @@
       "valuePlaceholder": "Value (e.g., your-linkedin-url)",
       "addButton": "Add Custom Field"
     },
-    "avatarAlt": "Avatar"
+    "avatarAlt": "Avatar",
+    "avatarUpload": {
+      "button": "Upload photo",
+      "clear": "Remove photo",
+      "success": "Photo updated",
+      "errors": {
+        "UNSUPPORTED_TYPE": "Unsupported image type (PNG / JPG / WebP / GIF only)",
+        "TOO_LARGE": "Image is too large, pick a smaller one",
+        "PROCESS_FAILED": "Couldn't process the image, try another",
+        "UPLOAD_FAILED": "Upload failed, please retry"
+      }
+    }
   },
   "header": {
     "version": "Version Management",

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -1141,47 +1141,92 @@
   "dynamicForm": {
     "fields": {
       "education": {
-        "school": { "label": "School", "placeholder": "School Name" },
-        "degree": { "label": "Degree", "placeholder": "Degree" },
-        "major": { "label": "Major", "placeholder": "Major" },
-        "date": { "label": "Date or Date Range", "placeholder": "2019-2023" },
-        "location": { "label": "Location", "placeholder": "City" }
+        "school": {
+          "label": "School",
+          "placeholder": "School Name"
+        },
+        "degree": {
+          "label": "Degree",
+          "placeholder": "Degree"
+        },
+        "major": {
+          "label": "Major",
+          "placeholder": "Major"
+        },
+        "date": {
+          "label": "Date or Date Range",
+          "placeholder": "2019-2023"
+        },
+        "location": {
+          "label": "Location",
+          "placeholder": "City"
+        }
       },
       "experience": {
-        "company": { "label": "Company", "placeholder": "Company Name" },
-        "position": { "label": "Position", "placeholder": "Position" },
+        "company": {
+          "label": "Company",
+          "placeholder": "Company Name"
+        },
+        "position": {
+          "label": "Position",
+          "placeholder": "Position"
+        },
         "date": {
           "label": "Date or Date Range",
           "placeholder": "March 2023 - Present"
         },
-        "location": { "label": "Location", "placeholder": "City" },
-        "website": { "label": "Website", "placeholder": "Website URL" }
+        "location": {
+          "label": "Location",
+          "placeholder": "City"
+        },
+        "website": {
+          "label": "Website",
+          "placeholder": "Website URL"
+        }
       },
       "profiles": {
         "platform": {
           "label": "Platform",
           "placeholder": "e.g., LinkedIn, GitHub"
         },
-        "url": { "label": "URL", "placeholder": "URL" }
+        "url": {
+          "label": "URL",
+          "placeholder": "URL"
+        }
       },
       "skills": {
-        "name": { "label": "Skill Name", "placeholder": "Skill Name" },
+        "name": {
+          "label": "Skill Name",
+          "placeholder": "Skill Name"
+        },
         "level": {
           "label": "Level",
           "placeholder": "e.g., Expert, Intermediate, Beginner"
         }
       },
       "projects": {
-        "name": { "label": "Project Name", "placeholder": "Project Name" },
-        "role": { "label": "Role", "placeholder": "Your Role" },
+        "name": {
+          "label": "Project Name",
+          "placeholder": "Project Name"
+        },
+        "role": {
+          "label": "Role",
+          "placeholder": "Your Role"
+        },
         "date": {
           "label": "Date or Date Range",
           "placeholder": "Jan 2022 - Dec 2022"
         },
-        "link": { "label": "Link", "placeholder": "Project Link" }
+        "link": {
+          "label": "Link",
+          "placeholder": "Project Link"
+        }
       },
       "languages": {
-        "language": { "label": "Language", "placeholder": "Language" },
+        "language": {
+          "label": "Language",
+          "placeholder": "Language"
+        },
         "level": {
           "label": "Level",
           "placeholder": "e.g., Native, Fluent, Intermediate"
@@ -1192,8 +1237,24 @@
           "label": "Certificate Name",
           "placeholder": "Certificate Name"
         },
-        "issuer": { "label": "Issuer", "placeholder": "Issuing Organization" },
-        "date": { "label": "Date", "placeholder": "Date Received" }
+        "issuer": {
+          "label": "Issuer",
+          "placeholder": "Issuing Organization"
+        },
+        "date": {
+          "label": "Date",
+          "placeholder": "Date Received"
+        }
+      },
+      "custom": {
+        "name": {
+          "label": "Title",
+          "placeholder": "Item title"
+        },
+        "date": {
+          "label": "Date",
+          "placeholder": "e.g. 2023.06"
+        }
       }
     }
   },
@@ -1477,7 +1538,11 @@
       "addCustom": "Add a custom model in settings",
       "noModel": "Configure a model in settings first",
       "strengthLabel": "Reasoning",
-      "strength": { "low": "Low", "medium": "Medium", "high": "High" }
+      "strength": {
+        "low": "Low",
+        "medium": "Medium",
+        "high": "High"
+      }
     },
     "widgets": {
       "unsupported": "(Unable to render card: {{kind}})",
@@ -1621,5 +1686,16 @@
     "profile": "Profile",
     "contact": "Contact",
     "awards": "Awards"
+  },
+  "customSection": {
+    "add": "Add custom section",
+    "createTitle": "Add custom section",
+    "renameTitle": "Rename section",
+    "rename": "Rename",
+    "hint": "The title appears on the resume exactly as you write it.",
+    "placeholder": "e.g. Highlights, Awards",
+    "iconLabel": "Icon (optional)",
+    "deleteTitle": "Delete section",
+    "deleteHint": "\"{{name}}\" and everything in it will be deleted. This cannot be undone."
   }
 }

--- a/apps/web/src/locales/zh/translation.json
+++ b/apps/web/src/locales/zh/translation.json
@@ -851,7 +851,18 @@
       "valuePlaceholder": "值（例如，your-linkedin-url）",
       "addButton": "添加自定义字段"
     },
-    "avatarAlt": "头像"
+    "avatarAlt": "头像",
+    "avatarUpload": {
+      "button": "上传头像",
+      "clear": "移除头像",
+      "success": "头像已更新",
+      "errors": {
+        "UNSUPPORTED_TYPE": "不支持的图片格式（仅 PNG / JPG / WebP / GIF）",
+        "TOO_LARGE": "图片太大了，换一张小一点的",
+        "PROCESS_FAILED": "图片处理失败，换一张试试",
+        "UPLOAD_FAILED": "上传失败，请重试"
+      }
+    }
   },
   "header": {
     "version": "版本管理",

--- a/apps/web/src/locales/zh/translation.json
+++ b/apps/web/src/locales/zh/translation.json
@@ -1245,6 +1245,16 @@
           "label": "获得时间",
           "placeholder": "获得时间"
         }
+      },
+      "custom": {
+        "name": {
+          "label": "标题",
+          "placeholder": "条目标题"
+        },
+        "date": {
+          "label": "时间",
+          "placeholder": "例如：2023.06"
+        }
       }
     }
   },
@@ -1528,7 +1538,11 @@
       "addCustom": "在设置里添加自定义模型",
       "noModel": "请先在设置里配置模型",
       "strengthLabel": "推理强度",
-      "strength": { "low": "低", "medium": "中", "high": "高" }
+      "strength": {
+        "low": "低",
+        "medium": "中",
+        "high": "高"
+      }
     },
     "widgets": {
       "unsupported": "（无法渲染的卡片：{{kind}}）",
@@ -1672,5 +1686,16 @@
     "profile": "个人信息",
     "contact": "联系方式",
     "awards": "奖项"
+  },
+  "customSection": {
+    "add": "添加自定义模块",
+    "createTitle": "添加自定义模块",
+    "renameTitle": "重命名模块",
+    "rename": "重命名",
+    "hint": "模块标题会原样显示在简历上。",
+    "placeholder": "例如：个人优势、获奖经历",
+    "iconLabel": "图标（可选）",
+    "deleteTitle": "删除模块",
+    "deleteHint": "「{{name}}」及其中的条目会一并删除，此操作无法撤销。"
   }
 }

--- a/apps/web/src/store/useResumeStore.ts
+++ b/apps/web/src/store/useResumeStore.ts
@@ -12,7 +12,7 @@ import { compare as compareJsonDocs } from 'fast-json-patch';
 import { isAxiosError } from 'axios';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
-import { normalizeResumeSectionOrder } from '@/lib/utils/resumeSectionOrder';
+import { normalizeResumeSectionOrder, isCustomSection, customSectionKey } from '@/lib/utils/resumeSectionOrder';
 import { migrateResume } from '@/lib/utils/resumeMigrations';
 import {
   Resume,
@@ -95,6 +95,12 @@ type ResumeState = {
   updateInfo: (info: Partial<InfoType>) => void;
   setSectionOrder: (sectionOrder: SectionOrder[]) => void;
   updateSectionItems: (key: string, items: SectionItem[]) => void;
+  /** Create a section the app does not define. Returns its generated key. */
+  addCustomSection: (title: string, icon?: string) => string | null;
+  /** Retitle / re-icon a section. Built-ins are refused — see isCustomSection. */
+  updateCustomSection: (key: string, patch: { label?: string; icon?: string }) => void;
+  /** Delete a custom section and its items. Built-ins are refused. */
+  removeCustomSection: (key: string) => void;
   updateSections: (sections: Section) => void;
   updateTemplate: (template: string) => void;
   updateCustomTemplate: (customTemplate: CustomTemplateConfig) => void;
@@ -898,6 +904,96 @@ const useResumeStore = create<ResumeState>()(
       const resumeIndex = state.resumes.findIndex(r => r.id === state.activeResume?.id);
       if (resumeIndex !== -1) {
         state.resumes[resumeIndex].sections[key] = items;
+        state.resumes[resumeIndex].updatedAt = state.activeResume.updatedAt;
+      }
+
+      const isCloudSyncOn = useSettingStore.getState().cloudSync;
+      state.syncStatus = isCloudSyncOn ? 'modified' : 'local';
+    });
+  },
+
+  /**
+   * Sections the app does not define are the user's to create, rename and
+   * delete; the built-in six are not. A built-in's label is an i18n key
+   * (`sections.skills`), so renaming one would swap a translated string for a
+   * literal and break every other language, and deleting one would remove a
+   * form the editor expects to exist. The guards below are that rule, not a
+   * defensive flourish.
+   */
+  addCustomSection: (title, icon) => {
+    const { activeResume } = get();
+    if (!activeResume) return null;
+
+    const label = title.trim();
+    if (!label) return null;
+
+    const key = customSectionKey(label, Object.keys(activeResume.sections ?? {}));
+
+    set(state => {
+      if (!state.activeResume) return;
+      state.activeResume.sections[key] = [];
+      state.activeResume.sectionOrder.push({ key, label, ...(icon ? { icon } : {}) });
+      state.activeResume.updatedAt = Date.now();
+
+      const resumeIndex = state.resumes.findIndex(r => r.id === state.activeResume?.id);
+      if (resumeIndex !== -1) {
+        state.resumes[resumeIndex].sections[key] = [];
+        state.resumes[resumeIndex].sectionOrder = state.activeResume.sectionOrder;
+        state.resumes[resumeIndex].updatedAt = state.activeResume.updatedAt;
+      }
+
+      const isCloudSyncOn = useSettingStore.getState().cloudSync;
+      state.syncStatus = isCloudSyncOn ? 'modified' : 'local';
+    });
+
+    return key;
+  },
+
+  updateCustomSection: (key, patch) => {
+    const { activeResume } = get();
+    if (!activeResume || !isCustomSection(key)) return;
+
+    const label = patch.label?.trim();
+    const current = activeResume.sectionOrder.find(s => s.key === key);
+    if (!current) return;
+    if ((label ?? current.label) === current.label && (patch.icon ?? current.icon) === current.icon) {
+      return;
+    }
+
+    set(state => {
+      if (!state.activeResume) return;
+      const target = state.activeResume.sectionOrder.find(s => s.key === key);
+      if (!target) return;
+      if (label) target.label = label;
+      if (patch.icon !== undefined) target.icon = patch.icon;
+      state.activeResume.updatedAt = Date.now();
+
+      const resumeIndex = state.resumes.findIndex(r => r.id === state.activeResume?.id);
+      if (resumeIndex !== -1) {
+        state.resumes[resumeIndex].sectionOrder = state.activeResume.sectionOrder;
+        state.resumes[resumeIndex].updatedAt = state.activeResume.updatedAt;
+      }
+
+      const isCloudSyncOn = useSettingStore.getState().cloudSync;
+      state.syncStatus = isCloudSyncOn ? 'modified' : 'local';
+    });
+  },
+
+  removeCustomSection: (key) => {
+    const { activeResume } = get();
+    if (!activeResume || !isCustomSection(key)) return;
+    if (!activeResume.sectionOrder.some(s => s.key === key)) return;
+
+    set(state => {
+      if (!state.activeResume) return;
+      delete state.activeResume.sections[key];
+      state.activeResume.sectionOrder = state.activeResume.sectionOrder.filter(s => s.key !== key);
+      state.activeResume.updatedAt = Date.now();
+
+      const resumeIndex = state.resumes.findIndex(r => r.id === state.activeResume?.id);
+      if (resumeIndex !== -1) {
+        delete state.resumes[resumeIndex].sections[key];
+        state.resumes[resumeIndex].sectionOrder = state.activeResume.sectionOrder;
         state.resumes[resumeIndex].updatedAt = state.activeResume.updatedAt;
       }
 

--- a/apps/web/src/store/useResumeStore.ts
+++ b/apps/web/src/store/useResumeStore.ts
@@ -13,6 +13,7 @@ import { isAxiosError } from 'axios';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 import { normalizeResumeSectionOrder } from '@/lib/utils/resumeSectionOrder';
+import { migrateResume } from '@/lib/utils/resumeMigrations';
 import {
   Resume,
   InfoType,
@@ -698,22 +699,11 @@ const useResumeStore = create<ResumeState>()(
         const updatedResumes = get().resumes;
         const resume = updatedResumes.find(r => r.id === id);
         if (resume) {
-          // Data migration on the fly: Ensure 'basics' section exists
-          const hasBasics = resume.sectionOrder.some(s => s.key === 'basics');
-          
+          // Repairs for resumes written by an older build — see migrateResume.
+          const migrated = migrateResume(resume);
           set(state => {
             if (!state.activeResume || state.activeResume.id !== id) {
-                if (!hasBasics) {
-                    state.activeResume = {
-                        ...resume,
-                        sectionOrder: [
-                          { key: 'basics', label: 'Basics' },
-                          ...resume.sectionOrder,
-                        ],
-                    };
-                } else {
-                    state.activeResume = { ...resume };
-                }
+              state.activeResume = { ...migrated };
             }
           });
         }
@@ -724,22 +714,11 @@ const useResumeStore = create<ResumeState>()(
     // 如果数据已经加载完成，从当前列表查找
     const resume = resumes.find(r => r.id === id);
     if (resume) {
-      const hasBasics = resume.sectionOrder.some(s => s.key === 'basics');
-      
+      const migrated = migrateResume(resume);
       set(state => {
         // Only set if not already matched to avoid unnecessary re-renders
         if (state.activeResume?.id !== id) {
-            if (!hasBasics) {
-                state.activeResume = {
-                    ...resume,
-                    sectionOrder: [
-                      { key: 'basics', label: 'Basics' },
-                      ...resume.sectionOrder,
-                    ],
-                };
-            } else {
-                state.activeResume = { ...resume };
-            }
+          state.activeResume = { ...migrated };
         }
       });
     } else {

--- a/apps/web/src/types/frontend/resume.ts
+++ b/apps/web/src/types/frontend/resume.ts
@@ -98,7 +98,13 @@ export type CustomInfoField = {
 export type SectionItem = {
   id: string;
   visible: boolean;
-  [key: string]: string | boolean;
+  /**
+   * Name/value pairs the user added to this item. Explicitly typed rather than
+   * folded into the index signature below, because they render through their
+   * own block — a key no template's fieldMap declares is dropped silently.
+   */
+  customFields?: CustomInfoField[];
+  [key: string]: string | boolean | CustomInfoField[] | undefined;
 };
 
 export type Section = {

--- a/apps/web/src/types/frontend/resume.ts
+++ b/apps/web/src/types/frontend/resume.ts
@@ -108,6 +108,12 @@ export type Section = {
 export type SectionOrder = {
   key: string;
   label: string;
+  /**
+   * Name from `SECTION_ICONS` in @magic-resume/resume-templates. A name and not
+   * a component because a resume is persisted, synced and exported as JSON.
+   * Unset means "guess" — the renderer still matches on key and title keywords.
+   */
+  icon?: string;
 };
 
 export type ResumeVersion = {

--- a/packages/resume-schema/src/index.ts
+++ b/packages/resume-schema/src/index.ts
@@ -55,6 +55,13 @@ export const sectionItemSchema = z
 export const sectionOrderItemSchema = z.object({
   key: z.string(),
   label: z.string(),
+  /**
+   * Icon name from `SECTION_ICONS` in @magic-resume/resume-templates. A name
+   * rather than a component because a resume is persisted, synced and exported
+   * as JSON. Absent means "guess" — the renderer still matches on the section
+   * key and on keywords in the title.
+   */
+  icon: z.string().optional(),
 });
 
 export const resumeSchema = z.object({

--- a/packages/resume-schema/src/index.ts
+++ b/packages/resume-schema/src/index.ts
@@ -14,6 +14,12 @@ export const templateIds = [
   'golden-elegant',
   'product-ops-focus',
   'compact-cn-photo',
+  'executive-band',
+  'timeline-pro',
+  'skills-first',
+  'serif-minimal',
+  'slate-sidebar',
+  'cn-formal-photo',
 ] as const;
 
 export const templateSchema = z.enum(templateIds);

--- a/packages/resume-templates/src/config/cn-formal-photo-template.ts
+++ b/packages/resume-templates/src/config/cn-formal-photo-template.ts
@@ -1,0 +1,83 @@
+import { MagicTemplateDSL } from '../types/magic-dsl';
+
+const expField = {
+  mainTitle: ['company', 'project', 'school', 'name', 'title', 'platform'],
+  mainSubtitle: ['location', 'major'],
+  secondarySubtitle: [],
+  sideTitle: ['date'],
+  sideSubtitle: ['position', 'degree', 'role'],
+  secondarySideSubtitle: [],
+  description: ['summary', 'description'],
+};
+const listField = {
+  itemName: ['skill', 'award', 'language', 'certificate', 'name', 'title'],
+  itemDetail: ['level'],
+  date: ['date'],
+  summary: ['summary'],
+};
+
+export const cnFormalPhotoTemplate: MagicTemplateDSL = {
+  id: 'cn-formal-photo',
+  name: '中文正装照',
+  version: '1.0.0',
+  description: 'Formal Chinese single-column with a rectangular ID photo and space for 政治面貌 / 籍贯 fields',
+  thumbnailUrl: '/thumbnails/cn-formal-photo.png',
+  tags: ['chinese', 'photo', 'formal', 'compact', 'ats-friendly'],
+  status: 'PUBLISHED',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+
+  designTokens: {
+    colors: {
+      primary: '#1d4ed8',
+      secondary: '#1e3a8a',
+      text: '#111827',
+      textSecondary: '#4b5563',
+      background: '#ffffff',
+      border: '#cbd5e1',
+      accent: '#1d4ed8',
+    },
+    typography: {
+      fontFamily: { primary: '"Inter", "PingFang SC", "Microsoft YaHei", sans-serif' },
+      fontSize: { xs: '9px', sm: '11px', md: '13px', lg: '15px', xl: '17px', xxl: '22px' },
+      fontWeight: { normal: 400, medium: 600, bold: 700 },
+      lineHeight: 1.45,
+      letterSpacing: '0px',
+    },
+    spacing: { xs: '0.2rem', sm: '0.4rem', md: '0.6rem', lg: '0.7rem', xl: '1rem' },
+    borderRadius: { none: '0', sm: '2px', md: '3px', lg: '4px' },
+  },
+
+  layout: {
+    type: 'single-column',
+    containerWidth: '794px',
+    padding: '30px',
+    gap: '10px',
+    showTitleDivider: true,
+    showTitleIcon: true,
+  },
+
+  components: [
+    {
+      id: 'header',
+      type: 'CenteredPhotoHeader',
+      dataBinding: 'info',
+      position: { area: 'main' },
+      props: {
+        title: 'Header',
+        avatarWidth: 84,
+        avatarHeight: 112,
+        avatarRounded: false,
+        showCustomFields: true,
+      },
+    },
+    { id: 'education', type: 'DefaultSection', dataBinding: 'sections.education', position: { area: 'main' }, props: { title: 'Education' }, fieldMap: expField },
+    { id: 'experience', type: 'DefaultSection', dataBinding: 'sections.experience', position: { area: 'main' }, props: { title: 'Experience' }, fieldMap: expField },
+    { id: 'projects', type: 'DefaultSection', dataBinding: 'sections.projects', position: { area: 'main' }, props: { title: 'Projects' }, fieldMap: expField },
+    { id: 'skills', type: 'ListSection', dataBinding: 'sections.skills', position: { area: 'main' }, props: { title: 'Skills' }, fieldMap: listField },
+    { id: 'languages', type: 'ListSection', dataBinding: 'sections.languages', position: { area: 'main' }, props: { title: 'Languages' }, fieldMap: listField },
+    { id: 'certificates', type: 'ListSection', dataBinding: 'sections.certificates', position: { area: 'main' }, props: { title: 'Certificates' }, fieldMap: listField },
+    { id: 'awards', type: 'ListSection', dataBinding: 'sections.awards', position: { area: 'main' }, props: { title: 'Awards' }, fieldMap: listField },
+    { id: 'profiles', type: 'ListSection', dataBinding: 'sections.profiles', position: { area: 'main' }, props: { title: 'Profiles' }, fieldMap: listField },
+  ],
+};

--- a/packages/resume-templates/src/config/executive-band-template.ts
+++ b/packages/resume-templates/src/config/executive-band-template.ts
@@ -1,0 +1,82 @@
+import { MagicTemplateDSL } from '../types/magic-dsl';
+
+// 时间轴用 title/subtitle/date/description 字段;宽松覆盖各分区常见键
+const tlField = {
+  title: ['company', 'school', 'name', 'project', 'platform'],
+  subtitle: ['position', 'degree', 'role', 'major'],
+  date: ['date'],
+  description: ['summary', 'description'],
+};
+const listField = {
+  itemName: ['skill', 'award', 'language', 'certificate', 'name', 'title'],
+  itemDetail: ['level'],
+  date: ['date'],
+  summary: ['summary'],
+};
+
+export const executiveBandTemplate: MagicTemplateDSL = {
+  id: 'executive-band',
+  name: 'Executive',
+  version: '1.0.0',
+  description: 'Corporate single-column with a shaded header band and a clean career timeline',
+  thumbnailUrl: '/thumbnails/executive-band.png',
+  tags: ['executive', 'navy', 'timeline', 'professional'],
+  status: 'PUBLISHED',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+
+  designTokens: {
+    colors: {
+      primary: '#1e40af',
+      secondary: '#1e3a8a',
+      text: '#0f172a',
+      textSecondary: '#475569',
+      background: '#ffffff',
+      border: '#dbe4f2',
+      accent: '#1e40af',
+    },
+    typography: {
+      fontFamily: { primary: '"Inter", "Helvetica Neue", Arial, sans-serif' },
+      fontSize: { xs: '10px', sm: '12px', md: '14px', lg: '17px', xl: '20px', xxl: '27px' },
+      fontWeight: { normal: 400, medium: 600, bold: 700 },
+      lineHeight: 1.55,
+      letterSpacing: '0px',
+    },
+    spacing: { xs: '0.25rem', sm: '0.5rem', md: '1rem', lg: '1.25rem', xl: '1.75rem' },
+    borderRadius: { none: '0', sm: '4px', md: '8px', lg: '12px' },
+  },
+
+  layout: {
+    type: 'single-column',
+    containerWidth: '794px',
+    padding: '40px',
+    gap: '18px',
+    showTitleDivider: true,
+    showTitleIcon: false,
+  },
+
+  components: [
+    {
+      id: 'header',
+      type: 'Header',
+      dataBinding: 'info',
+      position: { area: 'main' },
+      props: { title: 'Header' },
+      style: {
+        backgroundColor: '#eef4ff',
+        color: '#0f172a',
+        padding: '16px',
+        borderRadius: '10px',
+        marginBottom: '6px',
+      },
+    },
+    { id: 'experience', type: 'Timeline', dataBinding: 'sections.experience', position: { area: 'main' }, props: { title: 'Experience' }, fieldMap: tlField },
+    { id: 'education', type: 'Timeline', dataBinding: 'sections.education', position: { area: 'main' }, props: { title: 'Education' }, fieldMap: tlField },
+    { id: 'projects', type: 'Timeline', dataBinding: 'sections.projects', position: { area: 'main' }, props: { title: 'Projects' }, fieldMap: tlField },
+    { id: 'skills', type: 'ListSection', dataBinding: 'sections.skills', position: { area: 'main' }, props: { title: 'Skills' }, fieldMap: listField },
+    { id: 'languages', type: 'ListSection', dataBinding: 'sections.languages', position: { area: 'main' }, props: { title: 'Languages' }, fieldMap: listField },
+    { id: 'certificates', type: 'ListSection', dataBinding: 'sections.certificates', position: { area: 'main' }, props: { title: 'Certificates' }, fieldMap: listField },
+    { id: 'awards', type: 'ListSection', dataBinding: 'sections.awards', position: { area: 'main' }, props: { title: 'Awards' }, fieldMap: listField },
+    { id: 'profiles', type: 'ListSection', dataBinding: 'sections.profiles', position: { area: 'main' }, props: { title: 'Profiles' }, fieldMap: listField },
+  ],
+};

--- a/packages/resume-templates/src/config/serif-minimal-template.ts
+++ b/packages/resume-templates/src/config/serif-minimal-template.ts
@@ -1,0 +1,71 @@
+import { MagicTemplateDSL } from '../types/magic-dsl';
+
+const expField = {
+  mainTitle: ['company', 'project', 'school', 'name', 'title', 'platform'],
+  mainSubtitle: ['location', 'major'],
+  secondarySubtitle: [],
+  sideTitle: ['date'],
+  sideSubtitle: ['position', 'degree', 'role'],
+  secondarySideSubtitle: [],
+  description: ['summary', 'description'],
+};
+const listField = {
+  itemName: ['skill', 'award', 'language', 'certificate', 'name', 'title'],
+  itemDetail: ['level'],
+  date: ['date'],
+  summary: ['summary'],
+};
+
+export const serifMinimalTemplate: MagicTemplateDSL = {
+  id: 'serif-minimal',
+  name: 'Serif Minimal',
+  version: '1.0.0',
+  description: 'Typography-led, near monochrome serif layout with generous whitespace — premium and ATS-safe',
+  thumbnailUrl: '/thumbnails/serif-minimal.png',
+  tags: ['serif', 'minimal', 'monochrome', 'ats-friendly'],
+  status: 'PUBLISHED',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+
+  designTokens: {
+    colors: {
+      primary: '#1f2937',
+      secondary: '#374151',
+      text: '#111827',
+      textSecondary: '#6b7280',
+      background: '#ffffff',
+      border: '#d1d5db',
+      accent: '#1f2937',
+    },
+    typography: {
+      fontFamily: { primary: '"IBM Plex Serif", Georgia, serif' },
+      fontSize: { xs: '10px', sm: '12px', md: '14px', lg: '16px', xl: '19px', xxl: '28px' },
+      fontWeight: { normal: 400, medium: 500, bold: 700 },
+      lineHeight: 1.7,
+      letterSpacing: '0.2px',
+    },
+    spacing: { xs: '0.3rem', sm: '0.6rem', md: '1.1rem', lg: '1.4rem', xl: '2rem' },
+    borderRadius: { none: '0', sm: '0', md: '0', lg: '0' },
+  },
+
+  layout: {
+    type: 'single-column',
+    containerWidth: '794px',
+    padding: '52px',
+    gap: '22px',
+    showTitleDivider: true,
+    showTitleIcon: false,
+  },
+
+  components: [
+    { id: 'header', type: 'Header', dataBinding: 'info', position: { area: 'main' }, props: { title: 'Header' }, style: { marginBottom: '8px' } },
+    { id: 'experience', type: 'DefaultSection', dataBinding: 'sections.experience', position: { area: 'main' }, props: { title: 'Experience' }, fieldMap: expField },
+    { id: 'education', type: 'DefaultSection', dataBinding: 'sections.education', position: { area: 'main' }, props: { title: 'Education' }, fieldMap: expField },
+    { id: 'projects', type: 'DefaultSection', dataBinding: 'sections.projects', position: { area: 'main' }, props: { title: 'Projects' }, fieldMap: expField },
+    { id: 'skills', type: 'ListSection', dataBinding: 'sections.skills', position: { area: 'main' }, props: { title: 'Skills' }, fieldMap: listField },
+    { id: 'languages', type: 'ListSection', dataBinding: 'sections.languages', position: { area: 'main' }, props: { title: 'Languages' }, fieldMap: listField },
+    { id: 'certificates', type: 'ListSection', dataBinding: 'sections.certificates', position: { area: 'main' }, props: { title: 'Certificates' }, fieldMap: listField },
+    { id: 'awards', type: 'ListSection', dataBinding: 'sections.awards', position: { area: 'main' }, props: { title: 'Awards' }, fieldMap: listField },
+    { id: 'profiles', type: 'ListSection', dataBinding: 'sections.profiles', position: { area: 'main' }, props: { title: 'Profiles' }, fieldMap: listField },
+  ],
+};

--- a/packages/resume-templates/src/config/skills-first-template.ts
+++ b/packages/resume-templates/src/config/skills-first-template.ts
@@ -1,0 +1,72 @@
+import { MagicTemplateDSL } from '../types/magic-dsl';
+
+const expField = {
+  mainTitle: ['company', 'project', 'school', 'name', 'title', 'platform'],
+  mainSubtitle: ['location', 'major'],
+  secondarySubtitle: [],
+  sideTitle: ['date'],
+  sideSubtitle: ['position', 'degree', 'role'],
+  secondarySideSubtitle: [],
+  description: ['summary', 'description'],
+};
+const skillField = { title: ['skill', 'name', 'language', 'certificate'], level: ['level'] };
+const listField = {
+  itemName: ['skill', 'award', 'language', 'certificate', 'name', 'title'],
+  itemDetail: ['level'],
+  date: ['date'],
+  summary: ['summary'],
+};
+
+export const skillsFirstTemplate: MagicTemplateDSL = {
+  id: 'skills-first',
+  name: 'Skill Bars',
+  version: '1.0.0',
+  description: 'Single-column that visualizes skills and languages as proficiency bars, with a burgundy accent',
+  thumbnailUrl: '/thumbnails/skills-first.png',
+  tags: ['skills', 'visual', 'bars', 'burgundy'],
+  status: 'PUBLISHED',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+
+  designTokens: {
+    colors: {
+      primary: '#9f1239',
+      secondary: '#881337',
+      text: '#1f2937',
+      textSecondary: '#6b7280',
+      background: '#ffffff',
+      border: '#e5e7eb',
+      accent: '#9f1239',
+    },
+    typography: {
+      fontFamily: { primary: '"Inter", "Helvetica Neue", Arial, sans-serif' },
+      fontSize: { xs: '10px', sm: '12px', md: '14px', lg: '16px', xl: '19px', xxl: '25px' },
+      fontWeight: { normal: 400, medium: 600, bold: 700 },
+      lineHeight: 1.5,
+      letterSpacing: '0px',
+    },
+    spacing: { xs: '0.25rem', sm: '0.5rem', md: '0.9rem', lg: '1.1rem', xl: '1.5rem' },
+    borderRadius: { none: '0', sm: '3px', md: '6px', lg: '8px' },
+  },
+
+  layout: {
+    type: 'single-column',
+    containerWidth: '794px',
+    padding: '38px',
+    gap: '16px',
+    showTitleDivider: true,
+    showTitleIcon: true,
+  },
+
+  components: [
+    { id: 'header', type: 'Header', dataBinding: 'info', position: { area: 'main' }, props: { title: 'Header' }, style: { marginBottom: '4px' } },
+    { id: 'skills', type: 'CompactList', dataBinding: 'sections.skills', position: { area: 'main' }, props: { title: 'Skills', levelBar: true }, fieldMap: skillField },
+    { id: 'experience', type: 'DefaultSection', dataBinding: 'sections.experience', position: { area: 'main' }, props: { title: 'Experience' }, fieldMap: expField },
+    { id: 'projects', type: 'DefaultSection', dataBinding: 'sections.projects', position: { area: 'main' }, props: { title: 'Projects' }, fieldMap: expField },
+    { id: 'education', type: 'DefaultSection', dataBinding: 'sections.education', position: { area: 'main' }, props: { title: 'Education' }, fieldMap: expField },
+    { id: 'languages', type: 'CompactList', dataBinding: 'sections.languages', position: { area: 'main' }, props: { title: 'Languages', levelBar: true }, fieldMap: skillField },
+    { id: 'certificates', type: 'ListSection', dataBinding: 'sections.certificates', position: { area: 'main' }, props: { title: 'Certificates' }, fieldMap: listField },
+    { id: 'awards', type: 'ListSection', dataBinding: 'sections.awards', position: { area: 'main' }, props: { title: 'Awards' }, fieldMap: listField },
+    { id: 'profiles', type: 'ListSection', dataBinding: 'sections.profiles', position: { area: 'main' }, props: { title: 'Profiles' }, fieldMap: listField },
+  ],
+};

--- a/packages/resume-templates/src/config/slate-sidebar-template.ts
+++ b/packages/resume-templates/src/config/slate-sidebar-template.ts
@@ -1,0 +1,73 @@
+import { MagicTemplateDSL } from '../types/magic-dsl';
+
+const tlField = {
+  title: ['company', 'school', 'name', 'project', 'platform'],
+  subtitle: ['position', 'degree', 'role', 'major'],
+  date: ['date'],
+  description: ['summary', 'description'],
+};
+const skillField = { title: ['skill', 'name', 'language', 'certificate'], level: ['level'] };
+const listField = {
+  itemName: ['skill', 'award', 'language', 'certificate', 'name', 'title'],
+  itemDetail: ['level'],
+  date: ['date'],
+  summary: ['summary'],
+};
+
+export const slateSidebarTemplate: MagicTemplateDSL = {
+  id: 'slate-sidebar',
+  name: 'Slate',
+  version: '1.0.0',
+  description: 'Two-column with a dark slate sidebar, circular photo, proficiency bars, and a main-column timeline',
+  thumbnailUrl: '/thumbnails/slate-sidebar.png',
+  tags: ['two-column', 'dark', 'slate', 'photo', 'visual'],
+  status: 'PUBLISHED',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+
+  designTokens: {
+    colors: {
+      primary: '#0ea5e9',
+      secondary: '#0284c7',
+      text: '#0f172a',
+      textSecondary: '#475569',
+      background: '#ffffff',
+      border: '#e2e8f0',
+      accent: '#0ea5e9',
+      sidebar: '#1e293b',
+    },
+    typography: {
+      fontFamily: { primary: '"Inter", "Helvetica Neue", Arial, sans-serif' },
+      fontSize: { xs: '10px', sm: '12px', md: '14px', lg: '16px', xl: '19px', xxl: '23px' },
+      fontWeight: { normal: 400, medium: 600, bold: 700 },
+      lineHeight: 1.5,
+      letterSpacing: '0px',
+    },
+    spacing: { xs: '0.25rem', sm: '0.5rem', md: '0.9rem', lg: '1.1rem', xl: '1.5rem' },
+    borderRadius: { none: '0', sm: '4px', md: '8px', lg: '12px' },
+  },
+
+  layout: {
+    type: 'two-column',
+    containerWidth: '794px',
+    padding: '28px',
+    gap: '18px',
+    twoColumn: { leftWidth: '260px', rightWidth: '1fr', gap: '0' },
+    showTitleDivider: true,
+    showTitleIcon: true,
+  },
+
+  components: [
+    { id: 'profile-card', type: 'ProfileCard', dataBinding: 'info', position: { area: 'sidebar', order: 0 }, props: { title: 'Profile' } },
+    { id: 'contact-info', type: 'ContactInfo', dataBinding: 'info', position: { area: 'sidebar', order: 1 }, props: { title: 'Contact' } },
+    { id: 'skills', type: 'CompactList', dataBinding: 'sections.skills', position: { area: 'sidebar', order: 2 }, props: { title: 'Skills', levelBar: true }, fieldMap: skillField },
+    { id: 'languages', type: 'CompactList', dataBinding: 'sections.languages', position: { area: 'sidebar', order: 3 }, props: { title: 'Languages', levelBar: true }, fieldMap: skillField },
+    { id: 'certificates-side', type: 'CompactList', dataBinding: 'sections.certificates', position: { area: 'sidebar', order: 4 }, props: { title: 'Certificates' }, fieldMap: skillField },
+
+    { id: 'experience', type: 'Timeline', dataBinding: 'sections.experience', position: { area: 'main' }, props: { title: 'Experience' }, fieldMap: tlField },
+    { id: 'projects', type: 'Timeline', dataBinding: 'sections.projects', position: { area: 'main' }, props: { title: 'Projects' }, fieldMap: tlField },
+    { id: 'education', type: 'Timeline', dataBinding: 'sections.education', position: { area: 'main' }, props: { title: 'Education' }, fieldMap: tlField },
+    { id: 'awards', type: 'ListSection', dataBinding: 'sections.awards', position: { area: 'main' }, props: { title: 'Awards' }, fieldMap: listField },
+    { id: 'profiles', type: 'ListSection', dataBinding: 'sections.profiles', position: { area: 'main' }, props: { title: 'Profiles' }, fieldMap: listField },
+  ],
+};

--- a/packages/resume-templates/src/config/timeline-pro-template.ts
+++ b/packages/resume-templates/src/config/timeline-pro-template.ts
@@ -1,0 +1,68 @@
+import { MagicTemplateDSL } from '../types/magic-dsl';
+
+const tlField = {
+  title: ['company', 'school', 'name', 'project', 'platform'],
+  subtitle: ['position', 'degree', 'role', 'major'],
+  date: ['date'],
+  description: ['summary', 'description'],
+};
+const listField = {
+  itemName: ['skill', 'award', 'language', 'certificate', 'name', 'title'],
+  itemDetail: ['level'],
+  date: ['date'],
+  summary: ['summary'],
+};
+
+export const timelineProTemplate: MagicTemplateDSL = {
+  id: 'timeline-pro',
+  name: 'Timeline',
+  version: '1.0.0',
+  description: 'Career-progression focused single-column with section icons and a teal accent',
+  thumbnailUrl: '/thumbnails/timeline-pro.png',
+  tags: ['timeline', 'teal', 'modern', 'icons'],
+  status: 'PUBLISHED',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+
+  designTokens: {
+    colors: {
+      primary: '#0d9488',
+      secondary: '#0f766e',
+      text: '#0f172a',
+      textSecondary: '#4b5563',
+      background: '#ffffff',
+      border: '#d5dbe0',
+      accent: '#0d9488',
+    },
+    typography: {
+      fontFamily: { primary: '"Inter", "Helvetica Neue", Arial, sans-serif' },
+      fontSize: { xs: '10px', sm: '12px', md: '14px', lg: '16px', xl: '19px', xxl: '24px' },
+      fontWeight: { normal: 400, medium: 600, bold: 700 },
+      lineHeight: 1.5,
+      letterSpacing: '0px',
+    },
+    spacing: { xs: '0.25rem', sm: '0.5rem', md: '0.85rem', lg: '1rem', xl: '1.5rem' },
+    borderRadius: { none: '0', sm: '2px', md: '4px', lg: '6px' },
+  },
+
+  layout: {
+    type: 'single-column',
+    containerWidth: '794px',
+    padding: '36px',
+    gap: '15px',
+    showTitleDivider: true,
+    showTitleIcon: true,
+  },
+
+  components: [
+    { id: 'header', type: 'Header', dataBinding: 'info', position: { area: 'main' }, props: { title: 'Header' }, style: { marginBottom: '4px' } },
+    { id: 'experience', type: 'Timeline', dataBinding: 'sections.experience', position: { area: 'main' }, props: { title: 'Experience' }, fieldMap: tlField },
+    { id: 'projects', type: 'Timeline', dataBinding: 'sections.projects', position: { area: 'main' }, props: { title: 'Projects' }, fieldMap: tlField },
+    { id: 'education', type: 'Timeline', dataBinding: 'sections.education', position: { area: 'main' }, props: { title: 'Education' }, fieldMap: tlField },
+    { id: 'skills', type: 'ListSection', dataBinding: 'sections.skills', position: { area: 'main' }, props: { title: 'Skills' }, fieldMap: listField },
+    { id: 'languages', type: 'ListSection', dataBinding: 'sections.languages', position: { area: 'main' }, props: { title: 'Languages' }, fieldMap: listField },
+    { id: 'certificates', type: 'ListSection', dataBinding: 'sections.certificates', position: { area: 'main' }, props: { title: 'Certificates' }, fieldMap: listField },
+    { id: 'awards', type: 'ListSection', dataBinding: 'sections.awards', position: { area: 'main' }, props: { title: 'Awards' }, fieldMap: listField },
+    { id: 'profiles', type: 'ListSection', dataBinding: 'sections.profiles', position: { area: 'main' }, props: { title: 'Profiles' }, fieldMap: listField },
+  ],
+};

--- a/packages/resume-templates/src/index.ts
+++ b/packages/resume-templates/src/index.ts
@@ -7,6 +7,7 @@ export {
   magicTemplates,
 } from './config/magic-templates';
 export * from './registry';
+export * from './sectionIcons';
 export * from './renderer/MagicResumeRenderer';
 export * from './types/magic-dsl';
 export * from './types/resume';

--- a/packages/resume-templates/src/pdf/MagicResumePdfDocument.tsx
+++ b/packages/resume-templates/src/pdf/MagicResumePdfDocument.tsx
@@ -169,6 +169,39 @@ const resolveTitle = (component: ComponentDefinition, locale?: string): string =
   return ZH_TITLE_BY_SECTION_KEY[sectionKey] ?? ZH_TITLE_BY_ENGLISH[title.trim().toLowerCase()] ?? title;
 };
 
+/**
+ * Field aliases for a section no template described. Kept identical to the HTML
+ * renderer's — the two disagreeing would mean a resume that reads one way on
+ * screen and another in the export.
+ */
+const CUSTOM_SECTION_FIELD_MAP = {
+  itemName: ['name', 'title', 'skill', 'role', 'company', 'school'],
+  itemDetail: ['level', 'position', 'degree', 'issuer'],
+  date: ['date'],
+  summary: ['summary', 'description'],
+};
+
+/** A `ListSection` definition for an ordered key the template does not declare. */
+const synthesiseCustomSection = (
+  data: Resume,
+  entry: { key: string; label?: string },
+): ComponentDefinition | null => {
+  const items = (data.sections as Record<string, unknown> | undefined)?.[entry.key];
+  if (!Array.isArray(items) || items.length === 0) return null;
+
+  const title = entry.label || entry.key;
+  return {
+    id: `custom-section-${entry.key}`,
+    type: 'ListSection',
+    dataBinding: `sections.${entry.key}`,
+    position: { area: 'main' },
+    // Both titles carry the heading as the candidate wrote it, so `resolveTitle`
+    // cannot swap in a translation for a section only they have named.
+    props: { title, titleZh: title },
+    fieldMap: CUSTOM_SECTION_FIELD_MAP,
+  } as ComponentDefinition;
+};
+
 const sortComponents = (template: MagicTemplateDSL, data: Resume): ComponentDefinition[] => {
   const sidebar = template.components
     .filter((component) => component.position?.area === 'sidebar')
@@ -180,7 +213,17 @@ const sortComponents = (template: MagicTemplateDSL, data: Resume): ComponentDefi
 
   for (const entry of data.sectionOrder ?? []) {
     const component = sections.find((candidate) => candidate.dataBinding === `sections.${entry.key}`);
-    if (component) ordered.push(component);
+    if (component) {
+      ordered.push(component);
+      continue;
+    }
+    // Custom sections are synthesised here for the same reason the HTML
+    // renderer does it: a template lists its components by hand, so a key it
+    // never named renders nowhere. Skipping it here would be the worse half of
+    // that bug — the section would show on screen and be missing from the file
+    // the candidate actually sends out.
+    const synthesised = synthesiseCustomSection(data, entry);
+    if (synthesised) ordered.push(synthesised);
   }
 
   for (const component of sections) {
@@ -628,6 +671,34 @@ const Description = ({
   ) : null;
 };
 
+/**
+ * Name/value pairs the user added to an item.
+ *
+ * Rendered from the item directly rather than through the fieldMap, exactly as
+ * the HTML renderer does: a key no fieldMap declares is dropped silently, so a
+ * field somebody typed would be stored, visible on screen, and missing from the
+ * export — the worst place for it to go quiet.
+ */
+const ItemCustomFields = ({ item, context, fontSize }: {
+  item: SectionItem;
+  context: RenderContext;
+  fontSize: number;
+}) => {
+  const fields = (item.customFields ?? []).filter((field) => field?.name || field?.value);
+  if (fields.length === 0) return null;
+
+  return (
+    <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
+      {fields.map((field) => (
+        <Text key={field.id} style={{ color: context.colors.text, fontSize }}>
+          {field.name ? `${field.name}${field.value ? '：' : ''}` : ''}
+          {field.value}
+        </Text>
+      ))}
+    </View>
+  );
+};
+
 const DefaultSectionBlock = ({ component, items, context }: {
   component: ComponentDefinition;
   items: SectionItem[];
@@ -664,6 +735,7 @@ const DefaultSectionBlock = ({ component, items, context }: {
                   <Text style={{ color: context.colors.textSecondary, fontSize: bodyFontSize }}>{getFieldValue(record, fields.secondarySideSubtitle)}</Text>
                 </View>
               </View>
+              <ItemCustomFields item={item} context={context} fontSize={bodyFontSize} />
               <Description
                 value={getFieldValue(record, fields.description)}
                 color={context.colors.text}
@@ -703,6 +775,7 @@ const ListSectionBlock = ({ component, items, context }: {
                 fontFamily={dateFontFamily}
                 fontSize={bodyFontSize}
               />
+              <ItemCustomFields item={item} context={context} fontSize={bodyFontSize} />
               <Description
                 value={getFieldValue(record, fields.summary)}
                 color={context.colors.text}

--- a/packages/resume-templates/src/pdf/MagicResumePdfDocument.tsx
+++ b/packages/resume-templates/src/pdf/MagicResumePdfDocument.tsx
@@ -33,6 +33,7 @@ import { getPdfFontStack, getPdfRichTextFontFamily } from '../font-family';
 import { PdfLucideIcon } from './PdfLucideIcon';
 import { PdfRichText } from './PdfRichText';
 import { FREE_FORM_PAGE_SIZE, getFreeFormPageMinHeight } from './page-size';
+import { skillLevelToFraction } from '../templateLayout/skill-level';
 
 type PdfStyle = Style | Style[];
 
@@ -916,6 +917,9 @@ const CompactListBlock = ({ component, items, sidebar, context }: {
 }) => {
   const fields: FieldMapping = component.fieldMap ?? {};
   const color = component.style?.color ?? (sidebar ? context.colors.background : context.colors.text);
+  const levelBar = Boolean(component.props?.levelBar);
+  const trackColor = sidebar ? 'rgba(255,255,255,0.22)' : context.colors.border;
+  const fillColor = sidebar ? context.colors.background : context.colors.primary;
   return (
     <View style={toPdfComponentStyle(component.style)}>
       <SectionTitle
@@ -931,10 +935,17 @@ const CompactListBlock = ({ component, items, sidebar, context }: {
           const record = item as Record<string, unknown>;
           const name = getFieldValue(record, fields.title ?? ['name', 'skill', 'language', 'certificate']);
           const level = getFieldValue(record, fields.level ?? 'level');
+          const frac = levelBar ? skillLevelToFraction(level) : null;
           return (
             <View key={item.id || index} wrap={false} style={{ gap: 2 }}>
               <Text style={{ color, fontSize: 8.5, fontWeight: 700 }}>{name}</Text>
-              {level ? <Text style={{ color, fontSize: 7.5, opacity: 0.8 }}>{level}</Text> : null}
+              {frac !== null ? (
+                <View style={{ height: 3.5, borderRadius: 2, backgroundColor: trackColor, marginTop: 1 }}>
+                  <View style={{ width: `${Math.round(frac * 100)}%`, height: '100%', borderRadius: 2, backgroundColor: fillColor }} />
+                </View>
+              ) : level ? (
+                <Text style={{ color, fontSize: 7.5, opacity: 0.8 }}>{level}</Text>
+              ) : null}
             </View>
           );
         })}
@@ -1062,6 +1073,18 @@ export const MagicResumePdfDocument = ({ data, template, locale, cjkFallback = f
   };
   const padding = cssSizeToPoints(template.layout.padding, 24);
   const columnGap = cssSizeToPoints(template.layout.twoColumn?.gap, 0);
+  // 两栏主列用显式宽度(页宽 − 侧栏 − 列间距),不靠 flexGrow ——
+  // react-pdf 4.5.1 的 flex 对 flexGrow+minWidth:0 收敛不稳,长文本会把主列撑出页面被裁。
+  const sidebarWidth = cssSizeToPoints(template.layout.twoColumn?.leftWidth);
+  const mainColumnWidth = Math.max(0, pageWidth - sidebarWidth - columnGap);
+  // 两栏列的 padding 下限:azurill/orange/… 把 layout.padding 设成 "0",导致内容(含顶部、
+  // 侧栏)直接贴页边、没边距。给个 24pt 下限保证四周都有内边距;侧栏底色在 View 上、padding
+  // 在其内,所以底色照样铺满到页边。已有 ≥24 的模板(chikorita/gengar)不受影响。
+  const columnPadding = Math.max(padding, 24);
+  // 同理 azurill/orange/golden/teal 的 layout.gap:"0" → 分区零间距、挤成一团(尤其侧栏紧凑分区)。
+  // 给两栏列的分区间距设 12pt 下限(gap:24px 的 chikorita/gengar=18pt 不受影响;单栏不动,
+  // 保留 compact-cn-photo 故意的 0 间距)。
+  const columnSectionGap = Math.max(sectionGap, 12);
   const pageSize = { width: pageWidth };
   const pageMinHeightStyle: Style = {
     minHeight: getFreeFormPageMinHeight(pageWidth, template.layout.pageSize),
@@ -1083,20 +1106,22 @@ export const MagicResumePdfDocument = ({ data, template, locale, cjkFallback = f
         >
           <View
             style={{
-              width: cssSizeToPoints(template.layout.twoColumn.leftWidth),
+              width: sidebarWidth,
+              flexShrink: 0,
               backgroundColor: colors.sidebar ?? colors.primary,
-              padding,
-              gap: sectionGap,
+              padding: columnPadding,
+              gap: columnSectionGap,
             }}
           >
             {sidebar.map((component) => <ComponentBlock key={component.id} component={component} data={data} sidebar context={context} />)}
           </View>
           <View
             style={{
-              flexGrow: 1,
+              width: mainColumnWidth,
               flexShrink: 1,
-              padding,
-              gap: sectionGap,
+              minWidth: 0,
+              padding: columnPadding,
+              gap: columnSectionGap,
             }}
           >
             {main.map((component) => <ComponentBlock key={component.id} component={component} data={data} sidebar={false} context={context} />)}

--- a/packages/resume-templates/src/pdf/browser.tsx
+++ b/packages/resume-templates/src/pdf/browser.tsx
@@ -235,11 +235,36 @@ export const warmupMagicResumePdfExport = async (template?: MagicTemplateDSL): P
       .then(() => undefined);
 };
 
-const blobToDataUrl = (blob: Blob): Promise<string> => new Promise((resolve, reject) => {
-  const reader = new FileReader();
-  reader.onerror = () => reject(reader.error ?? new Error('Failed to read image data.'));
-  reader.onload = () => resolve(String(reader.result));
-  reader.readAsDataURL(blob);
+// 兜底转码:react-pdf(4.5.1)只认 PNG/JPEG,传 webp 会报 "Base64 image invalid format: webp"
+// (表现为「占了位却不画像素」)。我们自己传的头像现在已是 JPEG(直接跳过此转码),这里只兜底
+// 处理非 PNG/JPEG 的来源:用户粘贴的 webp/avif URL、以及历史遗留的 webp 对象。转成 JPEG(照片
+// 体积远小于 PNG)。关键:先 fetch 成 blob 再用 objectURL 画进 canvas —— objectURL 同源,不会
+// 污染 canvas,toDataURL 才不会抛 SecurityError(直接把远程 URL 塞进 <img> 画则会被污染)。
+const imageBlobToJpegDataUrl = (blob: Blob): Promise<string> => new Promise((resolve, reject) => {
+  const url = URL.createObjectURL(blob);
+  const img = new window.Image();
+  img.onload = () => {
+    URL.revokeObjectURL(url);
+    try {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.naturalWidth || 1;
+      canvas.height = img.naturalHeight || 1;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) throw new Error('Canvas 2D context unavailable.');
+      // JPEG 无 alpha:先铺白底,透明区(如透明 PNG/webp)否则会变黑。
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0);
+      resolve(canvas.toDataURL('image/jpeg', 0.9));
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error('Failed to encode avatar image.'));
+    }
+  };
+  img.onerror = () => {
+    URL.revokeObjectURL(url);
+    reject(new Error('Failed to decode avatar image.'));
+  };
+  img.src = url;
 });
 
 // Cache the remote-avatar → data-URL conversion by URL. The live preview
@@ -251,9 +276,12 @@ const fetchAvatarDataUrl = (avatar: string): Promise<string> => {
   let promise = avatarDataUrlCache.get(avatar);
   if (!promise) {
     promise = (async () => {
-      const response = await fetch(avatar, { cache: 'force-cache' });
+      // `reload`(强制走网络)而非 `force-cache`:头像对象带 immutable 一年强缓存,若浏览器
+      // 早前用 <img>(no-cors)缓存过它,force-cache 会复用那份「无 CORS 头」的旧响应,导致这里
+      // 的 cors fetch 被拦、头像被静默丢弃。会话内已有 avatarDataUrlCache 去重,重取不影响性能。
+      const response = await fetch(avatar, { cache: 'reload' });
       if (!response.ok) throw new Error(`Avatar request failed with ${response.status}.`);
-      return blobToDataUrl(await response.blob());
+      return imageBlobToJpegDataUrl(await response.blob());
     })();
     // Never cache a rejection — allow the next render to retry a failed fetch.
     void promise.catch(() => avatarDataUrlCache.delete(avatar));
@@ -264,10 +292,16 @@ const fetchAvatarDataUrl = (avatar: string): Promise<string> => {
 
 const prepareResumeImages = async (data: Resume): Promise<Resume> => {
   const avatar = data.info.avatar;
-  if (!avatar || avatar.startsWith('data:')) return data;
+  if (!avatar) return data;
+
+  // 已是 react-pdf 认得的 PNG/JPEG data URL 就直接用;远程 URL 与 webp data URL(self-hosted
+  // 内嵌)都要转成 PNG,否则 react-pdf 报 "Base64 image invalid format"。
+  if (/^data:image\/(png|jpe?g);/i.test(avatar)) return data;
 
   try {
-    const dataUrl = await fetchAvatarDataUrl(avatar);
+    const dataUrl = avatar.startsWith('data:')
+      ? await imageBlobToJpegDataUrl(await (await fetch(avatar)).blob())
+      : await fetchAvatarDataUrl(avatar);
     return { ...data, info: { ...data.info, avatar: dataUrl } };
   } catch {
     // A remote avatar should not prevent the rest of the resume from exporting.

--- a/packages/resume-templates/src/registry.ts
+++ b/packages/resume-templates/src/registry.ts
@@ -12,6 +12,12 @@ import { orangeModernTemplate } from './config/orange-modern-template';
 import { productOpsFocusTemplate } from './config/product-ops-focus-template';
 import { redAccentTemplate } from './config/red-accent-template';
 import { tealProfessionalTemplate } from './config/teal-professional-template';
+import { executiveBandTemplate } from './config/executive-band-template';
+import { timelineProTemplate } from './config/timeline-pro-template';
+import { skillsFirstTemplate } from './config/skills-first-template';
+import { serifMinimalTemplate } from './config/serif-minimal-template';
+import { slateSidebarTemplate } from './config/slate-sidebar-template';
+import { cnFormalPhotoTemplate } from './config/cn-formal-photo-template';
 import type { MagicTemplateDSL } from './types/magic-dsl';
 
 export type TemplateManifest = {
@@ -57,6 +63,12 @@ export const templateRegistry: Record<TemplateId, TemplateManifest> = {
   'golden-elegant': createManifest(goldenElegantTemplate),
   'product-ops-focus': createManifest(productOpsFocusTemplate),
   'compact-cn-photo': createManifest(compactCnPhotoTemplate),
+  'executive-band': createManifest(executiveBandTemplate),
+  'timeline-pro': createManifest(timelineProTemplate),
+  'skills-first': createManifest(skillsFirstTemplate),
+  'serif-minimal': createManifest(serifMinimalTemplate),
+  'slate-sidebar': createManifest(slateSidebarTemplate),
+  'cn-formal-photo': createManifest(cnFormalPhotoTemplate),
 };
 
 export const templateManifestList = Object.values(templateRegistry);

--- a/packages/resume-templates/src/renderer/MagicResumeRenderer.tsx
+++ b/packages/resume-templates/src/renderer/MagicResumeRenderer.tsx
@@ -34,6 +34,55 @@ const componentRegistry = {
   TwoColumnLayout,
 };
 
+/**
+ * Field aliases for a section no template described.
+ *
+ * Deliberately generous and ordered by how a heading usually reads: a custom
+ * section is whatever the candidate wrote — 个人优势, 获奖经历, 开源贡献 — so the
+ * right field cannot be known ahead of time. `summary` leads the rich-text
+ * aliases because it is the field the editor edits; `description` follows it so
+ * older imports still show.
+ */
+const CUSTOM_SECTION_FIELD_MAP = {
+  itemName: ['name', 'title', 'skill', 'role', 'company', 'school'],
+  itemDetail: ['level', 'position', 'degree', 'issuer'],
+  date: ['date'],
+  summary: ['summary', 'description'],
+};
+
+/**
+ * A `ListSection` for a section key the template does not declare.
+ *
+ * Returns null when there is nothing to show, so an empty custom section does
+ * not print a bare heading. `ListSection` is the right shape: bold item name
+ * plus rich text, which is what skills / languages / certificates already use
+ * and what a custom section almost always is.
+ */
+function synthesiseCustomSection(
+  data: Resume,
+  sectionOrderItem: { key: string; label?: string },
+) {
+  const items = (data.sections as Record<string, unknown> | undefined)?.[
+    sectionOrderItem.key
+  ];
+  if (!Array.isArray(items) || items.length === 0) return null;
+
+  return {
+    id: `custom-section-${sectionOrderItem.key}`,
+    type: 'ListSection' as const,
+    dataBinding: `sections.${sectionOrderItem.key}`,
+    position: { area: 'main' as const },
+    // The label is the heading as the candidate wrote it, so it is already in
+    // their language — the renderer's zh title mapping must not touch it.
+    props: {
+      title: sectionOrderItem.label || sectionOrderItem.key,
+      titleZh: sectionOrderItem.label || sectionOrderItem.key,
+      containerClassName: 'grid gap-x-6 gap-y-1',
+    },
+    fieldMap: CUSTOM_SECTION_FIELD_MAP,
+  };
+}
+
 interface Props {
   template: MagicTemplateDSL;
   data: Resume;
@@ -177,6 +226,17 @@ export const MagicResumeRenderer = React.memo(({ template, data, locale }: Props
   );
   
   const LayoutContainer = getLayoutComponent(layout.type);
+
+  // `sectionOrder` is where an explicit icon choice lives; the component list
+  // is keyed by dataBinding and knows nothing about it.
+  const iconBySectionKey = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const item of data.sectionOrder ?? []) {
+      const icon = (item as { icon?: string }).icon;
+      if (item?.key && icon) map.set(item.key, icon);
+    }
+    return map;
+  }, [data.sectionOrder]);
   
   const sortedComponents = useMemo(() => {
     const sidebarComponents = components.filter(comp => comp.position?.area === 'sidebar');
@@ -186,15 +246,24 @@ export const MagicResumeRenderer = React.memo(({ template, data, locale }: Props
     const sectionComponents = mainComponents.filter(comp => comp.dataBinding.startsWith('sections.'));
     
     const sortedMainSections = [] as typeof components;
-    
+
     if (data.sectionOrder && Array.isArray(data.sectionOrder)) {
       data.sectionOrder.forEach(sectionOrderItem => {
-        const matchingComponent = sectionComponents.find(comp => 
+        const matchingComponent = sectionComponents.find(comp =>
           comp.dataBinding === `sections.${sectionOrderItem.key}`
         );
         if (matchingComponent) {
           sortedMainSections.push(matchingComponent);
+          return;
         }
+        // A section this template never declared — a custom one the resume
+        // brought with it. Templates list their components by hand, so an
+        // unknown key used to render nowhere at all: the data survived every
+        // layer above this and then silently vanished at the last one.
+        // Synthesised here rather than added to thirteen template configs, so
+        // templates written later inherit the behaviour for free.
+        const synthesised = synthesiseCustomSection(data, sectionOrderItem);
+        if (synthesised) sortedMainSections.push(synthesised);
       });
     }
     
@@ -266,7 +335,11 @@ export const MagicResumeRenderer = React.memo(({ template, data, locale }: Props
             position: component.position,
             ...component.props,
             title: resolvedTitle,
-            titleIcon: getSectionIcon(sectionKey, rawTitle),
+            titleIcon: getSectionIcon(
+              sectionKey,
+              rawTitle,
+              sectionKey ? iconBySectionKey.get(sectionKey) : undefined,
+            ),
             sectionKey,
           };
 

--- a/packages/resume-templates/src/sectionIcons.ts
+++ b/packages/resume-templates/src/sectionIcons.ts
@@ -1,0 +1,72 @@
+import {
+  Award,
+  Briefcase,
+  Code2,
+  FileText,
+  FolderOpen,
+  Globe,
+  GraduationCap,
+  Heart,
+  Languages,
+  Lightbulb,
+  Rocket,
+  Sparkles,
+  Star,
+  Target,
+  Trophy,
+  User,
+  Wrench,
+} from 'lucide-react';
+import React from 'react';
+
+export type SectionIconComponent = React.ComponentType<{
+  // `string | number` because lucide accepts both and the editor's own `Meta`
+  // types it that way; narrowing here would make the shared registry unusable
+  // by one of its two consumers.
+  size?: string | number;
+  className?: string;
+  style?: React.CSSProperties;
+}>;
+
+/**
+ * Icons a section can be given by name.
+ *
+ * Named rather than stored as a component so the choice survives JSON — a
+ * resume is persisted, synced and exported, and none of those can carry a
+ * React component. The set is deliberately small: a picker with four hundred
+ * lucide icons is a worse experience than one with sixteen that cover what a
+ * resume section actually is.
+ *
+ * Shared by the editor (`sectionMeta`) and the renderer (`getSectionIcon`) so a
+ * section cannot wear one icon in the form and another on the page.
+ */
+export const SECTION_ICONS: Record<string, SectionIconComponent> = {
+  briefcase: Briefcase,
+  graduation: GraduationCap,
+  folder: FolderOpen,
+  wrench: Wrench,
+  languages: Languages,
+  award: Award,
+  trophy: Trophy,
+  user: User,
+  globe: Globe,
+  code: Code2,
+  rocket: Rocket,
+  lightbulb: Lightbulb,
+  target: Target,
+  star: Star,
+  sparkles: Sparkles,
+  heart: Heart,
+  file: FileText,
+};
+
+/** Stable order for the picker — grouped by what they tend to mean. */
+export const SECTION_ICON_NAMES = Object.keys(SECTION_ICONS);
+
+/** The component for a stored icon name, or null when unset/unknown. */
+export function sectionIconByName(
+  name: string | undefined | null,
+): SectionIconComponent | null {
+  if (!name) return null;
+  return SECTION_ICONS[name] ?? null;
+}

--- a/packages/resume-templates/src/templateLayout/CenteredPhotoHeader.tsx
+++ b/packages/resume-templates/src/templateLayout/CenteredPhotoHeader.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Image from 'next/image';
 import { useTranslation } from 'react-i18next';
 import type { InfoType } from '../types/resume';
 import { Editable } from '../renderer/EditableCanvas';
@@ -64,7 +63,9 @@ export const CenteredPhotoHeader = React.memo(function CenteredPhotoHeader({
   }
 
   const avatar = info.avatar ? (
-    <Image
+    // 原生 img:任意来源头像(R2/自定义域名/data:URL)都能渲染,不受 next/image 白名单限制。
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
       src={info.avatar}
       alt={t('basicForm.avatarAlt')}
       width={avatarWidth}
@@ -75,7 +76,6 @@ export const CenteredPhotoHeader = React.memo(function CenteredPhotoHeader({
         height: `${avatarHeight}px`,
         background: 'var(--color-background)',
       }}
-      unoptimized
     />
   ) : null;
 

--- a/packages/resume-templates/src/templateLayout/CompactList.tsx
+++ b/packages/resume-templates/src/templateLayout/CompactList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { getFieldValue } from './utils';
+import { skillLevelToFraction } from './skill-level';
 
 interface Item {
   [key: string]: unknown;
@@ -14,9 +15,11 @@ interface Props {
     area?: 'main' | 'sidebar' | 'header' | 'footer';
   };
   titleIcon?: React.ComponentType<{ size?: number; style?: React.CSSProperties }>;
+  /** 把 level 文本画成进度条(如"精通"→满格),识别不了的等级回退成文字 */
+  levelBar?: boolean;
 }
 
-export const CompactList = React.memo(function CompactList({ title, items, fieldMap = {}, style, position, titleIcon: TitleIcon }: Props) {
+export const CompactList = React.memo(function CompactList({ title, items, fieldMap = {}, style, position, titleIcon: TitleIcon, levelBar }: Props) {
   if (!items || items.length === 0) return null;
 
   const isInSidebar = position?.area === 'sidebar';
@@ -65,17 +68,24 @@ export const CompactList = React.memo(function CompactList({ title, items, field
         {items.map((item, idx) => {
           const name = getFieldValue(item, fieldMap.title || ['name', 'skill', 'language', 'certificate']);
           const level = getFieldValue(item, fieldMap.level || 'level');
-          
+          const frac = levelBar ? skillLevelToFraction(level) : null;
+          const trackColor = isInSidebar ? 'rgba(255,255,255,0.22)' : 'var(--color-border)';
+          const fillColor = isInSidebar ? 'var(--color-background)' : 'var(--color-primary)';
+
           return (
             <li key={idx} style={{ color: textColor }}>
               <div className="font-medium" style={{ fontSize: 'var(--font-size-body)' }}>
                 {name}
               </div>
-              {level && (
+              {frac !== null ? (
+                <div style={{ marginTop: 4, height: 5, borderRadius: 3, background: trackColor, overflow: 'hidden' }}>
+                  <div style={{ width: `${Math.round(frac * 100)}%`, height: '100%', borderRadius: 3, background: fillColor }} />
+                </div>
+              ) : level ? (
                 <div className="mt-1" style={{ color: secondaryColor, fontSize: 'var(--font-size-body)' }}>
                   {level}
                 </div>
-              )}
+              ) : null}
             </li>
           );
         })}

--- a/packages/resume-templates/src/templateLayout/DefaultSection.tsx
+++ b/packages/resume-templates/src/templateLayout/DefaultSection.tsx
@@ -75,6 +75,21 @@ export const DefaultSection = React.memo(function DefaultSection({ title, items,
                     <div>{getFieldValue(item, fieldMap.secondarySideSubtitle)}</div>
                   </div>
                 </div>
+                {/* Hand-added fields, rendered explicitly rather than via the
+                    fieldMap — see ListSection for why. */}
+                {Array.isArray(item.customFields) && item.customFields.length > 0 && (
+                  <div className="flex flex-wrap gap-x-4 gap-y-0.5">
+                    {item.customFields
+                      .filter((f) => f?.name || f?.value)
+                      .map((f) => (
+                        <div key={f.id}>
+                          {f.name ? <span className="font-medium">{f.name}</span> : null}
+                          {f.name && f.value ? '：' : ''}
+                          {f.value}
+                        </div>
+                      ))}
+                  </div>
+                )}
                 {description &&
                   (sectionKey && itemId ? (
                     <Editable

--- a/packages/resume-templates/src/templateLayout/Header.tsx
+++ b/packages/resume-templates/src/templateLayout/Header.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { InfoType } from '../types/resume';
 import { MapPin, Phone, Mail, Globe } from 'lucide-react';
-import Image from 'next/image';
 import { useTranslation } from 'react-i18next';
 import { Editable } from '../renderer/EditableCanvas';
 import { safeHref } from './utils';
@@ -44,7 +43,10 @@ export const Header = React.memo(function Header({
   const isRightAvatarLayout = avatarPosition === 'right';
 
   const avatarNode = info.avatar ? (
-    <Image
+    // 原生 img:头像可能是 R2 URL / 自定义域名 / data:URL,不走 next/image
+    // 的域名白名单,任意来源都能渲染(与 PDF/表单预览一致)。
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
       src={info.avatar}
       alt={t('basicForm.avatarAlt')}
       width={avatarWidth}
@@ -57,7 +59,6 @@ export const Header = React.memo(function Header({
         borderColor: 'var(--color-border)',
         boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)',
       }}
-      unoptimized
     />
   ) : null;
 

--- a/packages/resume-templates/src/templateLayout/ListSection.tsx
+++ b/packages/resume-templates/src/templateLayout/ListSection.tsx
@@ -86,6 +86,23 @@ export const ListSection = React.memo(function ListSection({ title, items, field
                 {getFieldValue(item, fieldMap.date) && (
                   <div>{getFieldValue(item, fieldMap.date)}</div>
                 )}
+                {/* Fields the user added by hand. Rendered explicitly, not
+                    through the fieldMap: `getFieldValue` drops any key a
+                    fieldMap does not declare, so a field somebody typed would
+                    otherwise be stored and invisible. */}
+                {Array.isArray(item.customFields) && item.customFields.length > 0 && (
+                  <div className="flex flex-wrap gap-x-4 gap-y-0.5">
+                    {item.customFields
+                      .filter((f) => f?.name || f?.value)
+                      .map((f) => (
+                        <div key={f.id}>
+                          {f.name ? <span className="font-medium">{f.name}</span> : null}
+                          {f.name && f.value ? '：' : ''}
+                          {f.value}
+                        </div>
+                      ))}
+                  </div>
+                )}
                 {summary &&
                   (sectionKey && itemId ? (
                     <Editable

--- a/packages/resume-templates/src/templateLayout/ProfileCard.tsx
+++ b/packages/resume-templates/src/templateLayout/ProfileCard.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { InfoType } from '../types/resume';
-import Image from 'next/image';
 import { MapPin, Phone, Mail, Globe } from 'lucide-react';
 
 interface Props {
@@ -42,14 +41,15 @@ export const ProfileCard = React.memo(function ProfileCard({ data: info, style, 
       >
         {info.avatar && (
           <div className="flex justify-center">
-            <Image
+            {/* 原生 img:任意来源头像都能渲染,不受 next/image 域名白名单限制 */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
               src={info.avatar}
               alt="Profile"
               width={120}
               height={120}
               className="w-30 h-30 rounded-full object-cover border-4 shadow-lg"
               style={{ borderColor }}
-              unoptimized
             />
           </div>
         )}
@@ -83,14 +83,15 @@ export const ProfileCard = React.memo(function ProfileCard({ data: info, style, 
     >
       {info.avatar && (
         <div className="flex justify-center">
-          <Image
+          {/* 原生 img:任意来源头像都能渲染,不受 next/image 域名白名单限制 */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
             src={info.avatar}
             alt="Profile"
             width={120}
             height={120}
             className="w-30 h-30 rounded-full object-cover border-4 shadow-lg"
             style={{ borderColor }}
-            unoptimized
           />
         </div>
       )}

--- a/packages/resume-templates/src/templateLayout/skill-level.ts
+++ b/packages/resume-templates/src/templateLayout/skill-level.ts
@@ -1,0 +1,37 @@
+/**
+ * 把技能/语言的等级文本(自由文本,如 "精通"/"Advanced"/"B2"/"90%"/"4")归一化为 0–1 比例,
+ * 供带 `levelBar` 的模板画进度条。识别不了就返回 null(调用方回退成纯文本)。
+ *
+ * 无任何依赖 —— 供 HTML 渲染器(CompactList)与 PDF 渲染器共同 import。
+ */
+const LEVEL_FRACTIONS: Record<string, number> = {
+  // 中文
+  '母语': 1, '精通': 1, '熟练': 0.82, '掌握': 0.72, '熟悉': 0.62, '良好': 0.6, '一般': 0.45, '了解': 0.4, '入门': 0.3, '基础': 0.35,
+  // 英文
+  native: 1, expert: 1, fluent: 0.9, advanced: 0.85, proficient: 0.8, professional: 0.78,
+  'upper intermediate': 0.7, intermediate: 0.6, conversational: 0.5, elementary: 0.4, basic: 0.35, beginner: 0.3, novice: 0.25,
+  // CEFR
+  c2: 1, c1: 0.85, b2: 0.7, b1: 0.55, a2: 0.4, a1: 0.25,
+};
+
+export function skillLevelToFraction(level: string | undefined | null): number | null {
+  if (!level) return null;
+  const raw = String(level).trim().toLowerCase();
+  if (!raw) return null;
+
+  const pct = raw.match(/^(\d{1,3})\s*%$/);
+  if (pct) return Math.min(1, Math.max(0, Number(pct[1]) / 100));
+
+  const num = Number(raw);
+  if (Number.isFinite(num)) {
+    if (num > 0 && num <= 1) return num;
+    if (num > 1 && num <= 5) return num / 5;
+    if (num > 5 && num <= 100) return num / 100;
+  }
+
+  if (raw in LEVEL_FRACTIONS) return LEVEL_FRACTIONS[raw];
+  for (const key of Object.keys(LEVEL_FRACTIONS)) {
+    if (key.length > 1 && raw.includes(key)) return LEVEL_FRACTIONS[key];
+  }
+  return null;
+}

--- a/packages/resume-templates/src/templateLayout/utils.ts
+++ b/packages/resume-templates/src/templateLayout/utils.ts
@@ -1,4 +1,5 @@
 import get from 'lodash.get';
+import { sectionIconByName, type SectionIconComponent } from '../sectionIcons';
 import React from 'react';
 import {
   Briefcase, GraduationCap, FolderOpen, Wrench,
@@ -56,7 +57,7 @@ export const getFieldEntry = (
   return null;
 };
 
-const SECTION_ICON_MAP: Record<string, React.ComponentType<{ size?: number; className?: string; style?: React.CSSProperties }>> = {
+const SECTION_ICON_MAP: Record<string, SectionIconComponent> = {
   experience: Briefcase,
   education: GraduationCap,
   projects: FolderOpen,
@@ -67,7 +68,7 @@ const SECTION_ICON_MAP: Record<string, React.ComponentType<{ size?: number; clas
   contact: Globe,
 };
 
-const TITLE_ICON_KEYWORDS: Record<string, React.ComponentType<{ size?: number; className?: string; style?: React.CSSProperties }>> = {
+const TITLE_ICON_KEYWORDS: Record<string, SectionIconComponent> = {
   '工作': Briefcase, 'experience': Briefcase, 'work': Briefcase,
   '教育': GraduationCap, 'education': GraduationCap,
   '项目': FolderOpen, 'project': FolderOpen,
@@ -78,7 +79,16 @@ const TITLE_ICON_KEYWORDS: Record<string, React.ComponentType<{ size?: number; c
   '联系': Globe, 'contact': Globe,
 };
 
-export function getSectionIcon(sectionKey?: string, title?: string): React.ComponentType<{ size?: number; className?: string; style?: React.CSSProperties }> | null {
+export function getSectionIcon(
+  sectionKey?: string,
+  title?: string,
+  /** Explicit choice from `sectionOrder.icon`, when the user made one. */
+  iconName?: string,
+): SectionIconComponent | null {
+  // An explicit choice outranks every guess below it.
+  const chosen = sectionIconByName(iconName);
+  if (chosen) return chosen;
+
   if (sectionKey) {
     const icon = SECTION_ICON_MAP[sectionKey];
     if (icon) return icon;

--- a/packages/resume-templates/src/types/resume.ts
+++ b/packages/resume-templates/src/types/resume.ts
@@ -92,10 +92,23 @@ export type InfoType = {
   customFields?: CustomInfoField[];
 };
 
+/** Name/value pairs a user added to one item. */
+export type CustomItemField = {
+  id: string;
+  name: string;
+  value: string;
+};
+
 export type SectionItem = {
   id: string;
   visible: boolean;
-  [key: string]: string | boolean;
+  /**
+   * Rendered by an explicit block rather than through a template's fieldMap:
+   * `getFieldValue` silently drops any key a fieldMap does not declare, so a
+   * field the user typed has to be one the renderer knows to look for.
+   */
+  customFields?: CustomItemField[];
+  [key: string]: string | boolean | CustomItemField[] | undefined;
 };
 
 export type Section = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,6 +294,9 @@ importers:
       '@next/bundle-analyzer':
         specifier: ^15.3.3
         version: 15.5.19
+      '@react-pdf/renderer':
+        specifier: 4.5.1
+        version: 4.5.1(react@19.2.7)
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.3.0
@@ -11270,8 +11273,8 @@ snapshots:
       '@typescript-eslint/parser': 8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4(jiti@2.7.0))
@@ -11290,7 +11293,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11301,22 +11304,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11327,7 +11330,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.60.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1100.0
+        version: 3.1100.0
       '@clerk/nextjs':
         specifier: ^6.22.0
         version: 6.39.5(next@15.3.8(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -515,6 +518,78 @@ packages:
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@aws-sdk/checksums@3.1000.24':
+    resolution: {integrity: sha512-7TWLjypP8kk3savsDBRuhZJx7mBuFFA2136BQhwwLllsAnO4Tmq/p+SXZaNxbuulkzUFz3BZzj0bb4YzexZcNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1100.0':
+    resolution: {integrity: sha512-5IvIlW6kWOC9EPq2RM7VQUgfDF2QFHHFgQJ2DichmrYBDg5yiAmqMkDiHqUSkFYosVexXaXD/lV4yYxTyA27zw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.4':
+    resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.65':
+    resolution: {integrity: sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.67':
+    resolution: {integrity: sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.10':
+    resolution: {integrity: sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.72':
+    resolution: {integrity: sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.76':
+    resolution: {integrity: sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.65':
+    resolution: {integrity: sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.9':
+    resolution: {integrity: sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.71':
+    resolution: {integrity: sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.70':
+    resolution: {integrity: sha512-APdP0iODt39AkjCjzTFIoFrxDH/Cz3CpWRDKLcsJg7eOnfE1htkxL9BhDoe/xL7cXdoMwh2HBYv3DiT1uf64NQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.39':
+    resolution: {integrity: sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1100.0':
+    resolution: {integrity: sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -2917,6 +2992,30 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.16':
+    resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.13':
+    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.13':
+    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -3818,6 +3917,9 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
@@ -7334,6 +7436,171 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@aws-sdk/checksums@3.1000.24':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1100.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.24
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/middleware-sdk-s3': 3.972.70
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.4':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.10':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-login': 3.972.72
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.76':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-ini': 3.973.10
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.9':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/token-providers': 3.1100.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.39':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1100.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -9573,6 +9840,39 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@stablelib/base64@1.0.1': {}
 
   '@swc/counter@0.1.3': {}
@@ -10581,6 +10881,8 @@ snapshots:
       - supports-color
 
   boolbase@1.0.0: {}
+
+  bowser@2.14.1: {}
 
   boxen@8.0.1:
     dependencies:


### PR DESCRIPTION
## 三个导入缺陷

**内容写进了不渲染的字段。** `summary` 是编辑器唯一会编辑、12/13 模板会渲染的富文本字段；此前导入把正文放在 `description`，结果是存下来了、看不见、也改不了。现在读取时迁移（`migrateResume`），存量简历打开即修复。

顺带消掉了 `loadResumeForEdit` 里**写了两遍**的 basics 修复——两个分支各一份，抽进同一个函数。无改动时返回原对象，避免多余写入和假的 `modified` 同步态。

**id 是模型编的。** `skill-1` 正是提示词示例里的字面量被照抄。App 自己用的是 `nanoid()`，而且全链路**没有任何 id 去重**——模型重复编号会打断 React key 和 dnd-kit 排序。现在在 PDF 与 JSON 两条导入路径的共同咽喉处统一重发。

## 自定义 section

排查中发现它**已经通了一半**：`sections` 是 `z.record`、`normalizeResumeSectionOrder` 会补全所有 key、`app.test.ts` 甚至已有断言。缺的是最后一层——**渲染器只画模板声明过的组件**，`sectionOrder` 仅负责排序，所以自定义 key 穿过了每一层，在最后一层消失。

- **渲染**：对「有数据但模板未声明」的 key 合成 `ListSection`。一处实现覆盖 13 个模板，新模板自动继承
- **标题**：编辑器此前显示原始 key，而两个面板外的 `OutlineRail` 显示 label——同一段落两个名字。统一读 label
- **增删改**：新建 / 重命名 / 删除。**内置段落受保护**——其 label 是 i18n key，改名会把翻译换成字面量；删除会拿掉编辑器预期存在的表单。store 与 UI 都设了闸
- **图标**：可选。存**名字**不存组件（简历要序列化、同步、导出）；不选时沿用既有的关键词猜测，纯增量
- **条目自定义字段**：复用 `BasicForm` 里那套 UI，并解掉它与单一模板的绑定

自定义字段必须走**显式渲染块**而非 fieldMap——否则用户随手加的 key 会像 `description` 一样被静默丢弃，等于重造本次的坑。这是整个 PR 的主线：**一个字段只有当有东西渲染它时才算真的存在。**

## 验收

`npm run lint`（含全仓 build）7/7；`tsc --noEmit` 干净；单测通过（新增导入 id 唯一性与格式、存量迁移、内置段落保护、key 生成含中文标题与冲突）；privacy scan 通过；两侧 locale key 一致。

**未做**：真实 PDF 重新导入的端到端回归、逐个切换 13 个模板目视确认——需要跑起应用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)