### PR TITLE
:lock: fix(web): 已登录用户不该还能回到登录页

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,8 @@ Format: `<emoji> <type>(<scope>?): <subject>` — e.g. `:sparkles: feat(web): ad
 ## Guardrails
 
 - Do not modify Clerk auth (`clerkMiddleware`, `ClerkProvider`, `useAuth`, cloud sync) unless explicitly requested.
-  - Recorded exception: the sign-in redirect carries `redirect_url` (`middleware.ts` → `afterAuthUrl`). `/billing(.*)` is a protected route, and without it a lapsed session loses `?orderId=` — the return page then cannot poll or sync, which is the only thing that captures a PayPal payment from the browser. Same-origin paths only.
+  - Recorded exception: the sign-in redirect carries `redirect_url` (`middleware.ts` → `signInUrl`). `/billing(.*)` is a protected route, and without it a lapsed session loses `?orderId=` — the return page then cannot poll or sync, which is the only thing that captures a PayPal payment from the browser. Same-origin paths only.
+  - Recorded exception: signed-in users are redirected away from `/sign-in(.*)` and `/sign-up(.*)` (`middleware.ts` → `isAuthRoute` / `afterAuthUrl`). Rendering a login form to someone already logged in is the bug this fixes. It honours the `redirect_url` the exception above puts there, so a lapsed-then-restored session still lands on the order it was paying for — and it accepts **same-origin paths only** (leading single `/`, no backslash), because unlike `signInUrl` this value comes off the query string and an unchecked redirect there is an open redirect.
 - Do not add new deployment modes or local/cloud switches unless explicitly requested.
 - MCP tools must remain schema-aware and patch-based. The `@magic-resume/mcp` package must not import from Next.js, React components, browser APIs, or IndexedDB.
 - When adding shared schema or type changes, prefer `packages/resume-schema` over duplicating shapes in `apps/web`.

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -20,6 +20,12 @@ const isProtectedRoute = createRouteMatcher([
   '/billing(.*)',
 ]);
 
+// The mirror of the rule above: these are the only routes that require *not*
+// being signed in. Catch-alls, because Clerk drives its own sub-routes under
+// both (`/sign-in/factor-one`, …) and a signed-in visitor has no business on
+// any of them.
+const isAuthRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)']);
+
 /**
  * Where to send someone back after they sign in.
  *
@@ -43,11 +49,43 @@ function signInUrl(req: NextRequest): string {
   return url.toString();
 }
 
+/**
+ * Where a *signed-in* visitor to the sign-in page should land instead.
+ *
+ * `redirect_url` is honoured because `signInUrl` above put it there: someone
+ * whose session lapsed mid-checkout, signed in, and came back to `/sign-in`
+ * from history should still reach the order they were paying for rather than a
+ * generic dashboard.
+ *
+ * But unlike `signInUrl`, this value arrives from the query string, so it is
+ * attacker-controlled and an unchecked `NextResponse.redirect` on it is an open
+ * redirect — the classic phishing hop through a domain the victim trusts. Only
+ * a same-origin *path* is accepted: it must start with a single `/`, and may
+ * not contain a backslash, which some browsers normalise to `/` and would turn
+ * `/\evil.com` into a protocol-relative jump off-site.
+ */
+function afterAuthUrl(req: NextRequest): URL {
+  const target = req.nextUrl.searchParams.get('redirect_url');
+  const safe =
+    target &&
+    target.startsWith('/') &&
+    !target.startsWith('//') &&
+    !target.includes('\\');
+  return new URL(safe ? target : '/dashboard', req.url);
+}
+
 // cloud: unauthenticated users on protected routes go to the sign-in page
-// (unauthenticatedUrl avoids Clerk's default 404 on protect).
+// (unauthenticatedUrl avoids Clerk's default 404 on protect); signed-in users
+// are kept off the sign-in/sign-up pages, which otherwise render a login form
+// to somebody who is already logged in.
 const cloudHandler = clerkMiddleware(async (auth, req) => {
   if (isProtectedRoute(req)) {
     await auth.protect({ unauthenticatedUrl: signInUrl(req) });
+    return;
+  }
+  if (isAuthRoute(req)) {
+    const { userId } = await auth();
+    if (userId) return NextResponse.redirect(afterAuthUrl(req));
   }
 });
 


### PR DESCRIPTION
## 问题

`middleware.ts` 只有单向规则 —— 受保护路由要求登录 —— 没有反向的那条。所以已登录用户直接访问 `/sign-in` 会看到一个登录表单。`sign-in/[[...sign-in]]/page.tsx` 里也只处理了 self-hosted 的跳转。

## 改动

加 `isAuthRoute` 匹配 `/sign-in(.*)` 与 `/sign-up(.*)`。用 catch-all 是因为 Clerk 在这两个前缀下自己驱动子路由（`/sign-in/factor-one` 等），已登录的人在任何一个上都没有事可做。

## 防开放重定向

沿用 `redirect_url` 是有意的：会话中途过期、登录后又从历史记录回到 `/sign-in` 的人，应该回到原本要付的那笔订单，而不是一个笼统的工作台。

但**这个值来自 query string、攻击者可控**，直接 `NextResponse.redirect` 就是开放重定向 —— 经由受害者信任的域名做钓鱼跳板的经典手法。所以只接受同源**路径**：

- 必须单个 `/` 开头（`//evil.com` 是协议相对 URL）
- 不含反斜杠（某些浏览器把 `\` 规范化成 `/`，于是 `/\evil.com` 又变回协议相对）

不合规则回落 `/dashboard`。

## Guardrails

本仓 `CLAUDE.md` 明令「不要改 Clerk auth，除非明确要求」，按既有惯例补了一条 recorded exception。同时修正了原有那条里过时的函数名 —— 写的是 `afterAuthUrl`，代码里实际叫 `signInUrl`。

## 验证

`lint` / `build` 均通过。手工：用已登录账号访问 `/sign-in`，应被送回 `/dashboard`；带 `?redirect_url=/billing/checkout?planId=x` 时应回到那一页；带 `?redirect_url=//evil.com` 或 `/\evil.com` 时应回落 `/dashboard`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)