### PR TITLE
:sparkles: feat(web): 结账中转页的路由外壳与文案

### DIFF
--- a/apps/web/src/app/billing/checkout/page.tsx
+++ b/apps/web/src/app/billing/checkout/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Suspense } from 'react';
+import { CheckoutPage } from '@/lib/extensions/billing-ui';
+
+/**
+ * Route shell for the checkout stop-over. The slot decides what it renders —
+ * an open-source build has nothing to sell and gets nothing.
+ *
+ * `Suspense` is not optional: the slot reads `useSearchParams`, and without a
+ * boundary `next build` fails prerendering this route — the same trap
+ * `billing/return/page.tsx` documents.
+ */
+export default function BillingCheckoutRoute() {
+  return (
+    <Suspense fallback={null}>
+      <CheckoutPage />
+    </Suspense>
+  );
+}

--- a/apps/web/src/lib/extensions/billing-ui.tsx
+++ b/apps/web/src/lib/extensions/billing-ui.tsx
@@ -9,3 +9,17 @@
 export function PricingModal() {
   return null;
 }
+
+/**
+ * Checkout slot — the stop-over between picking a plan and leaving for the
+ * payment channel.
+ *
+ * Same reasoning as the modal above, plus one of its own: the page's whole job
+ * is to name the payment methods a buyer can use, and naming them is exactly
+ * what this side of the line must not do. `app/billing/checkout/page.tsx` is a
+ * shell because the overlay cannot add a route; everything it renders lives in
+ * the commercial package.
+ */
+export function CheckoutPage() {
+  return null;
+}

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -1489,6 +1489,32 @@
       "errorTitle": "Could not confirm this order",
       "missingOrder": "The link carries no order id, so the payment result cannot be looked up.",
       "backToDashboard": "Back to dashboard"
+    },
+    "checkout": {
+      "summaryHeading": "Purchase",
+      "planRow": "Plan",
+      "amountRow": "Plan price",
+      "feeRow": "Tax / fees",
+      "totalRow": "Total due",
+      "payHeading": "Payment details",
+      "detailsToggle": "Order details",
+      "accountRow": "Account",
+      "methodHeading": "Choose a payment method",
+      "payNow": "Pay now",
+      "paying": "Taking you to payment…",
+      "back": "Back",
+      "agree": "By continuing you confirm you have read and agree to our",
+      "and": "and",
+      "termsLabel": "Terms of Service",
+      "privacyLabel": "Privacy Policy",
+      "secure": "Payment happens on the channel’s own page — we never see your payment details",
+      "loading": "Loading your order",
+      "missingPlan": "The link carries no plan, so there is nothing to check out.",
+      "planNotFound": "We could not find that plan — it may have been withdrawn.",
+      "noMethod": "No payment method is available in this region yet.",
+      "notSoldHere": "This plan is not sold in this region.",
+      "notBuyable": "This plan cannot be purchased right now.",
+      "loadFailed": "Could not load the plan. Please try again."
     }
   },
   "aiLab": {

--- a/apps/web/src/locales/zh/translation.json
+++ b/apps/web/src/locales/zh/translation.json
@@ -1489,6 +1489,32 @@
       "errorTitle": "无法确认订单",
       "missingOrder": "链接里没有订单号，无法查询支付结果。",
       "backToDashboard": "返回工作台"
+    },
+    "checkout": {
+      "summaryHeading": "购买",
+      "planRow": "套餐类型",
+      "amountRow": "套餐费用",
+      "feeRow": "税费 / 手续费",
+      "totalRow": "应付总额",
+      "payHeading": "支付详情",
+      "detailsToggle": "订单详情",
+      "accountRow": "账户",
+      "methodHeading": "选择支付方式",
+      "payNow": "立即结账",
+      "paying": "正在前往支付…",
+      "back": "返回",
+      "agree": "点击「立即结账」即表示你已阅读并同意",
+      "and": "与",
+      "termsLabel": "用户协议",
+      "privacyLabel": "隐私政策",
+      "secure": "支付在支付渠道自己的页面完成，我们不接触你的付款信息",
+      "loading": "正在载入订单",
+      "missingPlan": "链接里没有套餐信息，无法结账。",
+      "planNotFound": "找不到这个套餐，它可能已经下架。",
+      "noMethod": "当前地区暂时没有可用的支付方式。",
+      "notSoldHere": "这个套餐在当前地区不出售。",
+      "notBuyable": "这个套餐当前无法购买。",
+      "loadFailed": "载入套餐失败，请稍后重试。"
     }
   },
   "aiLab": {


### PR DESCRIPTION
## 为什么

买家在定价弹窗点购买后，浏览器**一步就跳到了站外支付网关**：中间没有任何确认面，看不到最终金额和订单构成；跳转失败时（实测过的 `PaymentConfigError`、支付宝 `insufficient-isv-permissions`）错误只是个裸异常名，弹在一个人已经在离开的页面上。

加一个站内中转结账页。

## 本 PR 的范围：只有 OSS 这一侧

三样东西 —— 路由外壳、插槽 stub、文案。**真正渲染的内容在商业包里**，因为这一页的职责就是列出可用的支付方式，而「有哪些支付渠道」正是开源构建不该知道的事（`verify-oss-boundary.mjs` 对插槽 stub 拦 `/paypal/i`、`/stripe/i`）。

## 两个不明显的约束

**① 外壳必须包 `Suspense`。** 插槽内部读 `useSearchParams`，不包会让 `next build` 预渲染这条路由直接失败 —— 与 `billing/return/page.tsx` 已经记录过的是同一个坑。

**② 插槽加 `CheckoutPage` 导出这件事本身就是契约。** `apply-overlay.mjs` 的 `assertProvides` 用 `git show HEAD:` 读**已提交**的 stub，商业包少导出一个就在构建期报错。

这意味着**本 PR 必须先于商业侧那个合入** —— 顺序反了的话 overlay 不会转发 `CheckoutPage`，结账页渲染 stub 的 `null`，白屏且不报错。

## 验证

`i18n:check`（251 文件，中英对齐）/ `lint` / `build` 全过，`/billing/checkout` 已出现在路由表。

🤖 Generated with [Claude Code](https://claude.com/claude-code)