### PR TITLE
:memo: docs(changelog): 删掉误判产生的 v1.0.0 段

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,6 @@
 
 All notable changes to Magic Resume are documented in this file.
 
-# v1.0.0 (2026-08-03)
-
-## ✨ New Features
-- [`7dd2b74`](https://github.com/Magic-Resume/Magic-Resume/commit/7dd2b74)  feat(web): stream PDF import with scanline parse progress (#129) (Issues: [`#129`](https://github.com/Magic-Resume/Magic-Resume/issues/129))
-- [`6c18398`](https://github.com/Magic-Resume/Magic-Resume/commit/6c18398)  feat(web): add switchable light theme (#130) (Issues: [`#130`](https://github.com/Magic-Resume/Magic-Resume/issues/130))
-- [`bd928d2`](https://github.com/Magic-Resume/Magic-Resume/commit/bd928d2)  feat(web): render resume preview with PDF canvas (#120) (Issues: [`#120`](https://github.com/Magic-Resume/Magic-Resume/issues/120))
-- [`ae2779e`](https://github.com/Magic-Resume/Magic-Resume/commit/ae2779e)  feat(web): default system theme + credit-free monthly quota UI (#149) (Issues: [`#149`](https://github.com/Magic-Resume/Magic-Resume/issues/149))
-- [`df9e30c`](https://github.com/Magic-Resume/Magic-Resume/commit/df9e30c)  feat(web): mark the pages a conversion passes through (#153) (#154) (Issues: [`#153`](https://github.com/Magic-Resume/Magic-Resume/issues/153) [`#154`](https://github.com/Magic-Resume/Magic-Resume/issues/154))
-- [`18d99bd`](https://github.com/Magic-Resume/Magic-Resume/commit/18d99bd)  feat: add compact Chinese photo resume template (#156) (Issues: [`#156`](https://github.com/Magic-Resume/Magic-Resume/issues/156))
-
-## 🐛 Bug Fixes
-- [`f081266`](https://github.com/Magic-Resume/Magic-Resume/commit/f081266)  fix(web): keep chat-agent SSE unbuffered through nginx (#121) (Issues: [`#121`](https://github.com/Magic-Resume/Magic-Resume/issues/121))
-- [`64507b0`](https://github.com/Magic-Resume/Magic-Resume/commit/64507b0)  fix(web): unwrap pdf parse backend response (#122) (Issues: [`#122`](https://github.com/Magic-Resume/Magic-Resume/issues/122))
-- [`caaf8ab`](https://github.com/Magic-Resume/Magic-Resume/commit/caaf8ab)  fix(web): move window.__ENV injection out of the commercial-overlaid runtime module (#147) (Issues: [`#147`](https://github.com/Magic-Resume/Magic-Resume/issues/147))
-
-## 🔒 Security Issues
-- [`4d1205a`](https://github.com/Magic-Resume/Magic-Resume/commit/4d1205a)  chore: remove OSS analytics facade (#114) (Issues: [`#114`](https://github.com/Magic-Resume/Magic-Resume/issues/114))
-
 # [v2.5.0](https://github.com/Magic-Resume/Magic-Resume/compare/v2.4.0...v2.5.0) (2026-07-30)
 
 ## ✨ New Features


### PR DESCRIPTION
配合本次版本号回退的修复。

## 背景

`v1.0.0` / `v1.0.1` / `v1.0.2` 这三个版本是误判产生的：master 的历史在 `release-2026-07-30 → master (#164)` 前后被重写过，v2.0.0–v2.5.0 全部 8 个 tag 指向的 commit 都不再在 master 历史里。semantic-release 只认从当前分支可达的 tag，于是在 2026-08-03 那次运行里报了：

```
No previous release found, retrieving all commits
There is no previous release, the next release version is 1.0.0
```

首次发布固定是 1.0.0 且不看 commit 类型，这也解释了它为什么会打在一个 `:memo: docs(changelog)` 提交上——按 `.releaserc.json` 的配置，docs 本来不该触发发布。

## 已处理

- 8 个 v2.x tag 重新指向 master 里的等价提交（内容一致，只是历史重写后 SHA 变了）
- 删除 `v1.0.0` / `v1.0.1` / `v1.0.2` 的 tag 与 GitHub Release，`v2.5.0` 重新成为 Latest
- 关闭为这些版本自动开的 changelog PR #175 #176

## 本 PR

删掉 CHANGELOG 里的 v1.0.0 段。它是「首次发布」模式下把全部历史提交重列了一遍的产物，没有独有信息——例如 `18d99bd` 同时出现在 v1.0.0 和 v2.5.0 两段里。

合并后下一次发布会从 v2.5.0 继续。

## 遗留

v2.x 各段里的 commit 链接指向的是历史重写前的旧 SHA。GitHub 通常仍能打开游离提交，所以不算坏链，但严格说已经对不上当前历史了。要不要回填是另一个话题，本 PR 不动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
