### PR TITLE
:lock: fix(web): 分享出去的简历不再进搜索引擎索引

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -177,6 +177,21 @@ const nextConfig: NextConfig = {
   },
   output: "standalone",
   transpilePackages: ['@magic-resume/resume-templates'],
+
+  // 分享出去的简历页里是真名 / 电话 / 邮箱 / 履历。页面自己已经声明了
+  // `robots: { index: false, follow: false }`，这里再发一遍响应头：meta 只在
+  // HTML 文档里有效，而这条对 OG 图、预取、任何非 HTML 响应同样成立，
+  // 也不依赖爬虫解析到 <head>。
+  async headers() {
+    return [
+      {
+        source: '/s/:path*',
+        headers: [
+          { key: 'X-Robots-Tag', value: 'noindex, nofollow, noarchive' },
+        ],
+      },
+    ];
+  },
   
   // 图片优化
   images: {

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,37 +1,48 @@
 import { MetadataRoute } from 'next'
 
+// robots.txt 的分组语义：一个爬虫只服从**最具体**的那一组，且那一组会**完全替换**
+// `*` 组 —— 不是叠加。所以任何具名 UA 组都必须自带完整的 disallow，
+// 否则给 Googlebot 单独调 crawlDelay 的那一行会顺手把 `*` 组的所有限制全部撤销
+// （此前 /dashboard*、/api/* 对 Googlebot 是完全放开的）。
+const DISALLOW = [
+  '/dashboard*',
+  '/edit*',
+  '/api/*',
+  '/sign-in*',
+  '/sign-up*',
+  '/*?*', // 禁止带参数的URL
+]
+
+// `/s/*`（分享出去的简历，页面里有真名 / 电话 / 邮箱）**故意不写进 disallow**：
+// 被 robots.txt 挡住的页面爬虫根本抓不到，也就看不到页面里的 `noindex`，
+// 反而可能被"仅 URL"收录且撤不下来。让它可抓、由 `s/[shareId]/page.tsx` 的
+// `robots: { index: false, follow: false }` 明确要求除名，才是能真正生效的那条路。
+
 export default function robots(): MetadataRoute.Robots {
   const baseUrl = 'https://magic-resume.cn'
-  
+
   return {
     rules: [
       {
         userAgent: '*',
-        allow: [
-          '/'
-        ],
-        disallow: [
-          '/dashboard*',
-          '/edit*', 
-          '/api/*',
-          '/sign-in*',
-          '/sign-up*',
-          '/*?*'  // 禁止带参数的URL
-        ],
+        allow: ['/'],
+        disallow: DISALLOW,
         crawlDelay: 1,
       },
       {
         userAgent: 'Googlebot',
         allow: '/',
+        disallow: DISALLOW,
         crawlDelay: 0,
       },
       {
         userAgent: 'Baiduspider',
         allow: '/',
+        disallow: DISALLOW,
         crawlDelay: 1,
-      }
+      },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,
     host: baseUrl,
   }
-} 
+}

--- a/apps/web/src/app/s/[shareId]/page.tsx
+++ b/apps/web/src/app/s/[shareId]/page.tsx
@@ -28,6 +28,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
         return {
             title,
             description,
+            // 分享链接是给收件人看的，不是给搜索引擎看的：这一页上有真名、电话、
+            // 邮箱、教育与履历，一旦进了索引就再也收不回来。OG / Twitter 卡片
+            // 不受影响，聊天工具里的预览照常。
+            robots: { index: false, follow: false },
             openGraph: {
                 title,
                 description,
@@ -51,6 +55,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: 'Magic Resume',
     description: 'Magic Resume - AI 智能简历制作器',
+    // 取不到简历时也一样不进索引：失败分支同样落在 /s/*，且下一次请求可能就取到了。
+    robots: { index: false, follow: false },
     openGraph: {
       title: 'Magic Resume',
       description: 'Magic Resume - AI 智能简历制作器',


### PR DESCRIPTION
来自 `docs/reviews/2026-08-01-commercial-readiness-audit.md` 第 0 层 0.2 —— 审计里 16 条实证问题中**唯一正在流血、且十分钟能改完**的一条。

## 问题

`/s/[shareId]` 的 `generateMetadata` 把真实姓名写进 `title` 与 description，页面正文里是电话、邮箱、教育与履历，而 `openGraph.type: 'profile'`、没有任何 `robots` 声明。后端 `GET /resumes/shared/:shareId` 是 `@Public()`。

robots.txt 也拦不住：分组语义是「最具体的一组**完全替换**」而不是叠加，所以

```ts
{ userAgent: 'Googlebot', allow: '/', crawlDelay: 0 }   // 无任何 disallow
```

这一行顺手把 `*` 组的全部限制对 Googlebot 撤销了 —— 连 `/dashboard*`、`/api/*` 都成了明确放行。

求职者点一次「分享」，姓名 / 电话 / 邮箱 / 教育 / 履历就可能进 Google 与百度索引，且无法收回。

## 改了什么

- 具名 UA 组（Googlebot / Baiduspider）补齐与 `*` 组相同的 disallow
- `/s/[shareId]` 两个 metadata 分支都声明 `robots: { index: false, follow: false }`
- `/s/:path*` 再发一条 `X-Robots-Tag: noindex, nofollow, noarchive`，覆盖 meta 到不了的非 HTML 响应

## 一处刻意的取舍

`/s/*` **故意没有**写进 robots.txt 的 disallow。被 robots.txt 挡住的页面爬虫根本抓不到，也就看不到页面里的 `noindex`，反而可能被「仅 URL」收录且撤不下来。让它可抓、由页面明确要求除名，才是能真正生效的那条路。文件里写了注释说明，免得下次有人「顺手补上」。

## 验证

`pnpm build` 通过；已核对产出的 `robots.txt`，三个 UA 组的 disallow 一致。OG / Twitter 卡片不受影响，聊天工具里的预览照常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Krx1sxjgSU27uMyKQEvuet