### PR TITLE
:green_heart: ci(release): 发布前校验最高 tag 是否可达

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,51 @@ jobs:
           fetch-depth: 0 # semantic-release needs full history + tags
           persist-credentials: true
 
+      # Guard against a silent version regression.
+      #
+      # semantic-release only considers tags reachable from the current branch. If
+      # the branch history is rewritten, older tags keep pointing at commits that
+      # are no longer ancestors of HEAD — semantic-release then reports "no previous
+      # release" and cuts an initial 1.0.0, regardless of commit types. That is what
+      # happened in August 2026: every v2.x tag was orphaned by a history rewrite and
+      # the next push produced v1.0.0 on a `:memo: docs` commit, below the v2.5.0
+      # that already existed.
+      #
+      # Failing here is the point. A red workflow is trivially recoverable; a
+      # published version that goes backwards is not.
+      - name: Verify the highest release tag is still reachable
+        run: |
+          set -euo pipefail
+          latest="$(git tag --list 'v*' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V | tail -1 || true)"
+
+          if [ -z "$latest" ]; then
+            echo "No release tags exist yet — treating this as a genuine first release."
+            exit 0
+          fi
+
+          if git merge-base --is-ancestor "$latest" HEAD; then
+            echo "OK — $latest is an ancestor of HEAD; semantic-release will build on it."
+            exit 0
+          fi
+
+          # No leading whitespace: ::error:: is only parsed as a workflow command
+          # when it starts the line.
+          echo "::error::Highest release tag $latest ($(git rev-parse --short "$latest")) is not reachable from HEAD — refusing to release."
+          echo
+          echo "semantic-release would ignore it, report 'no previous release', and cut a"
+          echo "fresh 1.0.0 — a version regression. Stopping instead."
+          echo
+          echo "This usually means the branch history was rewritten and the old tags now"
+          echo "point at orphaned commits. To fix, re-point each affected tag at its"
+          echo "equivalent commit in the current history, e.g.:"
+          echo
+          echo "    git push origin --force <new-sha>:refs/tags/$latest"
+          echo
+          echo "See docs/reference/release-automation.md for the full procedure."
+          exit 1
+
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,6 @@
 
 All notable changes to Magic Resume are documented in this file.
 
-# v1.0.0 (2026-08-03)
-
-## ✨ New Features
-- [`7dd2b74`](https://github.com/Magic-Resume/Magic-Resume/commit/7dd2b74)  feat(web): stream PDF import with scanline parse progress (#129) (Issues: [`#129`](https://github.com/Magic-Resume/Magic-Resume/issues/129))
-- [`6c18398`](https://github.com/Magic-Resume/Magic-Resume/commit/6c18398)  feat(web): add switchable light theme (#130) (Issues: [`#130`](https://github.com/Magic-Resume/Magic-Resume/issues/130))
-- [`bd928d2`](https://github.com/Magic-Resume/Magic-Resume/commit/bd928d2)  feat(web): render resume preview with PDF canvas (#120) (Issues: [`#120`](https://github.com/Magic-Resume/Magic-Resume/issues/120))
-- [`ae2779e`](https://github.com/Magic-Resume/Magic-Resume/commit/ae2779e)  feat(web): default system theme + credit-free monthly quota UI (#149) (Issues: [`#149`](https://github.com/Magic-Resume/Magic-Resume/issues/149))
-- [`df9e30c`](https://github.com/Magic-Resume/Magic-Resume/commit/df9e30c)  feat(web): mark the pages a conversion passes through (#153) (#154) (Issues: [`#153`](https://github.com/Magic-Resume/Magic-Resume/issues/153) [`#154`](https://github.com/Magic-Resume/Magic-Resume/issues/154))
-- [`18d99bd`](https://github.com/Magic-Resume/Magic-Resume/commit/18d99bd)  feat: add compact Chinese photo resume template (#156) (Issues: [`#156`](https://github.com/Magic-Resume/Magic-Resume/issues/156))
-
-## 🐛 Bug Fixes
-- [`f081266`](https://github.com/Magic-Resume/Magic-Resume/commit/f081266)  fix(web): keep chat-agent SSE unbuffered through nginx (#121) (Issues: [`#121`](https://github.com/Magic-Resume/Magic-Resume/issues/121))
-- [`64507b0`](https://github.com/Magic-Resume/Magic-Resume/commit/64507b0)  fix(web): unwrap pdf parse backend response (#122) (Issues: [`#122`](https://github.com/Magic-Resume/Magic-Resume/issues/122))
-- [`caaf8ab`](https://github.com/Magic-Resume/Magic-Resume/commit/caaf8ab)  fix(web): move window.__ENV injection out of the commercial-overlaid runtime module (#147) (Issues: [`#147`](https://github.com/Magic-Resume/Magic-Resume/issues/147))
-
-## 🔒 Security Issues
-- [`4d1205a`](https://github.com/Magic-Resume/Magic-Resume/commit/4d1205a)  chore: remove OSS analytics facade (#114) (Issues: [`#114`](https://github.com/Magic-Resume/Magic-Resume/issues/114))
-
 # [v2.5.0](https://github.com/Magic-Resume/Magic-Resume/compare/v2.4.0...v2.5.0) (2026-07-30)
 
 ## ✨ New Features

--- a/docs/reference/release-automation.md
+++ b/docs/reference/release-automation.md
@@ -55,6 +55,56 @@ release-worthy commit. Adjust the lists in `.releaserc.json` to taste.
   `github-actions[bot]` bypass on the branch ruleset and swap the
   `create-pull-request` step for the `@semantic-release/git` plugin.
 
+## Guard: the highest tag must stay reachable
+
+Before running semantic-release the workflow checks that the highest `vX.Y.Z` tag
+is an ancestor of `HEAD`. If it is not, the job fails instead of releasing.
+
+This exists because of a real incident. In August 2026 master's history was
+rewritten; all eight `v2.x` tags kept pointing at commits that were no longer
+ancestors of master. semantic-release only considers **reachable** tags, so it
+reported `No previous release found` and cut an initial **1.0.0** — below the
+existing `v2.5.0`, and on a `:memo: docs` commit that the config says should never
+trigger a release at all (an initial release ignores commit types). Two more
+patch releases stacked on top before anyone noticed, because nothing was broken
+from the outside: the workflow was green every time.
+
+A failed workflow is trivial to recover from. A published version number that
+goes backwards is not — so this check fails loudly rather than guessing.
+
+### When it fires
+
+Almost always: history was rewritten (force push, rebuilt release branch,
+squash-remerge) and the old tags are now orphaned. Confirm with:
+
+```bash
+git ls-remote --tags origin | grep -v '\^{}' | while read sha ref; do
+  git merge-base --is-ancestor "$sha" origin/master \
+    && echo "ok   ${ref#refs/tags/}" || echo "ORPHAN ${ref#refs/tags/} $sha"
+done
+```
+
+Fix by re-pointing each orphaned tag at the equivalent commit in the current
+history — match by commit subject, the content survives a rewrite even though the
+SHA does not:
+
+```bash
+git push origin --force <new-sha>:refs/tags/<tag>
+```
+
+> Run these one per line. Wrapping `git push` in `$(...)` or putting it in a
+> `set -e` pipeline has been observed to silently skip the push while reporting
+> success.
+
+Note that `git fetch --tags` does **not** move tags that already exist locally, so
+a local clone can look perfectly healthy while the remote tags are orphaned. Use
+`git ls-remote` (as above) or `git fetch --tags --force` when investigating.
+
+### The one case where it must not fire
+
+A genuine first release, when no `vX.Y.Z` tag exists at all. The check exits 0 in
+that case — an empty tag list is not the same as an unreachable tag.
+
 ## Verifying / dry-run
 
 Locally, against the real history (`--dry-run` skips publishing; use `--no-ci` to


### PR DESCRIPTION
堵住这次版本号倒退的根因，而不只是修复现场。

## 问题

semantic-release 只考虑**从当前分支可达**的 tag。历史一旦被重写，旧 tag 就指向不再是 `HEAD` 祖先的提交，它会报 `no previous release` 并按首次发布切出 `1.0.0`——而首次发布**不看 commit 类型**，所以连 `:memo: docs` 提交都会触发发布。

2026-08 正是如此：8 个 `v2.x` tag 全部孤儿化，master 上切出了 `v1.0.0` 压在已存在的 `v2.5.0` 下面，后面又叠了两个 patch 才被发现。

**最难受的一点是全程 workflow 都是绿的。** 没有任何报错，从外部看不出异常，所以潜伏了好几天。

## 改动

发布前加一步检查：最高的 `vX.Y.Z` tag 必须是 `HEAD` 的祖先，否则直接失败，并在日志里打出重新指向 tag 的命令。

放在 checkout 之后、装工具链之前，尽早失败不浪费一次 npm install。

**没有任何 tag 时照常放行**——真正的首次发布是合法的，空 tag 列表和不可达的 tag 是两回事。

## 已验证

| 用例 | 结果 |
|---|---|
| 当前 master（v2.5.0 可达） | exit 0，放行 |
| HEAD 停在 v2.3.0（v2.5.0 不可达） | exit 1，打印 `::error::` 并拦截 |
| 无 tag | exit 0，放行 |

YAML 解析通过，6 个步骤。`::error::` 行刻意不缩进——只有在行首才会被 Actions 识别为 workflow command。

## 文档

`docs/reference/release-automation.md` 补了这一节，含排查命令与修复步骤，以及两个害我绕路的坑：

- `git fetch --tags` **不会**移动已存在的本地 tag，所以本地克隆看着完全正常、远端 tag 其实早就断了
- `git push` 放进 `$(...)` 或 `set -e` 管道里会**静默不执行**却报成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)
