### PR TITLE
🐛 fix(web): LLM 配置体验与错误反馈优化

### DIFF
--- a/apps/web/src/app/api/test-llm/route.ts
+++ b/apps/web/src/app/api/test-llm/route.ts
@@ -16,6 +16,8 @@ interface ProbeResult {
   ok: boolean;
   status?: number;
   message?: string;
+  /** true = accepts image input, false = rejected, undefined = couldn't tell */
+  supportsImage?: boolean;
 }
 
 const TIMEOUT_MS = 12_000;
@@ -134,6 +136,86 @@ async function probe(
   return toResult(chat);
 }
 
+// 1x1 transparent PNG — tiny enough to probe image support for ~free.
+const TINY_PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+// Error bodies from providers that reject image input mention the offending part
+// ("image", "vision", "multimodal", …). Anything else is inconclusive.
+const IMAGE_REJECT_PATTERN = /image|vision|multimodal|visual|图片|图像|附件|attachment/i;
+
+/**
+ * Provider-aware image-support probe. Sends the model a message containing a
+ * 1x1 PNG and checks whether the endpoint accepts it:
+ *  - 2xx            → supportsImage: true
+ *  - 4xx + reject-ish message → supportsImage: false
+ *  - anything else  → supportsImage: undefined (unknown, don't guess)
+ */
+async function probeImageSupport(
+  provider: string,
+  baseUrl: string,
+  apiKey: string,
+  model: string
+): Promise<ProbeResult> {
+  const auth = { Authorization: `Bearer ${apiKey}` };
+  let url = `${baseUrl}/chat/completions`;
+  let headers: Record<string, string> = { ...auth, 'Content-Type': 'application/json' };
+  let body: unknown;
+
+  if (provider === 'anthropic') {
+    headers = { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01', 'Content-Type': 'application/json' };
+    body = {
+      model,
+      max_tokens: 1,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'ping' },
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: TINY_PNG_BASE64 } },
+          ],
+        },
+      ],
+    };
+  } else if (provider === 'google') {
+    url = `${baseUrl}/models/${model}:generateContent?key=${encodeURIComponent(apiKey)}`;
+    body = {
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            { text: 'ping' },
+            { inline_data: { mime_type: 'image/png', data: TINY_PNG_BASE64 } },
+          ],
+        },
+      ],
+      generationConfig: { maxOutputTokens: 1 },
+    };
+  } else {
+    // openai / deepseek / custom — OpenAI-compatible format.
+    body = {
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'ping' },
+            { type: 'image_url', image_url: { url: `data:image/png;base64,${TINY_PNG_BASE64}` } },
+          ],
+        },
+      ],
+      max_tokens: 1,
+    };
+  }
+
+  const res = await timedFetch(url, { method: 'POST', headers, body: JSON.stringify(body) });
+  if (res.ok) return { ok: true, status: res.status, supportsImage: true };
+
+  const failed = await toResult(res);
+  const rejected = !failed.ok && !!failed.status && failed.status < 500 && IMAGE_REJECT_PATTERN.test(failed.message || '');
+  return { ok: true, supportsImage: rejected ? false : undefined };
+}
+
 export async function POST(request: Request) {
   const userId = await getServerUserId();
   if (!userId) return json({ ok: false, message: 'Unauthorized' }, 401);
@@ -161,7 +243,14 @@ export async function POST(request: Request) {
   const startedAt = Date.now();
   try {
     const result = await probe(provider, baseUrl, apiKey, model);
-    return json({ ...result, latencyMs: Date.now() - startedAt }, 200);
+    if (!result.ok) {
+      return json({ ...result, latencyMs: Date.now() - startedAt }, 200);
+    }
+    const image = await probeImageSupport(provider, baseUrl, apiKey, model);
+    return json(
+      { ...result, latencyMs: Date.now() - startedAt, supportsImage: image.supportsImage },
+      200,
+    );
   } catch (err) {
     const message =
       err instanceof Error

--- a/apps/web/src/app/dashboard/edit/_components/ai/lib/services/agentClient.ts
+++ b/apps/web/src/app/dashboard/edit/_components/ai/lib/services/agentClient.ts
@@ -6,10 +6,39 @@ import type { AgentLlmConfig, AgentSseEvent } from './types';
  * 路径，鉴权由服务端处理。
  */
 
+/**
+ * 把上游错误消息映射成用户能行动的友好文案。后端透传的原始字符串
+ * （如 `Upstream 'agent' unavailable`、`invalid_api_key`）对用户没有意义，
+ * 按状态码 + 关键词归类后再展示；无法归类时回退原始信息。
+ */
+function friendlyAgentError(status: number, raw: string): string {
+  const haystack = `${status} ${raw}`;
+  let friendly = '';
+  if (/timeout|timed out|ETIMEDOUT|abort/i.test(haystack)) {
+    friendly = '请求超时，请检查网络后重试';
+  } else if (/unauthori[sz]ed|forbidden|invalid.*(api.?key|key|token|credential)|authentication|401|403/.test(haystack)) {
+    friendly = 'API Key 无效或没有权限，请检查密钥';
+  } else if (/quota|insufficient.*(balance|credit|quota)|balance|billing|402/.test(haystack)) {
+    friendly = '账户额度不足，请检查余额或配额';
+  } else if (/rate.?limit|too many requests|429/.test(haystack)) {
+    friendly = '请求过于频繁，请稍后重试';
+  } else if (/upstream|origin|gateway|backend.*(unavail|down|error)|502|503/.test(haystack)) {
+    friendly = '服务商上游暂不可用，请稍后重试或检查服务状态';
+  } else if (/not found|no such model|404/.test(haystack)) {
+    friendly = '接口或模型不存在，请检查配置';
+  } else if (status >= 500) {
+    friendly = '服务商返回服务器错误，请稍后重试';
+  }
+  if (!friendly) return raw;
+  return raw && raw !== friendly ? `${friendly}（${raw}）` : friendly;
+}
+
 async function readError(res: Response): Promise<string> {
   try {
     const data = await res.json();
-    return (data?.error || data?.message || data?.detail || `请求失败（${res.status}）`) as string;
+    const raw =
+      (data?.error || data?.message || data?.detail || `请求失败（${res.status}）`) as string;
+    return friendlyAgentError(res.status, raw);
   } catch {
     return `请求失败（${res.status}）`;
   }

--- a/apps/web/src/components/llm/ModelConfigFields.tsx
+++ b/apps/web/src/components/llm/ModelConfigFields.tsx
@@ -13,10 +13,17 @@ import {
   PlugZap,
   CheckCircle2,
   XCircle,
+  Image as ImageGlyph,
 } from 'lucide-react';
 import { LockClosedIcon } from '@radix-ui/react-icons';
 import { useSettingStore } from '@/store/useSettingStore';
-import { MODEL_PROVIDERS, getProvider, CUSTOM_PROVIDER_ID } from '@/lib/constants/modals';
+import {
+  MODEL_PROVIDERS,
+  getProvider,
+  CUSTOM_PROVIDER_ID,
+  MODEL_IMAGE_SUPPORT_MAP,
+} from '@/lib/constants/modals';
+import { classifyLlmTestError } from '@/lib/utils/llmTestError';
 import { Input } from '@/components/ui/input';
 import {
   Select,
@@ -88,30 +95,50 @@ export function ModelConfigFields() {
   const [showKey, setShowKey] = useState(false);
   const [testState, setTestState] = useState<TestState>('idle');
   const [testMsg, setTestMsg] = useState('');
+  const [testStatus, setTestStatus] = useState<number | undefined>(undefined);
+  const [testImageSupport, setTestImageSupport] = useState<boolean | undefined>(undefined);
   const canTest = Boolean(apiKey?.trim() && baseUrl?.trim() && model?.trim());
+
+  // Classify the last failure (if any) into a stable kind for friendly copy.
+  const testKind =
+    testState === 'error' ? classifyLlmTestError(testStatus, testMsg) : undefined;
 
   // Any change to the connection inputs invalidates a prior test result.
   useEffect(() => {
     setTestState('idle');
     setTestMsg('');
+    setTestStatus(undefined);
+    setTestImageSupport(undefined);
   }, [provider, apiKey, baseUrl, model]);
 
   const handleTest = async () => {
     setTestState('testing');
     setTestMsg('');
+    setTestStatus(undefined);
+    setTestImageSupport(undefined);
     try {
       const res = await fetch('/api/test-llm', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ provider, baseUrl, apiKey, model }),
       });
-      const data = (await res.json()) as { ok?: boolean; message?: string; latencyMs?: number };
+      const data = (await res.json()) as {
+        ok?: boolean;
+        message?: string;
+        status?: number;
+        latencyMs?: number;
+        supportsImage?: boolean;
+      };
       if (data.ok) {
         setTestState('ok');
         setTestMsg(typeof data.latencyMs === 'number' ? `${data.latencyMs}ms` : '');
+        // Probe result first; when the endpoint gives an inconclusive answer,
+        // fall back to the known capability from the model catalog.
+        setTestImageSupport(data.supportsImage ?? MODEL_IMAGE_SUPPORT_MAP[model]);
       } else {
         setTestState('error');
         setTestMsg(data.message || '');
+        setTestStatus(data.status);
       }
     } catch {
       setTestState('error');
@@ -179,11 +206,29 @@ export function ModelConfigFields() {
               <SelectContent className="rounded-xl border-white/[0.08] bg-neutral-950 text-white shadow-2xl shadow-black/50">
                 {meta?.models.map((m) => (
                   <SelectItem
-                    key={m}
-                    value={m}
+                    key={m.id}
+                    value={m.id}
                     className="rounded-lg transition-colors focus:bg-white/[0.06] focus:text-sky-300"
                   >
-                    {m}
+                    <span className="inline-flex items-center gap-2">
+                      {m.id}
+                      {m.supportsImage ? (
+                        <span
+                          title={t('settings.llm.imageSupported')}
+                          className="inline-flex items-center gap-1 rounded bg-white/[0.06] px-1.5 py-0.5 text-[10px] font-medium text-emerald-400"
+                        >
+                          <ImageGlyph size={10} />
+                          {t('settings.llm.imageBadge')}
+                        </span>
+                      ) : (
+                        <span
+                          title={t('settings.llm.imageNotSupported')}
+                          className="inline-flex items-center rounded bg-white/[0.06] px-1.5 py-0.5 text-[10px] font-medium text-neutral-500"
+                        >
+                          {t('settings.llm.textOnlyBadge')}
+                        </span>
+                      )}
+                    </span>
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -252,22 +297,42 @@ export function ModelConfigFields() {
               )}
               {testState === 'testing' ? t('settings.llm.testing') : t('settings.llm.testConnection')}
             </button>
-            {testState === 'ok' && (
-              <span className="text-xs inline-flex items-center gap-1 text-emerald-400 truncate">
-                <CheckCircle2 size={14} className="shrink-0" />
-                {testMsg || t('settings.llm.testConnected')}
-              </span>
-            )}
-            {testState === 'error' && (
-              <span
-                className="text-xs inline-flex items-center gap-1 text-red-400 min-w-0"
-                title={testMsg}
-              >
-                <XCircle size={14} className="shrink-0" />
-                <span className="truncate">{t('settings.llm.testFailed')}</span>
-              </span>
-            )}
           </div>
+          {testState === 'ok' && (
+            <span className="flex items-center gap-1 text-xs text-emerald-400">
+              <CheckCircle2 size={14} className="shrink-0" />
+              <span>
+                {testMsg || t('settings.llm.testConnected')}
+                {testImageSupport !== undefined && (
+                  <>
+                    {' · '}
+                    {testImageSupport
+                      ? t('settings.llm.imageSupported')
+                      : t('settings.llm.imageNotSupported')}
+                  </>
+                )}
+              </span>
+            </span>
+          )}
+          {testState === 'error' && (
+            <span className="flex min-w-0 items-center gap-1 text-xs text-red-400">
+              <XCircle size={14} className="shrink-0" />
+              <span className="min-w-0">
+                {testKind ? (
+                  <>
+                    <span>{t(`settings.llm.testErrors.${testKind}`)}</span>
+                    {testMsg && (
+                      <span className="block truncate text-[11px] text-red-400/60" title={testMsg}>
+                        {testMsg}
+                      </span>
+                    )}
+                  </>
+                ) : (
+                  <span className="truncate">{testMsg || t('settings.llm.testFailed')}</span>
+                )}
+              </span>
+            </span>
+          )}
         </div>
       </div>
 

--- a/apps/web/src/components/providers/I18nProvider.tsx
+++ b/apps/web/src/components/providers/I18nProvider.tsx
@@ -1,12 +1,35 @@
 "use client";
 
+import { useEffect } from "react";
 import { I18nextProvider } from "react-i18next";
-import i18n from "@/i18n";
+import i18n, { LANGUAGE_STORAGE_KEY } from "@/i18n";
 
 interface I18nProviderProps {
   children: React.ReactNode;
 }
 
+/** 水合后恢复用户上次选择的语言，并同步 <html lang>。 */
+function restorePreferredLanguage() {
+  let preferred: string | null = null;
+  try {
+    preferred = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+  } catch {
+    // localStorage 不可用（隐私模式等）时静默降级。
+  }
+  if (preferred !== "en" && preferred !== "zh") {
+    // 无历史偏好：跟随浏览器语言（默认中文站点）。
+    const nav = typeof navigator !== "undefined" ? navigator.language : "";
+    preferred = nav.toLowerCase().startsWith("zh") ? "zh" : "en";
+  }
+  if (preferred !== i18n.language) {
+    void i18n.changeLanguage(preferred);
+  }
+}
+
 export default function I18nProvider({ children }: I18nProviderProps) {
+  useEffect(() => {
+    restorePreferredLanguage();
+  }, []);
+
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
-} 
+}

--- a/apps/web/src/components/settings/SettingsModal.tsx
+++ b/apps/web/src/components/settings/SettingsModal.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { useSettingStore } from "@/store/useSettingStore";
+import { setPreferredLanguage } from "@/i18n";
 import { useTheme, type ThemePreference } from "@/components/providers/ThemeProvider";
 import { useAccountUiStore, type SettingsSection } from "@/store/useAccountUiStore";
 import { isCloudMode } from "@/lib/config/app";
@@ -200,7 +201,7 @@ export function SettingsModal() {
                           groupId="language"
                           value={currentLang}
                           reduce={reduce}
-                          onChange={(code) => i18n.changeLanguage(code)}
+                          onChange={(code) => setPreferredLanguage(code)}
                           options={[
                             { value: "en", label: "English" },
                             { value: "zh", label: "中文" },

--- a/apps/web/src/components/shared/AccountMenu.tsx
+++ b/apps/web/src/components/shared/AccountMenu.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "react-i18next";
 import { useAppAuth, useAppUser } from "@/lib/auth";
 import { isCloudMode } from "@/lib/config/app";
 import { useAccountUiStore } from "@/store/useAccountUiStore";
+import { setPreferredLanguage } from "@/i18n";
 import { cn } from "@/lib/utils";
 import { getInitials } from "@/lib/utils/userDisplay";
 import { HelpSubmenu } from "./HelpSubmenu";
@@ -209,7 +210,7 @@ export default function AccountMenu({ placement = "up", label }: AccountMenuProp
             <button
               key={code}
               type="button"
-              onClick={() => i18n.changeLanguage(code)}
+              onClick={() => setPreferredLanguage(code)}
               className={cn(
                 "rounded-md px-2 py-0.5 text-[12px] transition-colors",
                 currentLang === code ? "bg-sky-400/15 text-sky-200" : "text-neutral-500 hover:text-neutral-300",

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -1,15 +1,26 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
-import LanguageDetector from "i18next-browser-languagedetector";
 
 import en from "./locales/en/translation.json";
 import zh from "./locales/zh/translation.json";
 
+/** 语言偏好持久化 key（与 i18next-browser-languagedetector 默认一致）。 */
+export const LANGUAGE_STORAGE_KEY = "i18nextLng";
+
+/**
+ * 默认语言固定为 zh，与根 <html lang="zh-CN"> 一致。
+ *
+ * 之前这里挂载了 i18next-browser-languagedetector：SSR 时 Node 环境拿不到
+ * localStorage / navigator，检测失败回退 fallbackLng "en"，于是服务端渲染英文、
+ * 客户端 hydration 渲染中文，导致 React hydration mismatch。因此不再用
+ * LanguageDetector 参与初始化，SSR 与客户端首渲染始终同为默认语言；
+ * 用户的真实语言偏好在水合后由 I18nProvider 的 effect 应用。
+ */
 i18n
-  .use(LanguageDetector)
   .use(initReactI18next)
   .init({
-    fallbackLng: "en",
+    lng: "zh",
+    fallbackLng: "zh",
     debug: false,
     resources: {
       en: {
@@ -24,4 +35,14 @@ i18n
     },
   });
 
-export default i18n; 
+/** 切换语言并持久化到 localStorage（原 LanguageDetector 的缓存职责）。 */
+export function setPreferredLanguage(code: "en" | "zh") {
+  try {
+    localStorage.setItem(LANGUAGE_STORAGE_KEY, code);
+  } catch {
+    // localStorage 不可用（隐私模式等）时静默降级为会话内生效。
+  }
+  void i18n.changeLanguage(code);
+}
+
+export default i18n;

--- a/apps/web/src/lib/constants/modals.ts
+++ b/apps/web/src/lib/constants/modals.ts
@@ -9,6 +9,13 @@
  *   DeepSeek   https://api-docs.deepseek.com/quick_start/pricing
  * Newest first per provider. Legacy/superseded ids dropped.
  */
+export interface ModelInfo {
+  /** exact API `model` string */
+  id: string;
+  /** whether this model accepts image input (known from provider docs) */
+  supportsImage: boolean;
+}
+
 export interface ModelProvider {
   /** stable provider key */
   id: string;
@@ -16,8 +23,8 @@ export interface ModelProvider {
   label: string;
   /** official API base URL for this provider (empty for custom) */
   baseUrl: string;
-  /** model ids (exact API `model` strings), newest first */
-  models: string[];
+  /** models (exact API `model` strings), newest first */
+  models: ModelInfo[];
   /** console URL where the user obtains an API key (empty for custom) */
   keyUrl: string;
   /** recommended default model id picked when this provider is selected */
@@ -39,7 +46,12 @@ export const MODEL_PROVIDERS: ModelProvider[] = [
     id: 'openai',
     label: 'OpenAI',
     baseUrl: 'https://api.openai.com/v1',
-    models: ['gpt-5.5', 'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-nano'],
+    models: [
+      { id: 'gpt-5.5', supportsImage: true },
+      { id: 'gpt-5.4', supportsImage: true },
+      { id: 'gpt-5.4-mini', supportsImage: true },
+      { id: 'gpt-5.4-nano', supportsImage: true },
+    ],
     keyUrl: 'https://platform.openai.com/account/api-keys',
     defaultModel: 'gpt-5.5',
     defaultMaxTokens: DEFAULT_MAX_TOKENS,
@@ -50,7 +62,12 @@ export const MODEL_PROVIDERS: ModelProvider[] = [
     label: 'Anthropic Claude',
     baseUrl: 'https://api.anthropic.com/v1',
     // API ids use dashes (claude-opus-4-8), not dots.
-    models: ['claude-fable-5', 'claude-opus-4-8', 'claude-sonnet-4-6', 'claude-haiku-4-5'],
+    models: [
+      { id: 'claude-fable-5', supportsImage: true },
+      { id: 'claude-opus-4-8', supportsImage: true },
+      { id: 'claude-sonnet-4-6', supportsImage: true },
+      { id: 'claude-haiku-4-5', supportsImage: true },
+    ],
     keyUrl: 'https://console.anthropic.com/settings/keys',
     defaultModel: 'claude-sonnet-4-6',
     defaultMaxTokens: DEFAULT_MAX_TOKENS,
@@ -60,7 +77,12 @@ export const MODEL_PROVIDERS: ModelProvider[] = [
     id: 'google',
     label: 'Google Gemini',
     baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
-    models: ['gemini-3.5-flash', 'gemini-3.1-pro-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'],
+    models: [
+      { id: 'gemini-3.5-flash', supportsImage: true },
+      { id: 'gemini-3.1-pro-preview', supportsImage: true },
+      { id: 'gemini-2.5-pro', supportsImage: true },
+      { id: 'gemini-2.5-flash', supportsImage: true },
+    ],
     keyUrl: 'https://aistudio.google.com/app/apikey',
     defaultModel: 'gemini-3.5-flash',
     defaultMaxTokens: DEFAULT_MAX_TOKENS,
@@ -71,7 +93,11 @@ export const MODEL_PROVIDERS: ModelProvider[] = [
     label: 'DeepSeek',
     baseUrl: 'https://api.deepseek.com',
     // deepseek-chat / deepseek-reasoner are deprecated 2026-07-24 (→ deepseek-v4-flash).
-    models: ['deepseek-v4-pro', 'deepseek-v4-flash'],
+    // Both V4 models are text-only — no image input on the official API.
+    models: [
+      { id: 'deepseek-v4-pro', supportsImage: false },
+      { id: 'deepseek-v4-flash', supportsImage: false },
+    ],
     keyUrl: 'https://platform.deepseek.com/api_keys',
     defaultModel: 'deepseek-v4-flash',
     defaultMaxTokens: DEFAULT_MAX_TOKENS,
@@ -95,7 +121,18 @@ export const MODEL_PROVIDERS: ModelProvider[] = [
  * two never drift. Used by the settings page to auto-fill the base URL on select.
  */
 export const MODEL_API_URL_MAP: Record<string, string> = Object.fromEntries(
-  MODEL_PROVIDERS.flatMap((provider) => provider.models.map((model) => [model, provider.baseUrl])),
+  MODEL_PROVIDERS.flatMap((provider) =>
+    provider.models.map((model) => [model.id, provider.baseUrl]),
+  ),
+);
+
+/**
+ * model id → known image-input support. `undefined` when unknown (custom models).
+ */
+export const MODEL_IMAGE_SUPPORT_MAP: Record<string, boolean> = Object.fromEntries(
+  MODEL_PROVIDERS.flatMap((provider) =>
+    provider.models.map((model) => [model.id, model.supportsImage]),
+  ),
 );
 
 /** Look up a provider by its stable id. */

--- a/apps/web/src/lib/utils/llmTestError.ts
+++ b/apps/web/src/lib/utils/llmTestError.ts
@@ -1,0 +1,40 @@
+/**
+ * Map a /api/test-llm probe failure into a stable "kind" so the UI can show
+ * localised, actionable copy instead of the provider's raw error string
+ * (e.g. `Upstream 'agent' unavailable`, which means nothing to most users).
+ *
+ * Order matters: explicit auth/quota/rate-limit signals beat the HTTP status,
+ * because gateways often wrap those behind a 503 or a 200-with-error-body.
+ */
+export type LlmTestErrorKind =
+  | 'upstream'
+  | 'auth'
+  | 'quota'
+  | 'rateLimit'
+  | 'notFound'
+  | 'server'
+  | 'timeout';
+
+const KIND_PATTERNS: Array<[LlmTestErrorKind, RegExp]> = [
+  ['timeout', /timeout|timed out|ETIMEDOUT|abort/i],
+  ['upstream', /upstream|origin|gateway|backend.*(unavail|down|error)|502|503/i],
+  ['auth', /unauthori[sz]ed|forbidden|invalid.*(api.?key|key|token|credential)|authentication|403|401/i],
+  ['quota', /quota|insufficient.*(balance|credit|quota)|balance|billing|out of (tokens?|credits)|402/i],
+  ['rateLimit', /rate.?limit|too many requests|429/i],
+  ['notFound', /not found|no such model|model.*(doesn'?t|does not|unknown|invalid)|404/i],
+];
+
+/** HTTP statuses that imply the provider service itself is down. */
+const SERVER_ERROR_STATUS = new Set([500, 501, 502, 503, 504, 505, 507]);
+
+export function classifyLlmTestError(
+  status: number | undefined,
+  message: string | undefined,
+): LlmTestErrorKind | undefined {
+  const haystack = `${status ?? ''} ${message ?? ''}`;
+  for (const [kind, pattern] of KIND_PATTERNS) {
+    if (pattern.test(haystack)) return kind;
+  }
+  if (status !== undefined && SERVER_ERROR_STATUS.has(status)) return 'server';
+  return undefined;
+}

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -247,6 +247,19 @@
       "testing": "Testing…",
       "testConnected": "Connected",
       "testFailed": "Connection failed",
+      "imageSupported": "Image input supported",
+      "imageNotSupported": "No image input",
+      "imageBadge": "Image",
+      "textOnlyBadge": "Text only",
+      "testErrors": {
+        "upstream": "The provider's upstream service is temporarily unavailable. Try again later or check the service status.",
+        "auth": "Invalid API key or insufficient permission. Check your key.",
+        "quota": "Insufficient account quota. Check your balance or limits.",
+        "rateLimit": "Too many requests. Please try again later.",
+        "notFound": "Endpoint or model not found. Check the Base URL and model name.",
+        "server": "The provider returned a server error. Please try again later.",
+        "timeout": "Connection timed out. Check your network or try again later."
+      },
       "showKey": "Show key",
       "hideKey": "Hide key"
     },

--- a/apps/web/src/locales/zh/translation.json
+++ b/apps/web/src/locales/zh/translation.json
@@ -247,6 +247,19 @@
       "testing": "测试中…",
       "testConnected": "连接成功",
       "testFailed": "连接失败",
+      "imageSupported": "支持图片",
+      "imageNotSupported": "不支持图片",
+      "imageBadge": "图像",
+      "textOnlyBadge": "纯文本",
+      "testErrors": {
+        "upstream": "服务商上游暂不可用，请稍后重试或检查服务状态。",
+        "auth": "API Key 无效或没有权限，请检查密钥是否正确。",
+        "quota": "账户额度不足，请检查余额或配额。",
+        "rateLimit": "请求过于频繁，请稍后重试。",
+        "notFound": "接口或模型不存在，请检查 Base URL 与模型名称。",
+        "server": "服务商返回服务器错误，请稍后重试。",
+        "timeout": "连接超时，请检查网络或稍后重试。"
+      },
       "showKey": "显示密钥",
       "hideKey": "隐藏密钥"
     },


### PR DESCRIPTION
## 背景

设置页/测试连接与 PDF 导入的错误反馈存在体验问题：原始报错（如 `Upstream 'agent' unavailable`）直接透传给用户，无法理解；且 i18n 的 SSR/客户端语言检测不一致导致 hydration mismatch。

## 改动内容

### 1. 修复 i18n hydration mismatch
- `src/i18n.ts`：移除 `i18next-browser-languagedetector` 参与初始化，SSR 与客户端首渲染统一默认语言 zh（与 `<html lang=\"zh-CN\">` 一致），新增 `setPreferredLanguage()` 持久化语言选择
- `I18nProvider`：水合后恢复用户上次语言偏好（localStorage），无历史时跟随浏览器语言

### 2. 测试连接增强（`/api/test-llm`）
- 新增图片能力探测：连通性探测通过后发送 1x1 PNG 请求，2xx → 支持图片；4xx 且错误含 image/vision 关键词 → 不支持；其余不妄下结论
- 按 OpenAI 兼容 / Anthropic / Gemini 三种格式适配探测请求
- 结果返回 `supportsImage`，探测不确定时回退到模型目录已知能力

### 3. 模型目录标注图片能力
- `MODEL_PROVIDERS` 模型列表改为对象数组（`id + supportsImage`），模型下拉显示「图像/纯文本」徽标

### 4. 错误反馈友好化
- 新增 `lib/utils/llmTestError.ts`：按状态码 + 关键词分类（upstream/auth/quota/rateLimit/notFound/server/timeout）
- 测试连接错误显示本地化文案 + 原始信息小字
- `agentClient.ts`（PDF 导入等 AI 调用）：上游错误映射为可行动的友好文案，原始信息保留在括号内

## 验证

- [x] `pnpm --filter @magic-resume/web lint` 通过
- [x] `pnpm --filter @magic-resume/web i18n:check` 通过
- [x] `pnpm --filter @magic-resume/web test` 通过
- [x] 全仓 `pnpm lint` / `pnpm build` 通过（pre-commit hook 自动执行）