### PR TITLE
feat: 头像上传（R2）+ 6 个新简历模板

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -27,3 +27,14 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # Prod: the public gateway origin (nginx terminates TLS in front).
 # NEXT_PUBLIC_API_URL=http://localhost:3110
 
+# ------ Cloudflare R2 (avatar upload, cloud mode) ---------------------
+# Server-side only — used by /api/uploads/avatar to store avatars in R2.
+# Create an R2 API Token (Object Read & Write) in the Cloudflare dashboard to
+# get the Access Key ID / Secret. Self-hosted mode never uses these (it embeds
+# the avatar as a data: URL instead).
+# R2_ACCOUNT_ID=
+# R2_ACCESS_KEY_ID=
+# R2_SECRET_ACCESS_KEY=
+# R2_BUCKET=magic-resume-assets
+# R2_PUBLIC_BASE_URL=https://pub-xxxx.r2.dev
+

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -59,6 +59,13 @@ const nextConfig: NextConfig = {
         hostname: 'img.clerk.com',
         port: '',
         pathname: '/**',
+      },
+      {
+        // Cloudflare R2 头像:public dev URL(*.r2.dev)。绑自定义域名后再加一条。
+        protocol: 'https',
+        hostname: 'pub-ca5e6f293e274c1b9298cf78d112e0be.r2.dev',
+        port: '',
+        pathname: '/**',
       }
     ],
     // 优化图片格式

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "test:unit": "tsx src/app.test.ts"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1100.0",
     "@clerk/nextjs": "^6.22.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",

--- a/apps/web/src/app/api/uploads/avatar/route.ts
+++ b/apps/web/src/app/api/uploads/avatar/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { DeleteObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { getServerUserId } from '@/lib/auth/server';
+import {
+  getR2Client,
+  isR2Configured,
+  ownAvatarKeyFromUrl,
+  publicUrlForKey,
+  R2_BUCKET,
+} from '@/lib/storage/r2';
+
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+
+// 客户端把头像压到 ~120KB JPEG;服务端上限贴合实际产出留足余量即可(512KB),
+// 砍掉「绕过前端直接 POST 大文件」的放大空间(此前 2MB=16 倍太宽)。
+const MAX_AVATAR_BYTES = 512 * 1024;
+
+/** 每个用户每分钟最多上传次数(进程内软限流,防刷 Class A 操作)。 */
+const RATE_LIMIT_PER_MINUTE = 20;
+const rateBuckets = new Map<string, number[]>();
+
+function rateLimited(userId: string): boolean {
+  const now = Date.now();
+  const windowStart = now - 60_000;
+  const hits = (rateBuckets.get(userId) ?? []).filter((t) => t > windowStart);
+  if (hits.length >= RATE_LIMIT_PER_MINUTE) {
+    rateBuckets.set(userId, hits);
+    return true;
+  }
+  hits.push(now);
+  rateBuckets.set(userId, hits);
+  return false;
+}
+
+/** 魔数嗅探:只认真正的位图,SVG / 其它一律拒绝(防 XSS / polyglot)。 */
+function sniffImage(buf: Uint8Array): { ext: string; contentType: string } | null {
+  const b = buf;
+  // PNG: 89 50 4E 47
+  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47) {
+    return { ext: 'png', contentType: 'image/png' };
+  }
+  // JPEG: FF D8 FF
+  if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) {
+    return { ext: 'jpg', contentType: 'image/jpeg' };
+  }
+  // GIF: 47 49 46 38
+  if (b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x38) {
+    return { ext: 'gif', contentType: 'image/gif' };
+  }
+  // WEBP: RIFF....WEBP
+  if (
+    b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 &&
+    b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50
+  ) {
+    return { ext: 'webp', contentType: 'image/webp' };
+  }
+  return null;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const userId = await getServerUserId();
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    if (!isR2Configured()) {
+      // 密钥没配好时明确报可用性问题,而不是 500 崩栈。
+      return NextResponse.json({ error: 'Avatar upload is not configured' }, { status: 503 });
+    }
+
+    if (rateLimited(userId)) {
+      return NextResponse.json({ error: 'Too many uploads, slow down' }, { status: 429 });
+    }
+
+    const contentLength = Number(req.headers.get('content-length') ?? 0);
+    if (contentLength > MAX_AVATAR_BYTES + 256 * 1024) {
+      return NextResponse.json({ error: 'File too large' }, { status: 413 });
+    }
+
+    const form = await req.formData();
+    const file = form.get('file');
+    const prevUrl = typeof form.get('prevUrl') === 'string' ? (form.get('prevUrl') as string) : null;
+
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'Missing file' }, { status: 400 });
+    }
+    if (file.size > MAX_AVATAR_BYTES) {
+      return NextResponse.json({ error: 'File too large' }, { status: 413 });
+    }
+
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    const kind = sniffImage(bytes);
+    if (!kind) {
+      return NextResponse.json({ error: 'Unsupported image format' }, { status: 415 });
+    }
+
+    // 每用户固定 key:上传即覆盖 → 存储硬封顶在「每人恒 1 个对象」,即便有人绕过前端
+    // 疯狂上传也堆不出量(防盗刷占存储)。固定扩展名 .jpg 保证不因格式不同产生第二个对象;
+    // 真实 Content-Type 仍按嗅探设置(浏览器按 Content-Type 而非扩展名解析)。
+    const key = `avatars/${userId}.jpg`;
+    const client = getR2Client();
+
+    await client.send(
+      new PutObjectCommand({
+        Bucket: R2_BUCKET,
+        Key: key,
+        Body: bytes,
+        ContentType: kind.contentType,
+        CacheControl: 'public, max-age=31536000, immutable',
+      }),
+    );
+
+    // 固定 key 会命中 CDN/浏览器缓存,靠 ?v=<ts> 破缓存拿到新图。
+    const url = `${publicUrlForKey(key)}?v=${Date.now()}`;
+
+    // 过渡期清理:旧方案(avatars/<userId>/<nanoid>.ext)残留对象,借 prevUrl 尽力删掉。
+    // 仅删自己前缀下的、且非当前固定 key。失败不影响上传结果。
+    const oldKey = ownAvatarKeyFromUrl(prevUrl, userId);
+    if (oldKey && oldKey !== key) {
+      client
+        .send(new DeleteObjectCommand({ Bucket: R2_BUCKET, Key: oldKey }))
+        .catch(() => undefined);
+    }
+
+    return NextResponse.json({ url });
+  } catch (err) {
+    console.error('[avatar-upload] failed', err);
+    return NextResponse.json({ error: 'Upload failed' }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/dashboard/edit/_components/forms/BasicForm.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/forms/BasicForm.tsx
@@ -47,6 +47,7 @@ export default function BasicForm({
         <AvatarField
           value={info.avatar}
           onChange={handleInfoChange}
+          onValueChange={(avatar) => updateInfo({ avatar })}
           alt={t('basicForm.avatarAlt')}
         />
       </div>

--- a/apps/web/src/app/dashboard/edit/_components/forms/fields.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/forms/fields.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import React from "react";
-import Image from "next/image";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Upload, Loader2, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { processAndStoreAvatar, AvatarError } from "@/lib/api/avatarUpload";
+import { ACCEPTED_IMAGE_ACCEPT_ATTR } from "@/lib/utils/image";
 
 /* ------------------------------------------------------------------ *
  * 左侧表单的统一控件 —— 与右侧自定义面板同一套深色工作台 + sky 风格。
@@ -66,39 +70,106 @@ export function TextField({
 export function AvatarField({
   value,
   onChange,
+  onValueChange,
   name = "avatar",
   alt,
   placeholder = "https://...",
 }: {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  /** 上传 / 清除后直接回写头像值(URL 或 data:URL) */
+  onValueChange?: (value: string) => void;
   name?: string;
   alt: string;
   placeholder?: string;
 }) {
+  const { t } = useTranslation();
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = React.useState(false);
+
+  const openPicker = () => {
+    if (!uploading) fileInputRef.current?.click();
+  };
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = ""; // 允许重复选同一个文件
+    if (!file) return;
+    setUploading(true);
+    try {
+      const next = await processAndStoreAvatar(file, value);
+      onValueChange?.(next);
+      toast.success(t("basicForm.avatarUpload.success"));
+    } catch (err) {
+      const code = err instanceof AvatarError ? err.code : "UPLOAD_FAILED";
+      toast.error(t(`basicForm.avatarUpload.errors.${code}`));
+    } finally {
+      setUploading(false);
+    }
+  };
+
   return (
     <div className="flex items-center gap-3">
-      {value ? (
-        <Image
-          src={value}
-          alt={alt}
-          width={40}
-          height={40}
-          unoptimized
-          className="h-10 w-10 shrink-0 rounded-full border border-white/10 object-cover"
+      <button
+        type="button"
+        onClick={openPicker}
+        disabled={uploading}
+        aria-label={t("basicForm.avatarUpload.button")}
+        title={t("basicForm.avatarUpload.button")}
+        className="group relative h-10 w-10 shrink-0 overflow-hidden rounded-full border border-white/10 bg-white/[0.04] outline-none transition-colors hover:border-sky-400/60 focus-visible:border-sky-400/60"
+      >
+        {value ? (
+          // 用原生 img:头像可能是 data:URL(self-hosted 内嵌),与简历模板保持一致渲染。
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={value} alt={alt} className="h-full w-full object-cover" />
+        ) : null}
+        <span
+          className={cn(
+            "absolute inset-0 flex items-center justify-center bg-black/50 text-white transition-opacity",
+            uploading
+              ? "opacity-100"
+              : value
+                ? "opacity-0 group-hover:opacity-100"
+                : "opacity-60 group-hover:opacity-100",
+          )}
+        >
+          {uploading ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Upload className="h-3.5 w-3.5" />
+          )}
+        </span>
+      </button>
+
+      <div className="relative flex-1">
+        <input
+          id={name}
+          name={name}
+          type="text"
+          value={value ?? ""}
+          onChange={onChange}
+          placeholder={placeholder}
+          spellCheck={false}
+          className={cn(fieldInputClass, value && "pr-8")}
         />
-      ) : (
-        <div className="h-10 w-10 shrink-0 rounded-full border border-white/10 bg-white/[0.04]" />
-      )}
+        {value ? (
+          <button
+            type="button"
+            onClick={() => onValueChange?.("")}
+            aria-label={t("basicForm.avatarUpload.clear")}
+            className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-1 text-neutral-500 transition-colors hover:text-neutral-200"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        ) : null}
+      </div>
+
       <input
-        id={name}
-        name={name}
-        type="text"
-        value={value ?? ""}
-        onChange={onChange}
-        placeholder={placeholder}
-        spellCheck={false}
-        className={fieldInputClass}
+        ref={fileInputRef}
+        type="file"
+        accept={ACCEPTED_IMAGE_ACCEPT_ATTR}
+        onChange={handleFile}
+        className="hidden"
       />
     </div>
   );

--- a/apps/web/src/lib/api/avatarUpload.ts
+++ b/apps/web/src/lib/api/avatarUpload.ts
@@ -1,0 +1,66 @@
+import { isCloudMode } from '@/lib/config/app';
+import { compressAvatarImage, ACCEPTED_IMAGE_TYPES } from '@/lib/utils/image';
+import { WEB_AGENT_ROUTES } from '@/lib/api/routes';
+
+/** 用户选图后的最大原始大小(压缩前)。太离谱的直接拒,连解码都省了。 */
+const MAX_INPUT_BYTES = 15 * 1024 * 1024;
+
+export type AvatarUploadError =
+  | 'UNSUPPORTED_TYPE'
+  | 'TOO_LARGE'
+  | 'PROCESS_FAILED'
+  | 'UPLOAD_FAILED';
+
+export class AvatarError extends Error {
+  code: AvatarUploadError;
+  constructor(code: AvatarUploadError) {
+    super(code);
+    this.code = code;
+  }
+}
+
+/**
+ * 处理并"落地"一张头像,返回可写入 info.avatar 的字符串。
+ *  - cloud 模式:压缩后 POST 到 /api/uploads/avatar → 返回 R2 公开 URL;
+ *  - self-hosted 模式:压缩后返回 data:URL,直接内嵌进简历 JSON(零后端)。
+ *
+ * @param prevUrl 旧头像值(用于 cloud 模式删除旧对象,self-hosted 忽略)
+ */
+export async function processAndStoreAvatar(file: File, prevUrl?: string): Promise<string> {
+  if (!ACCEPTED_IMAGE_TYPES.includes(file.type as (typeof ACCEPTED_IMAGE_TYPES)[number])) {
+    throw new AvatarError('UNSUPPORTED_TYPE');
+  }
+  if (file.size > MAX_INPUT_BYTES) {
+    throw new AvatarError('TOO_LARGE');
+  }
+
+  let compressed;
+  try {
+    compressed = await compressAvatarImage(file);
+  } catch {
+    throw new AvatarError('PROCESS_FAILED');
+  }
+
+  // self-hosted:没有后端,直接内嵌。
+  if (!isCloudMode) {
+    return compressed.dataUrl;
+  }
+
+  // cloud:传 R2。
+  const form = new FormData();
+  form.append('file', compressed.blob, 'avatar.jpg');
+  if (prevUrl) form.append('prevUrl', prevUrl);
+
+  let res: Response;
+  try {
+    res = await fetch(WEB_AGENT_ROUTES.avatarUpload, { method: 'POST', body: form });
+  } catch {
+    throw new AvatarError('UPLOAD_FAILED');
+  }
+  if (!res.ok) {
+    throw new AvatarError(res.status === 413 ? 'TOO_LARGE' : 'UPLOAD_FAILED');
+  }
+  const data = (await res.json()) as { url?: string };
+  if (!data.url) throw new AvatarError('UPLOAD_FAILED');
+  return data.url;
+}

--- a/apps/web/src/lib/api/routes.ts
+++ b/apps/web/src/lib/api/routes.ts
@@ -84,4 +84,5 @@ export const WEB_AGENT_ROUTES = {
   chatSession:      '/api/chat-agent/session',
   chatEdit:         '/api/chat-agent/edit',
   pdfParse:         '/api/pdf/parse',
+  avatarUpload:     '/api/uploads/avatar',
 } as const;

--- a/apps/web/src/lib/storage/r2.ts
+++ b/apps/web/src/lib/storage/r2.ts
@@ -1,0 +1,58 @@
+import 'server-only';
+import { S3Client } from '@aws-sdk/client-s3';
+
+/**
+ * Cloudflare R2 服务端接入(S3 兼容 API)。密钥只在服务端读,永不出网到浏览器。
+ *
+ * 需要的环境变量(见 .env.example):
+ *  - R2_ACCOUNT_ID          Cloudflare 账号 ID
+ *  - R2_ACCESS_KEY_ID       R2 API Token 的 Access Key ID
+ *  - R2_SECRET_ACCESS_KEY   R2 API Token 的 Secret
+ *  - R2_BUCKET              桶名(magic-resume-assets)
+ *  - R2_PUBLIC_BASE_URL     公开读地址,无尾斜杠(如 https://pub-xxxx.r2.dev 或自定义域名)
+ */
+
+export const R2_BUCKET = process.env.R2_BUCKET ?? '';
+export const R2_PUBLIC_BASE_URL = (process.env.R2_PUBLIC_BASE_URL ?? '').replace(/\/+$/, '');
+
+const accountId = process.env.R2_ACCOUNT_ID ?? '';
+const accessKeyId = process.env.R2_ACCESS_KEY_ID ?? '';
+const secretAccessKey = process.env.R2_SECRET_ACCESS_KEY ?? '';
+
+/** 五个变量齐了才算配好;没配好时上传 route 返回 503 而不是崩。 */
+export function isR2Configured(): boolean {
+  return Boolean(accountId && accessKeyId && secretAccessKey && R2_BUCKET && R2_PUBLIC_BASE_URL);
+}
+
+let client: S3Client | null = null;
+
+export function getR2Client(): S3Client {
+  if (!isR2Configured()) throw new Error('R2_NOT_CONFIGURED');
+  if (!client) {
+    client = new S3Client({
+      region: 'auto',
+      endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+      credentials: { accessKeyId, secretAccessKey },
+    });
+  }
+  return client;
+}
+
+export function publicUrlForKey(key: string): string {
+  return `${R2_PUBLIC_BASE_URL}/${key}`;
+}
+
+/**
+ * 从一个公开 URL 反解出对象 key —— 仅当它确实是本桶公开地址下、
+ * 且落在 `avatars/<userId>/` 前缀里时才返回,否则 null。
+ * 用于「换头像删旧对象」时防止越权删到别人 / 别的路径的对象。
+ */
+export function ownAvatarKeyFromUrl(url: string | undefined | null, userId: string): string | null {
+  if (!url || !R2_PUBLIC_BASE_URL) return null;
+  const prefix = `${R2_PUBLIC_BASE_URL}/`;
+  if (!url.startsWith(prefix)) return null;
+  const key = decodeURIComponent(url.slice(prefix.length).split('?')[0]);
+  const expected = `avatars/${userId}/`;
+  if (!key.startsWith(expected) || key.includes('..')) return null;
+  return key;
+}

--- a/apps/web/src/lib/utils/image.ts
+++ b/apps/web/src/lib/utils/image.ts
@@ -1,0 +1,148 @@
+/**
+ * 客户端头像图片预处理 —— 在上传 / 内嵌前先在浏览器里把图压小。
+ *
+ * 输出 JPEG(不是 webp):头像是照片,JPEG 体积和 webp 接近(~几十 KB),而且
+ * react-pdf 原生支持 JPEG —— webp 会让 PDF 渲染报 "Base64 image invalid format: webp"。
+ *
+ *  - 统一缩到 ≤512px、转 JPEG,循环降质直到 ≤ maxBytes(默认 ~120KB);
+ *  - self-hosted 直接拿 dataUrl 内嵌进简历 JSON,不落任何后端;
+ *  - cloud 拿 blob 传到 R2,单张只占几十 KB,存储与流量都可忽略。
+ */
+
+/** 允许的输入图片类型(魔数/扩展兜底由服务端再校验一次)。SVG 一律拒绝(XSS)。 */
+export const ACCEPTED_IMAGE_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/webp',
+  'image/gif',
+] as const;
+
+export const ACCEPTED_IMAGE_ACCEPT_ATTR = ACCEPTED_IMAGE_TYPES.join(',');
+
+export type CompressedImage = {
+  /** JPEG 编码后的二进制,用于上传 R2 */
+  blob: Blob;
+  /** data:image/jpeg;base64,... —— 用于 self-hosted 内嵌 */
+  dataUrl: string;
+  width: number;
+  height: number;
+  bytes: number;
+};
+
+export type CompressOptions = {
+  /** 最长边像素上限 */
+  maxDimension?: number;
+  /** 目标字节上限,超了就继续降质/降尺寸 */
+  maxBytes?: number;
+  /** 起始 JPEG 质量 */
+  quality?: number;
+};
+
+const DEFAULTS = {
+  maxDimension: 512,
+  maxBytes: 120 * 1024,
+  quality: 0.9,
+} satisfies Required<CompressOptions>;
+
+function loadImage(file: Blob): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      resolve(img);
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error('IMAGE_DECODE_FAILED'));
+    };
+    img.src = url;
+  });
+}
+
+function canvasToJpegBlob(canvas: HTMLCanvasElement, quality: number): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error('CANVAS_ENCODE_FAILED'))),
+      'image/jpeg',
+      quality,
+    );
+  });
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error('BLOB_READ_FAILED'));
+    reader.readAsDataURL(blob);
+  });
+}
+
+function drawScaled(img: HTMLImageElement, maxDimension: number) {
+  const ratio = Math.min(1, maxDimension / Math.max(img.naturalWidth, img.naturalHeight));
+  const width = Math.max(1, Math.round(img.naturalWidth * ratio));
+  const height = Math.max(1, Math.round(img.naturalHeight * ratio));
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('CANVAS_UNAVAILABLE');
+  // JPEG 无 alpha:先铺白底,否则透明 PNG 的透明区在 JPEG 里会变黑。
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, width, height);
+  ctx.imageSmoothingEnabled = true;
+  ctx.imageSmoothingQuality = 'high';
+  ctx.drawImage(img, 0, 0, width, height);
+  return { canvas, width, height };
+}
+
+/**
+ * 把用户选的图压成受控大小的 JPEG。
+ * 先按 maxDimension 缩放,再从 quality 起逐档降质;若最低质量仍超 maxBytes,
+ * 就把尺寸再砍一半重试,直到达标或到最小尺寸。
+ */
+export async function compressAvatarImage(
+  file: File,
+  options: CompressOptions = {},
+): Promise<CompressedImage> {
+  const { maxDimension, maxBytes, quality } = { ...DEFAULTS, ...options };
+
+  const img = await loadImage(file);
+
+  let dimension = maxDimension;
+  let best: Blob | null = null;
+
+  // 外层:尺寸阶梯(512 → 384 → …),内层:质量阶梯。取第一个 ≤ maxBytes 的结果。
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const { canvas } = drawScaled(img, dimension);
+    for (let q = quality; q >= 0.4; q -= 0.15) {
+      const blob = await canvasToJpegBlob(canvas, q);
+      if (!best || blob.size < best.size) best = blob;
+      if (blob.size <= maxBytes) {
+        const dataUrl = await blobToDataUrl(blob);
+        return {
+          blob,
+          dataUrl,
+          width: canvas.width,
+          height: canvas.height,
+          bytes: blob.size,
+        };
+      }
+    }
+    dimension = Math.round(dimension * 0.75);
+    if (dimension < 96) break;
+  }
+
+  // 兜底:即使没压到目标也返回当前最小的(极端图),服务端还有硬上限拦截。
+  const fallback = best ?? (await canvasToJpegBlob(drawScaled(img, dimension).canvas, 0.4));
+  const dataUrl = await blobToDataUrl(fallback);
+  return {
+    blob: fallback,
+    dataUrl,
+    width: 0,
+    height: 0,
+    bytes: fallback.size,
+  };
+}

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -851,7 +851,18 @@
       "valuePlaceholder": "Value (e.g., your-linkedin-url)",
       "addButton": "Add Custom Field"
     },
-    "avatarAlt": "Avatar"
+    "avatarAlt": "Avatar",
+    "avatarUpload": {
+      "button": "Upload photo",
+      "clear": "Remove photo",
+      "success": "Photo updated",
+      "errors": {
+        "UNSUPPORTED_TYPE": "Unsupported image type (PNG / JPG / WebP / GIF only)",
+        "TOO_LARGE": "Image is too large, pick a smaller one",
+        "PROCESS_FAILED": "Couldn't process the image, try another",
+        "UPLOAD_FAILED": "Upload failed, please retry"
+      }
+    }
   },
   "header": {
     "version": "Version Management",

--- a/apps/web/src/locales/zh/translation.json
+++ b/apps/web/src/locales/zh/translation.json
@@ -851,7 +851,18 @@
       "valuePlaceholder": "值（例如，your-linkedin-url）",
       "addButton": "添加自定义字段"
     },
-    "avatarAlt": "头像"
+    "avatarAlt": "头像",
+    "avatarUpload": {
+      "button": "上传头像",
+      "clear": "移除头像",
+      "success": "头像已更新",
+      "errors": {
+        "UNSUPPORTED_TYPE": "不支持的图片格式（仅 PNG / JPG / WebP / GIF）",
+        "TOO_LARGE": "图片太大了，换一张小一点的",
+        "PROCESS_FAILED": "图片处理失败，换一张试试",
+        "UPLOAD_FAILED": "上传失败，请重试"
+      }
+    }
   },
   "header": {
     "version": "版本管理",

--- a/packages/resume-schema/src/index.ts
+++ b/packages/resume-schema/src/index.ts
@@ -14,6 +14,12 @@ export const templateIds = [
   'golden-elegant',
   'product-ops-focus',
   'compact-cn-photo',
+  'executive-band',
+  'timeline-pro',
+  'skills-first',
+  'serif-minimal',
+  'slate-sidebar',
+  'cn-formal-photo',
 ] as const;
 
 export const templateSchema = z.enum(templateIds);

--- a/packages/resume-templates/src/config/cn-formal-photo-template.ts
+++ b/packages/resume-templates/src/config/cn-formal-photo-template.ts
@@ -1,0 +1,83 @@
+import { MagicTemplateDSL } from '../types/magic-dsl';
+
+const expField = {
+  mainTitle: ['company', 'project', 'school', 'name', 'title', 'platform'],
+  mainSubtitle: ['location', 'major'],
+  secondarySubtitle: [],
+  sideTitle: ['date'],
+  sideSubtitle: ['position', 'degree', 'role'],
+  secondarySideSubtitle: [],
+  description: ['summary', 'description'],
+};
+const listField = {
+  itemName: ['skill', 'award', 'language', 'certificate', 'name', 'title'],
+  itemDetail: ['level'],
+  date: ['date'],
+  summary: ['summary'],
+};
+
+export const cnFormalPhotoTemplate: MagicTemplateDSL = {
+  id: 'cn-formal-photo',
+  name: '中文正装照',
+  version: '1.0.0',
+  description: 'Formal Chinese single-column with a rectangular ID photo and space for 政治面貌 / 籍贯 fields',
+  thumbnailUrl: '/thumbnails/cn-formal-photo.png',
+  tags: ['chinese', 'photo', 'formal', 'compact', 'ats-friendly'],
+  status: 'PUBLISHED',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+
+  designTokens: {
+    colors: {
+      primary: '#1d4ed8',
+      secondary: '#1e3a8a',
+      text: '#111827',
+      textSecondary: '#4b5563',
+      background: '#ffffff',
+      border: '#cbd5e1',
+      accent: '#1d4ed8',
+    },
+    typography: {
+      fontFamily: { primary: '"Inter", "PingFang SC", "Microsoft YaHei", sans-serif' },
+      fontSize: { xs: '9px', sm: '11px', md: '13px', lg: '15px', xl: '17px', xxl: '22px' },
+      fontWeight: { normal: 400, medium: 600, bold: 700 },
+      lineHeight: 1.45,
+      letterSpacing: '0px',
+    },
+    spacing: { xs: '0.2rem', sm: '0.4rem', md: '0.6rem', lg: '0.7rem', xl: '1rem' },
+    borderRadius: { none: '0', sm: '2px', md: '3px', lg: '4px' },
+  },
+
+  layout: {
+    type: 'single-column',
+    containerWidth: '794px',
+    padding: '30px',
+    gap: '10px',
+    showTitleDivider: true,
+    showTitleIcon: true,
+  },
+
+  components: [
+    {
+      id: 'header',
+      type: 'CenteredPhotoHeader',
+      dataBinding: 'info',
+      position: { area: 'main' },
+      props: {
+        title: 'Header',
+        avatarWidth: 84,
+        avatarHeight: 112,
+        avatarRounded: false,
+        showCustomFields: true,
+      },
+    },
+    { id: 'education', type: 'DefaultSection', dataBinding: 'sections.education', position: { area: 'main' }, props: { title: 'Education' }, fieldMap: expField },
+    { id: 'experience', type: 'DefaultSection', dataBinding: 'sections.experience', position: { area: 'main' }, props: { title: 'Experience' }, fieldMap: expField },
+    { id: 'projects', type: 'DefaultSection', dataBinding: 'sections.projects', position: { area: 'main' }, props: { title: 'Projects' }, fieldMap: expField },
+    { id: 'skills', type: 'ListSection', dataBinding: 'sections.skills', position: { area: 'main' }, props: { title: 'Skills' }, fieldMap: listField },
+    { id: 'languages', type: 'ListSection', dataBinding: 'sections.languages', position: { area: 'main' }, props: { title: 'Languages' }, fieldMap: listField },
+    { id: 'certificates', type: 'ListSection', dataBinding: 'sections.certificates', position: { area: 'main' }, props: { title: 'Certificates' }, fieldMap: listField },
+    { id: 'awards', type: 'ListSection', dataBinding: 'sections.awards', position: { area: 'main' }, props: { title: 'Awards' }, fieldMap: listField },
+    { id: 'profiles', type: 'ListSection', dataBinding: 'sections.profiles', position: { area: 'main' }, props: { title: 'Profiles' }, fieldMap: listField },
+  ],
+};

--- a/packages/resume-templates/src/config/executive-band-template.ts
+++ b/packages/resume-templates/src/config/executive-band-template.ts
@@ -1,0 +1,82 @@
+import { MagicTemplateDSL } from '../types/magic-dsl';
+
+// 时间轴用 title/subtitle/date/description 字段;宽松覆盖各分区常见键
+const tlField = {
+  title: ['company', 'school', 'name', 'project', 'platform'],
+  subtitle: ['position', 'degree', 'role', 'major'],
+  date: ['date'],
+  description: ['summary', 'description'],
+};
+const listField = {
+  itemName: ['skill', 'award', 'language', 'certificate', 'name', 'title'],
+  itemDetail: ['level'],
+  date: ['date'],
+  summary: ['summary'],
+};
+
+export const executiveBandTemplate: MagicTemplateDSL = {
+  id: 'executive-band',
+  name: 'Executive',
+  version: '1.0.0',
+  description: 'Corporate single-column with a shaded header band and a clean career timeline',
+  thumbnailUrl: '/thumbnails/executive-band.png',
+  tags: ['executive', 'navy', 'timeline', 'professional'],
+  status: 'PUBLISHED',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+
+  designTokens: {
+    colors: {
+      primary: '#1e40af',
+      secondary: '#1e3a8a',
+      text: '#0f172a',
+      textSecondary: '#475569',
+      background: '#ffffff',
+      border: '#dbe4f2',
+      accent: '#1e40af',
+    },
+    typography: {
+      fontFamily: { primary: '"Inter", "Helvetica Neue", Arial, sans-serif' },
+      fontSize: { xs: '10px', sm: '12px', md: '14px', lg: '17px', xl: '20px', xxl: '27px' },
+      fontWeight: { normal: 400, medium: 600, bold: 700 },
+      lineHeight: 1.55,
+      letterSpacing: '0px',
+    },
+    spacing: { xs: '0.25rem', sm: '0.5rem', md: '1rem', lg: '1.25rem', xl: '1.75rem' },
+    borderRadius: { none: '0', sm: '4px', md: '8px', lg: '12px' },
+  },
+
+  layout: {
+    type: 'single-column',
+    containerWidth: '794px',
+    padding: '40px',
+    gap: '18px',
+    showTitleDivider: true,
+    showTitleIcon: false,
+  },
+
+  components: [
+    {
+      id: 'header',
+      type: 'Header',
+      dataBinding: 'info',
+      position: { area: 'main' },
+      props: { title: 'Header' },
+      style: {
+        backgroundColor: '#eef4ff',
+        color: '#0f172a',
+        padding: '16px',
+        borderRadius: '10px',
+        marginBottom: '6px',
+      },
+    },
+    { id: 'experience', type: 'Timeline', dataBinding: 'sections.experience', position: { area: 'main' }, props: { title: 'Experience' }, fieldMap: tlField },
+    { id: 'education', type: 'Timeline', dataBinding: 'sections.education', position: { area: 'main' }, props: { title: 'Education' }, fieldMap: tlField },
+    { id: 'projects', type: 'Timeline', dataBinding: 'sections.projects', position: { area: 'main' }, props: { title: 'Projects' }, fieldMap: tlField },
+    { id: 'skills', type: 'ListSection', dataBinding: 'sections.skills', position: { area: 'main' }, props: { title: 'Skills' }, fieldMap: listField },
+    { id: 'languages', type: 'ListSection', dataBinding: 'sections.languages', position: { area: 'main' }, props: { title: 'Languages' }, fieldMap: listField },
+    { id: 'certificates', type: 'ListSection', dataBinding: 'sections.certificates', position: { area: 'main' }, props: { title: 'Certificates' }, fieldMap: listField },
+    { id: 'awards', type: 'ListSection', dataBinding: 'sections.awards', position: { area: 'main' }, props: { title: 'Awards' }, fieldMap: listField },
+    { id: 'profiles', type: 'ListSection', dataBinding: 'sections.profiles', position: { area: 'main' }, props: { title: 'Profiles' }, fieldMap: listField },
+  ],
+};

--- a/packages/resume-templates/src/config/serif-minimal-template.ts
+++ b/packages/resume-templates/src/config/serif-minimal-template.ts
@@ -1,0 +1,71 @@
+import { MagicTemplateDSL } from '../types/magic-dsl';
+
+const expField = {
+  mainTitle: ['company', 'project', 'school', 'name', 'title', 'platform'],
+  mainSubtitle: ['location', 'major'],
+  secondarySubtitle: [],
+  sideTitle: ['date'],
+  sideSubtitle: ['position', 'degree', 'role'],
+  secondarySideSubtitle: [],
+  description: ['summary', 'description'],
+};
+const listField = {
+  itemName: ['skill', 'award', 'language', 'certificate', 'name', 'title'],
+  itemDetail: ['level'],
+  date: ['date'],
+  summary: ['summary'],
+};
+
+export const serifMinimalTemplate: MagicTemplateDSL = {
+  id: 'serif-minimal',
+  name: 'Serif Minimal',
+  version: '1.0.0',
+  description: 'Typography-led, near monochrome serif layout with generous whitespace — premium and ATS-safe',
+  thumbnailUrl: '/thumbnails/serif-minimal.png',
+  tags: ['serif', 'minimal', 'monochrome', 'ats-friendly'],
+  status: 'PUBLISHED',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+
+  designTokens: {
+    colors: {
+      primary: '#1f2937',
+      secondary: '#374151',
+      text: '#111827',
+      textSecondary: '#6b7280',
+      background: '#ffffff',
+      border: '#d1d5db',
+      accent: '#1f2937',
+    },
+    typography: {
+      fontFamily: { primary: '"IBM Plex Serif", Georgia, serif' },
+      fontSize: { xs: '10px', sm: '12px', md: '14px', lg: '16px', xl: '19px', xxl: '28px' },
+      fontWeight: { normal: 400, medium: 500, bold: 700 },
+      lineHeight: 1.7,
+      letterSpacing: '0.2px',
+    },
+    spacing: { xs: '0.3rem', sm: '0.6rem', md: '1.1rem', lg: '1.4rem', xl: '2rem' },
+    borderRadius: { none: '0', sm: '0', md: '0', lg: '0' },
+  },
+
+  layout: {
+    type: 'single-column',
+    containerWidth: '794px',
+    padding: '52px',
+    gap: '22px',
+    showTitleDivider: true,
+    showTitleIcon: false,
+  },
+
+  components: [
+    { id: 'header', type: 'Header', dataBinding: 'info', position: { area: 'main' }, props: { title: 'Header' }, style: { marginBottom: '8px' } },
+    { id: 'experience', type: 'DefaultSection', dataBinding: 'sections.experience', position: { area: 'main' }, props: { title: 'Experience' }, fieldMap: expField },
+    { id: 'education', type: 'DefaultSection', dataBinding: 'sections.education', position: { area: 'main' }, props: { title: 'Education' }, fieldMap: expField },
+    { id: 'projects', type: 'DefaultSection', dataBinding: 'sections.projects', position: { area: 'main' }, props: { title: 'Projects' }, fieldMap: expField },
+    { id: 'skills', type: 'ListSection', dataBinding: 'sections.skills', position: { area: 'main' }, props: { title: 'Skills' }, fieldMap: listField },
+    { id: 'languages', type: 'ListSection', dataBinding: 'sections.languages', position: { area: 'main' }, props: { title: 'Languages' }, fieldMap: listField },
+    { id: 'certificates', type: 'ListSection', dataBinding: 'sections.certificates', position: { area: 'main' }, props: { title: 'Certificates' }, fieldMap: listField },
+    { id: 'awards', type: 'ListSection', dataBinding: 'sections.awards', position: { area: 'main' }, props: { title: 'Awards' }, fieldMap: listField },
+    { id: 'profiles', type: 'ListSection', dataBinding: 'sections.profiles', position: { area: 'main' }, props: { title: 'Profiles' }, fieldMap: listField },
+  ],
+};

--- a/packages/resume-templates/src/config/skills-first-template.ts
+++ b/packages/resume-templates/src/config/skills-first-template.ts
@@ -1,0 +1,72 @@
+import { MagicTemplateDSL } from '../types/magic-dsl';
+
+const expField = {
+  mainTitle: ['company', 'project', 'school', 'name', 'title', 'platform'],
+  mainSubtitle: ['location', 'major'],
+  secondarySubtitle: [],
+  sideTitle: ['date'],
+  sideSubtitle: ['position', 'degree', 'role'],
+  secondarySideSubtitle: [],
+  description: ['summary', 'description'],
+};
+const skillField = { title: ['skill', 'name', 'language', 'certificate'], level: ['level'] };
+const listField = {
+  itemName: ['skill', 'award', 'language', 'certificate', 'name', 'title'],
+  itemDetail: ['level'],
+  date: ['date'],
+  summary: ['summary'],
+};
+
+export const skillsFirstTemplate: MagicTemplateDSL = {
+  id: 'skills-first',
+  name: 'Skill Bars',
+  version: '1.0.0',
+  description: 'Single-column that visualizes skills and languages as proficiency bars, with a burgundy accent',
+  thumbnailUrl: '/thumbnails/skills-first.png',
+  tags: ['skills', 'visual', 'bars', 'burgundy'],
+  status: 'PUBLISHED',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+
+  designTokens: {
+    colors: {
+      primary: '#9f1239',
+      secondary: '#881337',
+      text: '#1f2937',
+      textSecondary: '#6b7280',
+      background: '#ffffff',
+      border: '#e5e7eb',
+      accent: '#9f1239',
+    },
+    typography: {
+      fontFamily: { primary: '"Inter", "Helvetica Neue", Arial, sans-serif' },
+      fontSize: { xs: '10px', sm: '12px', md: '14px', lg: '16px', xl: '19px', xxl: '25px' },
+      fontWeight: { normal: 400, medium: 600, bold: 700 },
+      lineHeight: 1.5,
+      letterSpacing: '0px',
+    },
+    spacing: { xs: '0.25rem', sm: '0.5rem', md: '0.9rem', lg: '1.1rem', xl: '1.5rem' },
+    borderRadius: { none: '0', sm: '3px', md: '6px', lg: '8px' },
+  },
+
+  layout: {
+    type: 'single-column',
+    containerWidth: '794px',
+    padding: '38px',
+    gap: '16px',
+    showTitleDivider: true,
+    showTitleIcon: true,
+  },
+
+  components: [
+    { id: 'header', type: 'Header', dataBinding: 'info', position: { area: 'main' }, props: { title: 'Header' }, style: { marginBottom: '4px' } },
+    { id: 'skills', type: 'CompactList', dataBinding: 'sections.skills', position: { area: 'main' }, props: { title: 'Skills', levelBar: true }, fieldMap: skillField },
+    { id: 'experience', type: 'DefaultSection', dataBinding: 'sections.experience', position: { area: 'main' }, props: { title: 'Experience' }, fieldMap: expField },
+    { id: 'projects', type: 'DefaultSection', dataBinding: 'sections.projects', position: { area: 'main' }, props: { title: 'Projects' }, fieldMap: expField },
+    { id: 'education', type: 'DefaultSection', dataBinding: 'sections.education', position: { area: 'main' }, props: { title: 'Education' }, fieldMap: expField },
+    { id: 'languages', type: 'CompactList', dataBinding: 'sections.languages', position: { area: 'main' }, props: { title: 'Languages', levelBar: true }, fieldMap: skillField },
+    { id: 'certificates', type: 'ListSection', dataBinding: 'sections.certificates', position: { area: 'main' }, props: { title: 'Certificates' }, fieldMap: listField },
+    { id: 'awards', type: 'ListSection', dataBinding: 'sections.awards', position: { area: 'main' }, props: { title: 'Awards' }, fieldMap: listField },
+    { id: 'profiles', type: 'ListSection', dataBinding: 'sections.profiles', position: { area: 'main' }, props: { title: 'Profiles' }, fieldMap: listField },
+  ],
+};

--- a/packages/resume-templates/src/config/slate-sidebar-template.ts
+++ b/packages/resume-templates/src/config/slate-sidebar-template.ts
@@ -1,0 +1,73 @@
+import { MagicTemplateDSL } from '../types/magic-dsl';
+
+const tlField = {
+  title: ['company', 'school', 'name', 'project', 'platform'],
+  subtitle: ['position', 'degree', 'role', 'major'],
+  date: ['date'],
+  description: ['summary', 'description'],
+};
+const skillField = { title: ['skill', 'name', 'language', 'certificate'], level: ['level'] };
+const listField = {
+  itemName: ['skill', 'award', 'language', 'certificate', 'name', 'title'],
+  itemDetail: ['level'],
+  date: ['date'],
+  summary: ['summary'],
+};
+
+export const slateSidebarTemplate: MagicTemplateDSL = {
+  id: 'slate-sidebar',
+  name: 'Slate',
+  version: '1.0.0',
+  description: 'Two-column with a dark slate sidebar, circular photo, proficiency bars, and a main-column timeline',
+  thumbnailUrl: '/thumbnails/slate-sidebar.png',
+  tags: ['two-column', 'dark', 'slate', 'photo', 'visual'],
+  status: 'PUBLISHED',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+
+  designTokens: {
+    colors: {
+      primary: '#0ea5e9',
+      secondary: '#0284c7',
+      text: '#0f172a',
+      textSecondary: '#475569',
+      background: '#ffffff',
+      border: '#e2e8f0',
+      accent: '#0ea5e9',
+      sidebar: '#1e293b',
+    },
+    typography: {
+      fontFamily: { primary: '"Inter", "Helvetica Neue", Arial, sans-serif' },
+      fontSize: { xs: '10px', sm: '12px', md: '14px', lg: '16px', xl: '19px', xxl: '23px' },
+      fontWeight: { normal: 400, medium: 600, bold: 700 },
+      lineHeight: 1.5,
+      letterSpacing: '0px',
+    },
+    spacing: { xs: '0.25rem', sm: '0.5rem', md: '0.9rem', lg: '1.1rem', xl: '1.5rem' },
+    borderRadius: { none: '0', sm: '4px', md: '8px', lg: '12px' },
+  },
+
+  layout: {
+    type: 'two-column',
+    containerWidth: '794px',
+    padding: '28px',
+    gap: '18px',
+    twoColumn: { leftWidth: '260px', rightWidth: '1fr', gap: '0' },
+    showTitleDivider: true,
+    showTitleIcon: true,
+  },
+
+  components: [
+    { id: 'profile-card', type: 'ProfileCard', dataBinding: 'info', position: { area: 'sidebar', order: 0 }, props: { title: 'Profile' } },
+    { id: 'contact-info', type: 'ContactInfo', dataBinding: 'info', position: { area: 'sidebar', order: 1 }, props: { title: 'Contact' } },
+    { id: 'skills', type: 'CompactList', dataBinding: 'sections.skills', position: { area: 'sidebar', order: 2 }, props: { title: 'Skills', levelBar: true }, fieldMap: skillField },
+    { id: 'languages', type: 'CompactList', dataBinding: 'sections.languages', position: { area: 'sidebar', order: 3 }, props: { title: 'Languages', levelBar: true }, fieldMap: skillField },
+    { id: 'certificates-side', type: 'CompactList', dataBinding: 'sections.certificates', position: { area: 'sidebar', order: 4 }, props: { title: 'Certificates' }, fieldMap: skillField },
+
+    { id: 'experience', type: 'Timeline', dataBinding: 'sections.experience', position: { area: 'main' }, props: { title: 'Experience' }, fieldMap: tlField },
+    { id: 'projects', type: 'Timeline', dataBinding: 'sections.projects', position: { area: 'main' }, props: { title: 'Projects' }, fieldMap: tlField },
+    { id: 'education', type: 'Timeline', dataBinding: 'sections.education', position: { area: 'main' }, props: { title: 'Education' }, fieldMap: tlField },
+    { id: 'awards', type: 'ListSection', dataBinding: 'sections.awards', position: { area: 'main' }, props: { title: 'Awards' }, fieldMap: listField },
+    { id: 'profiles', type: 'ListSection', dataBinding: 'sections.profiles', position: { area: 'main' }, props: { title: 'Profiles' }, fieldMap: listField },
+  ],
+};

--- a/packages/resume-templates/src/config/timeline-pro-template.ts
+++ b/packages/resume-templates/src/config/timeline-pro-template.ts
@@ -1,0 +1,68 @@
+import { MagicTemplateDSL } from '../types/magic-dsl';
+
+const tlField = {
+  title: ['company', 'school', 'name', 'project', 'platform'],
+  subtitle: ['position', 'degree', 'role', 'major'],
+  date: ['date'],
+  description: ['summary', 'description'],
+};
+const listField = {
+  itemName: ['skill', 'award', 'language', 'certificate', 'name', 'title'],
+  itemDetail: ['level'],
+  date: ['date'],
+  summary: ['summary'],
+};
+
+export const timelineProTemplate: MagicTemplateDSL = {
+  id: 'timeline-pro',
+  name: 'Timeline',
+  version: '1.0.0',
+  description: 'Career-progression focused single-column with section icons and a teal accent',
+  thumbnailUrl: '/thumbnails/timeline-pro.png',
+  tags: ['timeline', 'teal', 'modern', 'icons'],
+  status: 'PUBLISHED',
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+
+  designTokens: {
+    colors: {
+      primary: '#0d9488',
+      secondary: '#0f766e',
+      text: '#0f172a',
+      textSecondary: '#4b5563',
+      background: '#ffffff',
+      border: '#d5dbe0',
+      accent: '#0d9488',
+    },
+    typography: {
+      fontFamily: { primary: '"Inter", "Helvetica Neue", Arial, sans-serif' },
+      fontSize: { xs: '10px', sm: '12px', md: '14px', lg: '16px', xl: '19px', xxl: '24px' },
+      fontWeight: { normal: 400, medium: 600, bold: 700 },
+      lineHeight: 1.5,
+      letterSpacing: '0px',
+    },
+    spacing: { xs: '0.25rem', sm: '0.5rem', md: '0.85rem', lg: '1rem', xl: '1.5rem' },
+    borderRadius: { none: '0', sm: '2px', md: '4px', lg: '6px' },
+  },
+
+  layout: {
+    type: 'single-column',
+    containerWidth: '794px',
+    padding: '36px',
+    gap: '15px',
+    showTitleDivider: true,
+    showTitleIcon: true,
+  },
+
+  components: [
+    { id: 'header', type: 'Header', dataBinding: 'info', position: { area: 'main' }, props: { title: 'Header' }, style: { marginBottom: '4px' } },
+    { id: 'experience', type: 'Timeline', dataBinding: 'sections.experience', position: { area: 'main' }, props: { title: 'Experience' }, fieldMap: tlField },
+    { id: 'projects', type: 'Timeline', dataBinding: 'sections.projects', position: { area: 'main' }, props: { title: 'Projects' }, fieldMap: tlField },
+    { id: 'education', type: 'Timeline', dataBinding: 'sections.education', position: { area: 'main' }, props: { title: 'Education' }, fieldMap: tlField },
+    { id: 'skills', type: 'ListSection', dataBinding: 'sections.skills', position: { area: 'main' }, props: { title: 'Skills' }, fieldMap: listField },
+    { id: 'languages', type: 'ListSection', dataBinding: 'sections.languages', position: { area: 'main' }, props: { title: 'Languages' }, fieldMap: listField },
+    { id: 'certificates', type: 'ListSection', dataBinding: 'sections.certificates', position: { area: 'main' }, props: { title: 'Certificates' }, fieldMap: listField },
+    { id: 'awards', type: 'ListSection', dataBinding: 'sections.awards', position: { area: 'main' }, props: { title: 'Awards' }, fieldMap: listField },
+    { id: 'profiles', type: 'ListSection', dataBinding: 'sections.profiles', position: { area: 'main' }, props: { title: 'Profiles' }, fieldMap: listField },
+  ],
+};

--- a/packages/resume-templates/src/pdf/MagicResumePdfDocument.tsx
+++ b/packages/resume-templates/src/pdf/MagicResumePdfDocument.tsx
@@ -33,6 +33,7 @@ import { getPdfFontStack, getPdfRichTextFontFamily } from '../font-family';
 import { PdfLucideIcon } from './PdfLucideIcon';
 import { PdfRichText } from './PdfRichText';
 import { FREE_FORM_PAGE_SIZE, getFreeFormPageMinHeight } from './page-size';
+import { skillLevelToFraction } from '../templateLayout/skill-level';
 
 type PdfStyle = Style | Style[];
 
@@ -916,6 +917,9 @@ const CompactListBlock = ({ component, items, sidebar, context }: {
 }) => {
   const fields: FieldMapping = component.fieldMap ?? {};
   const color = component.style?.color ?? (sidebar ? context.colors.background : context.colors.text);
+  const levelBar = Boolean(component.props?.levelBar);
+  const trackColor = sidebar ? 'rgba(255,255,255,0.22)' : context.colors.border;
+  const fillColor = sidebar ? context.colors.background : context.colors.primary;
   return (
     <View style={toPdfComponentStyle(component.style)}>
       <SectionTitle
@@ -931,10 +935,17 @@ const CompactListBlock = ({ component, items, sidebar, context }: {
           const record = item as Record<string, unknown>;
           const name = getFieldValue(record, fields.title ?? ['name', 'skill', 'language', 'certificate']);
           const level = getFieldValue(record, fields.level ?? 'level');
+          const frac = levelBar ? skillLevelToFraction(level) : null;
           return (
             <View key={item.id || index} wrap={false} style={{ gap: 2 }}>
               <Text style={{ color, fontSize: 8.5, fontWeight: 700 }}>{name}</Text>
-              {level ? <Text style={{ color, fontSize: 7.5, opacity: 0.8 }}>{level}</Text> : null}
+              {frac !== null ? (
+                <View style={{ height: 3.5, borderRadius: 2, backgroundColor: trackColor, marginTop: 1 }}>
+                  <View style={{ width: `${Math.round(frac * 100)}%`, height: '100%', borderRadius: 2, backgroundColor: fillColor }} />
+                </View>
+              ) : level ? (
+                <Text style={{ color, fontSize: 7.5, opacity: 0.8 }}>{level}</Text>
+              ) : null}
             </View>
           );
         })}
@@ -1062,6 +1073,18 @@ export const MagicResumePdfDocument = ({ data, template, locale, cjkFallback = f
   };
   const padding = cssSizeToPoints(template.layout.padding, 24);
   const columnGap = cssSizeToPoints(template.layout.twoColumn?.gap, 0);
+  // 两栏主列用显式宽度(页宽 − 侧栏 − 列间距),不靠 flexGrow ——
+  // react-pdf 4.5.1 的 flex 对 flexGrow+minWidth:0 收敛不稳,长文本会把主列撑出页面被裁。
+  const sidebarWidth = cssSizeToPoints(template.layout.twoColumn?.leftWidth);
+  const mainColumnWidth = Math.max(0, pageWidth - sidebarWidth - columnGap);
+  // 两栏列的 padding 下限:azurill/orange/… 把 layout.padding 设成 "0",导致内容(含顶部、
+  // 侧栏)直接贴页边、没边距。给个 24pt 下限保证四周都有内边距;侧栏底色在 View 上、padding
+  // 在其内,所以底色照样铺满到页边。已有 ≥24 的模板(chikorita/gengar)不受影响。
+  const columnPadding = Math.max(padding, 24);
+  // 同理 azurill/orange/golden/teal 的 layout.gap:"0" → 分区零间距、挤成一团(尤其侧栏紧凑分区)。
+  // 给两栏列的分区间距设 12pt 下限(gap:24px 的 chikorita/gengar=18pt 不受影响;单栏不动,
+  // 保留 compact-cn-photo 故意的 0 间距)。
+  const columnSectionGap = Math.max(sectionGap, 12);
   const pageSize = { width: pageWidth };
   const pageMinHeightStyle: Style = {
     minHeight: getFreeFormPageMinHeight(pageWidth, template.layout.pageSize),
@@ -1083,20 +1106,22 @@ export const MagicResumePdfDocument = ({ data, template, locale, cjkFallback = f
         >
           <View
             style={{
-              width: cssSizeToPoints(template.layout.twoColumn.leftWidth),
+              width: sidebarWidth,
+              flexShrink: 0,
               backgroundColor: colors.sidebar ?? colors.primary,
-              padding,
-              gap: sectionGap,
+              padding: columnPadding,
+              gap: columnSectionGap,
             }}
           >
             {sidebar.map((component) => <ComponentBlock key={component.id} component={component} data={data} sidebar context={context} />)}
           </View>
           <View
             style={{
-              flexGrow: 1,
+              width: mainColumnWidth,
               flexShrink: 1,
-              padding,
-              gap: sectionGap,
+              minWidth: 0,
+              padding: columnPadding,
+              gap: columnSectionGap,
             }}
           >
             {main.map((component) => <ComponentBlock key={component.id} component={component} data={data} sidebar={false} context={context} />)}

--- a/packages/resume-templates/src/pdf/browser.tsx
+++ b/packages/resume-templates/src/pdf/browser.tsx
@@ -235,11 +235,36 @@ export const warmupMagicResumePdfExport = async (template?: MagicTemplateDSL): P
       .then(() => undefined);
 };
 
-const blobToDataUrl = (blob: Blob): Promise<string> => new Promise((resolve, reject) => {
-  const reader = new FileReader();
-  reader.onerror = () => reject(reader.error ?? new Error('Failed to read image data.'));
-  reader.onload = () => resolve(String(reader.result));
-  reader.readAsDataURL(blob);
+// 兜底转码:react-pdf(4.5.1)只认 PNG/JPEG,传 webp 会报 "Base64 image invalid format: webp"
+// (表现为「占了位却不画像素」)。我们自己传的头像现在已是 JPEG(直接跳过此转码),这里只兜底
+// 处理非 PNG/JPEG 的来源:用户粘贴的 webp/avif URL、以及历史遗留的 webp 对象。转成 JPEG(照片
+// 体积远小于 PNG)。关键:先 fetch 成 blob 再用 objectURL 画进 canvas —— objectURL 同源,不会
+// 污染 canvas,toDataURL 才不会抛 SecurityError(直接把远程 URL 塞进 <img> 画则会被污染)。
+const imageBlobToJpegDataUrl = (blob: Blob): Promise<string> => new Promise((resolve, reject) => {
+  const url = URL.createObjectURL(blob);
+  const img = new window.Image();
+  img.onload = () => {
+    URL.revokeObjectURL(url);
+    try {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.naturalWidth || 1;
+      canvas.height = img.naturalHeight || 1;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) throw new Error('Canvas 2D context unavailable.');
+      // JPEG 无 alpha:先铺白底,透明区(如透明 PNG/webp)否则会变黑。
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0);
+      resolve(canvas.toDataURL('image/jpeg', 0.9));
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error('Failed to encode avatar image.'));
+    }
+  };
+  img.onerror = () => {
+    URL.revokeObjectURL(url);
+    reject(new Error('Failed to decode avatar image.'));
+  };
+  img.src = url;
 });
 
 // Cache the remote-avatar → data-URL conversion by URL. The live preview
@@ -251,9 +276,12 @@ const fetchAvatarDataUrl = (avatar: string): Promise<string> => {
   let promise = avatarDataUrlCache.get(avatar);
   if (!promise) {
     promise = (async () => {
-      const response = await fetch(avatar, { cache: 'force-cache' });
+      // `reload`(强制走网络)而非 `force-cache`:头像对象带 immutable 一年强缓存,若浏览器
+      // 早前用 <img>(no-cors)缓存过它,force-cache 会复用那份「无 CORS 头」的旧响应,导致这里
+      // 的 cors fetch 被拦、头像被静默丢弃。会话内已有 avatarDataUrlCache 去重,重取不影响性能。
+      const response = await fetch(avatar, { cache: 'reload' });
       if (!response.ok) throw new Error(`Avatar request failed with ${response.status}.`);
-      return blobToDataUrl(await response.blob());
+      return imageBlobToJpegDataUrl(await response.blob());
     })();
     // Never cache a rejection — allow the next render to retry a failed fetch.
     void promise.catch(() => avatarDataUrlCache.delete(avatar));
@@ -264,10 +292,16 @@ const fetchAvatarDataUrl = (avatar: string): Promise<string> => {
 
 const prepareResumeImages = async (data: Resume): Promise<Resume> => {
   const avatar = data.info.avatar;
-  if (!avatar || avatar.startsWith('data:')) return data;
+  if (!avatar) return data;
+
+  // 已是 react-pdf 认得的 PNG/JPEG data URL 就直接用;远程 URL 与 webp data URL(self-hosted
+  // 内嵌)都要转成 PNG,否则 react-pdf 报 "Base64 image invalid format"。
+  if (/^data:image\/(png|jpe?g);/i.test(avatar)) return data;
 
   try {
-    const dataUrl = await fetchAvatarDataUrl(avatar);
+    const dataUrl = avatar.startsWith('data:')
+      ? await imageBlobToJpegDataUrl(await (await fetch(avatar)).blob())
+      : await fetchAvatarDataUrl(avatar);
     return { ...data, info: { ...data.info, avatar: dataUrl } };
   } catch {
     // A remote avatar should not prevent the rest of the resume from exporting.

--- a/packages/resume-templates/src/registry.ts
+++ b/packages/resume-templates/src/registry.ts
@@ -12,6 +12,12 @@ import { orangeModernTemplate } from './config/orange-modern-template';
 import { productOpsFocusTemplate } from './config/product-ops-focus-template';
 import { redAccentTemplate } from './config/red-accent-template';
 import { tealProfessionalTemplate } from './config/teal-professional-template';
+import { executiveBandTemplate } from './config/executive-band-template';
+import { timelineProTemplate } from './config/timeline-pro-template';
+import { skillsFirstTemplate } from './config/skills-first-template';
+import { serifMinimalTemplate } from './config/serif-minimal-template';
+import { slateSidebarTemplate } from './config/slate-sidebar-template';
+import { cnFormalPhotoTemplate } from './config/cn-formal-photo-template';
 import type { MagicTemplateDSL } from './types/magic-dsl';
 
 export type TemplateManifest = {
@@ -57,6 +63,12 @@ export const templateRegistry: Record<TemplateId, TemplateManifest> = {
   'golden-elegant': createManifest(goldenElegantTemplate),
   'product-ops-focus': createManifest(productOpsFocusTemplate),
   'compact-cn-photo': createManifest(compactCnPhotoTemplate),
+  'executive-band': createManifest(executiveBandTemplate),
+  'timeline-pro': createManifest(timelineProTemplate),
+  'skills-first': createManifest(skillsFirstTemplate),
+  'serif-minimal': createManifest(serifMinimalTemplate),
+  'slate-sidebar': createManifest(slateSidebarTemplate),
+  'cn-formal-photo': createManifest(cnFormalPhotoTemplate),
 };
 
 export const templateManifestList = Object.values(templateRegistry);

--- a/packages/resume-templates/src/templateLayout/CenteredPhotoHeader.tsx
+++ b/packages/resume-templates/src/templateLayout/CenteredPhotoHeader.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Image from 'next/image';
 import { useTranslation } from 'react-i18next';
 import type { InfoType } from '../types/resume';
 import { Editable } from '../renderer/EditableCanvas';
@@ -64,7 +63,9 @@ export const CenteredPhotoHeader = React.memo(function CenteredPhotoHeader({
   }
 
   const avatar = info.avatar ? (
-    <Image
+    // 原生 img:任意来源头像(R2/自定义域名/data:URL)都能渲染,不受 next/image 白名单限制。
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
       src={info.avatar}
       alt={t('basicForm.avatarAlt')}
       width={avatarWidth}
@@ -75,7 +76,6 @@ export const CenteredPhotoHeader = React.memo(function CenteredPhotoHeader({
         height: `${avatarHeight}px`,
         background: 'var(--color-background)',
       }}
-      unoptimized
     />
   ) : null;
 

--- a/packages/resume-templates/src/templateLayout/CompactList.tsx
+++ b/packages/resume-templates/src/templateLayout/CompactList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { getFieldValue } from './utils';
+import { skillLevelToFraction } from './skill-level';
 
 interface Item {
   [key: string]: unknown;
@@ -14,9 +15,11 @@ interface Props {
     area?: 'main' | 'sidebar' | 'header' | 'footer';
   };
   titleIcon?: React.ComponentType<{ size?: number; style?: React.CSSProperties }>;
+  /** 把 level 文本画成进度条(如"精通"→满格),识别不了的等级回退成文字 */
+  levelBar?: boolean;
 }
 
-export const CompactList = React.memo(function CompactList({ title, items, fieldMap = {}, style, position, titleIcon: TitleIcon }: Props) {
+export const CompactList = React.memo(function CompactList({ title, items, fieldMap = {}, style, position, titleIcon: TitleIcon, levelBar }: Props) {
   if (!items || items.length === 0) return null;
 
   const isInSidebar = position?.area === 'sidebar';
@@ -65,17 +68,24 @@ export const CompactList = React.memo(function CompactList({ title, items, field
         {items.map((item, idx) => {
           const name = getFieldValue(item, fieldMap.title || ['name', 'skill', 'language', 'certificate']);
           const level = getFieldValue(item, fieldMap.level || 'level');
-          
+          const frac = levelBar ? skillLevelToFraction(level) : null;
+          const trackColor = isInSidebar ? 'rgba(255,255,255,0.22)' : 'var(--color-border)';
+          const fillColor = isInSidebar ? 'var(--color-background)' : 'var(--color-primary)';
+
           return (
             <li key={idx} style={{ color: textColor }}>
               <div className="font-medium" style={{ fontSize: 'var(--font-size-body)' }}>
                 {name}
               </div>
-              {level && (
+              {frac !== null ? (
+                <div style={{ marginTop: 4, height: 5, borderRadius: 3, background: trackColor, overflow: 'hidden' }}>
+                  <div style={{ width: `${Math.round(frac * 100)}%`, height: '100%', borderRadius: 3, background: fillColor }} />
+                </div>
+              ) : level ? (
                 <div className="mt-1" style={{ color: secondaryColor, fontSize: 'var(--font-size-body)' }}>
                   {level}
                 </div>
-              )}
+              ) : null}
             </li>
           );
         })}

--- a/packages/resume-templates/src/templateLayout/Header.tsx
+++ b/packages/resume-templates/src/templateLayout/Header.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { InfoType } from '../types/resume';
 import { MapPin, Phone, Mail, Globe } from 'lucide-react';
-import Image from 'next/image';
 import { useTranslation } from 'react-i18next';
 import { Editable } from '../renderer/EditableCanvas';
 import { safeHref } from './utils';
@@ -44,7 +43,10 @@ export const Header = React.memo(function Header({
   const isRightAvatarLayout = avatarPosition === 'right';
 
   const avatarNode = info.avatar ? (
-    <Image
+    // 原生 img:头像可能是 R2 URL / 自定义域名 / data:URL,不走 next/image
+    // 的域名白名单,任意来源都能渲染(与 PDF/表单预览一致)。
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
       src={info.avatar}
       alt={t('basicForm.avatarAlt')}
       width={avatarWidth}
@@ -57,7 +59,6 @@ export const Header = React.memo(function Header({
         borderColor: 'var(--color-border)',
         boxShadow: '0 1px 2px rgba(0, 0, 0, 0.06)',
       }}
-      unoptimized
     />
   ) : null;
 

--- a/packages/resume-templates/src/templateLayout/ProfileCard.tsx
+++ b/packages/resume-templates/src/templateLayout/ProfileCard.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { InfoType } from '../types/resume';
-import Image from 'next/image';
 import { MapPin, Phone, Mail, Globe } from 'lucide-react';
 
 interface Props {
@@ -42,14 +41,15 @@ export const ProfileCard = React.memo(function ProfileCard({ data: info, style, 
       >
         {info.avatar && (
           <div className="flex justify-center">
-            <Image
+            {/* 原生 img:任意来源头像都能渲染,不受 next/image 域名白名单限制 */}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
               src={info.avatar}
               alt="Profile"
               width={120}
               height={120}
               className="w-30 h-30 rounded-full object-cover border-4 shadow-lg"
               style={{ borderColor }}
-              unoptimized
             />
           </div>
         )}
@@ -83,14 +83,15 @@ export const ProfileCard = React.memo(function ProfileCard({ data: info, style, 
     >
       {info.avatar && (
         <div className="flex justify-center">
-          <Image
+          {/* 原生 img:任意来源头像都能渲染,不受 next/image 域名白名单限制 */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
             src={info.avatar}
             alt="Profile"
             width={120}
             height={120}
             className="w-30 h-30 rounded-full object-cover border-4 shadow-lg"
             style={{ borderColor }}
-            unoptimized
           />
         </div>
       )}

--- a/packages/resume-templates/src/templateLayout/skill-level.ts
+++ b/packages/resume-templates/src/templateLayout/skill-level.ts
@@ -1,0 +1,37 @@
+/**
+ * 把技能/语言的等级文本(自由文本,如 "精通"/"Advanced"/"B2"/"90%"/"4")归一化为 0–1 比例,
+ * 供带 `levelBar` 的模板画进度条。识别不了就返回 null(调用方回退成纯文本)。
+ *
+ * 无任何依赖 —— 供 HTML 渲染器(CompactList)与 PDF 渲染器共同 import。
+ */
+const LEVEL_FRACTIONS: Record<string, number> = {
+  // 中文
+  '母语': 1, '精通': 1, '熟练': 0.82, '掌握': 0.72, '熟悉': 0.62, '良好': 0.6, '一般': 0.45, '了解': 0.4, '入门': 0.3, '基础': 0.35,
+  // 英文
+  native: 1, expert: 1, fluent: 0.9, advanced: 0.85, proficient: 0.8, professional: 0.78,
+  'upper intermediate': 0.7, intermediate: 0.6, conversational: 0.5, elementary: 0.4, basic: 0.35, beginner: 0.3, novice: 0.25,
+  // CEFR
+  c2: 1, c1: 0.85, b2: 0.7, b1: 0.55, a2: 0.4, a1: 0.25,
+};
+
+export function skillLevelToFraction(level: string | undefined | null): number | null {
+  if (!level) return null;
+  const raw = String(level).trim().toLowerCase();
+  if (!raw) return null;
+
+  const pct = raw.match(/^(\d{1,3})\s*%$/);
+  if (pct) return Math.min(1, Math.max(0, Number(pct[1]) / 100));
+
+  const num = Number(raw);
+  if (Number.isFinite(num)) {
+    if (num > 0 && num <= 1) return num;
+    if (num > 1 && num <= 5) return num / 5;
+    if (num > 5 && num <= 100) return num / 100;
+  }
+
+  if (raw in LEVEL_FRACTIONS) return LEVEL_FRACTIONS[raw];
+  for (const key of Object.keys(LEVEL_FRACTIONS)) {
+    if (key.length > 1 && raw.includes(key)) return LEVEL_FRACTIONS[key];
+  }
+  return null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1100.0
+        version: 3.1100.0
       '@clerk/nextjs':
         specifier: ^6.22.0
         version: 6.39.5(next@15.3.8(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -515,6 +518,78 @@ packages:
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@aws-sdk/checksums@3.1000.24':
+    resolution: {integrity: sha512-7TWLjypP8kk3savsDBRuhZJx7mBuFFA2136BQhwwLllsAnO4Tmq/p+SXZaNxbuulkzUFz3BZzj0bb4YzexZcNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1100.0':
+    resolution: {integrity: sha512-5IvIlW6kWOC9EPq2RM7VQUgfDF2QFHHFgQJ2DichmrYBDg5yiAmqMkDiHqUSkFYosVexXaXD/lV4yYxTyA27zw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.4':
+    resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.65':
+    resolution: {integrity: sha512-lJT2aRw9wCV8jPHyFJjdZLD4HTydL6/22AnCSOB8e/LqOc55nEJGLHkJQeSxhn8QiqyjFwPKQFtMw0ovjRUY/g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.67':
+    resolution: {integrity: sha512-N7fw/15hSwI/CPxe5ohOyb7O4ge9f5me1gVIn8OIkBRB0squ8OJqQyDyH/HoL+Sb1W5xdC88jVC+bHkw73iu+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.10':
+    resolution: {integrity: sha512-Zh9XRaPnDN9buO7GfWBubS22R6Nq5D6hbyYEMN05LiOnXugm/8WDjUx6y756bSPbdn3aJB2qG4zFW3bN82QhoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.72':
+    resolution: {integrity: sha512-zZapIKwaHp7TdTf9hbH1I3CVUdEupmt7FXO/BoTQGC+4h6NkXKWpqF2p5WyfpjurDLHCpSyh+BzMlAg8arqWLA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.76':
+    resolution: {integrity: sha512-1yzLmRiYSgGC25v7ZZEwJn/auhHHTIHgFOmzL2f36hf1+7jSLcX+1QrAz4760WEzPiiQl8xmlpFhHfl2OoyVzA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.65':
+    resolution: {integrity: sha512-e5DbbNteOSalN58U83G6kFa4ECLEuGbGqNBHIXE7zYXA/m4GHblIGjFbSH7wYv6gBV8iNSDcRZBKfQZF5vF9nw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.9':
+    resolution: {integrity: sha512-0V0u4t+KBku9fbh5CPCaC5hUWwSzDafp8nCuDy817zWbp2gz80jO44rMQkiwnZ+k54B+tjAtzRy00DJRGTKGBg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.71':
+    resolution: {integrity: sha512-e4dwiRltGAaQ+2yxw57Hj0l/BF3BHiG14+QpYE7bGYBlpAq/fkIri2BDhjWon8c0mhhtd2txQBAkQb9BcTStFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.70':
+    resolution: {integrity: sha512-APdP0iODt39AkjCjzTFIoFrxDH/Cz3CpWRDKLcsJg7eOnfE1htkxL9BhDoe/xL7cXdoMwh2HBYv3DiT1uf64NQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.39':
+    resolution: {integrity: sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1100.0':
+    resolution: {integrity: sha512-THf3MkgY3fNJZ3zdgSenLqR7gSE68KccCj1RCKretlG73Ppszvues02VpCUO9NlB/tZDC483FvGCld+AiPCkvg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -2917,6 +2992,30 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.16':
+    resolution: {integrity: sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.13':
+    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.13':
+    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
+    engines: {node: '>=18.0.0'}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -3818,6 +3917,9 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
@@ -7334,6 +7436,171 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@aws-sdk/checksums@3.1000.24':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1100.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1000.24
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-node': 3.972.76
+      '@aws-sdk/middleware-sdk-s3': 3.972.70
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.4':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.67':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.10':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-login': 3.972.72
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.72':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.76':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.65
+      '@aws-sdk/credential-provider-http': 3.972.67
+      '@aws-sdk/credential-provider-ini': 3.973.10
+      '@aws-sdk/credential-provider-process': 3.972.65
+      '@aws-sdk/credential-provider-sso': 3.973.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.71
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/credential-provider-imds': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.9':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/token-providers': 3.1100.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.70':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.39':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1100.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
+
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -9573,6 +9840,39 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@smithy/core@3.31.1':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@stablelib/base64@1.0.1': {}
 
   '@swc/counter@0.1.3': {}
@@ -10581,6 +10881,8 @@ snapshots:
       - supports-color
 
   boolbase@1.0.0: {}
+
+  bowser@2.14.1: {}
 
   boxen@8.0.1:
     dependencies:


### PR DESCRIPTION
## 概述
两块内容：**头像上传**（Cloudflare R2）+ **6 个新简历模板**（附带两栏 PDF 布局修复）。

> ⚠️ **堆叠 PR**：base 指向 `fix/resume-import-fields-and-custom-sections`（#162），因为本改动建立在其提交之上。**#162 合入 master 后，请把本 PR 的 base 改成 `master`**，diff 即为纯本次改动。

## 头像上传
- 头像从「只能填 URL」→ 可上传（`AvatarField` 点击上传 + loading/清除，保留 URL 输入）。
- **cloud**：客户端压到 ≤512px **JPEG** → `POST /api/uploads/avatar`（Next route）→ 服务端 S3 兼容 API 传 **Cloudflare R2** → 回公开 URL。
- **self-hosted**：压缩后返回 `data:image/jpeg` 内嵌进简历 JSON，零后端。
- **防盗刷**：每用户**固定 key 覆盖写**（存储硬封顶「每人 1 个对象」）；服务端 **512KB** 上限 + 魔数校验（拒 SVG）+ 每用户限流；密钥仅服务端。
- **格式=JPEG**：react-pdf 不认 webp；PDF 管线把远程头像 `fetch`→canvas 重编码成 JPEG 兜底（需桶 CORS，已配）。
- 模板/PDF 头像渲染从 `next/image` 改原生 `<img>`（任意来源/data-URL 都能显示）。

## 6 个新模板
`executive-band`（色带页眉）· `timeline-pro`（时间轴）· `skills-first`（技能进度条）· `serif-minimal`（衬线克制）· `slate-sidebar`（深板岩两栏+圆头像+进度条）· `cn-formal-photo`（中文正装证件照）。

- 新增 **CompactList 等级条**：可选 `levelBar`，把 `精通/Advanced/B2/90%` 等等级文本映射成进度条；**两渲染器都 prop-gated，现有模板不受影响**。
- 顺带修**两栏 PDF 布局**：正文溢出裁切（主列改显式宽度）、`padding:0` 模板缺失的四周边距与分区间距。

## 未包含
- `apps/web/.env.local`（含 R2 密钥）**未提交**（gitignore）。**生产需配 `R2_*` 五个环境变量**（见 `.env.example`）。

## 验证
- schema / resume-templates typecheck + build ✅；web `tsc --noEmit` exit 0 ✅；`next lint` ✅。
- 两次提交的 **pre-commit 全量 turbo build 均通过**。
- 视觉验收由本人在预览中完成。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
