### PR TITLE
release: 2026-08-06 —— 结账中转页的路由外壳 + 已登录用户不再回登录页

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,8 @@ Format: `<emoji> <type>(<scope>?): <subject>` — e.g. `:sparkles: feat(web): ad
 ## Guardrails
 
 - Do not modify Clerk auth (`clerkMiddleware`, `ClerkProvider`, `useAuth`, cloud sync) unless explicitly requested.
-  - Recorded exception: the sign-in redirect carries `redirect_url` (`middleware.ts` → `afterAuthUrl`). `/billing(.*)` is a protected route, and without it a lapsed session loses `?orderId=` — the return page then cannot poll or sync, which is the only thing that captures a PayPal payment from the browser. Same-origin paths only.
+  - Recorded exception: the sign-in redirect carries `redirect_url` (`middleware.ts` → `signInUrl`). `/billing(.*)` is a protected route, and without it a lapsed session loses `?orderId=` — the return page then cannot poll or sync, which is the only thing that captures a PayPal payment from the browser. Same-origin paths only.
+  - Recorded exception: signed-in users are redirected away from `/sign-in(.*)` and `/sign-up(.*)` (`middleware.ts` → `isAuthRoute` / `afterAuthUrl`). Rendering a login form to someone already logged in is the bug this fixes. It honours the `redirect_url` the exception above puts there, so a lapsed-then-restored session still lands on the order it was paying for — and it accepts **same-origin paths only** (leading single `/`, no backslash), because unlike `signInUrl` this value comes off the query string and an unchecked redirect there is an open redirect.
 - Do not add new deployment modes or local/cloud switches unless explicitly requested.
 - MCP tools must remain schema-aware and patch-based. The `@magic-resume/mcp` package must not import from Next.js, React components, browser APIs, or IndexedDB.
 - When adding shared schema or type changes, prefer `packages/resume-schema` over duplicating shapes in `apps/web`.

--- a/apps/web/src/app/billing/checkout/page.tsx
+++ b/apps/web/src/app/billing/checkout/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { Suspense } from 'react';
+import { CheckoutPage } from '@/lib/extensions/billing-ui';
+
+/**
+ * Route shell for the checkout stop-over. The slot decides what it renders —
+ * an open-source build has nothing to sell and gets nothing.
+ *
+ * `Suspense` is not optional: the slot reads `useSearchParams`, and without a
+ * boundary `next build` fails prerendering this route — the same trap
+ * `billing/return/page.tsx` documents.
+ */
+export default function BillingCheckoutRoute() {
+  return (
+    <Suspense fallback={null}>
+      <CheckoutPage />
+    </Suspense>
+  );
+}

--- a/apps/web/src/lib/extensions/billing-ui.tsx
+++ b/apps/web/src/lib/extensions/billing-ui.tsx
@@ -9,3 +9,17 @@
 export function PricingModal() {
   return null;
 }
+
+/**
+ * Checkout slot — the stop-over between picking a plan and leaving for the
+ * payment channel.
+ *
+ * Same reasoning as the modal above, plus one of its own: the page's whole job
+ * is to name the payment methods a buyer can use, and naming them is exactly
+ * what this side of the line must not do. `app/billing/checkout/page.tsx` is a
+ * shell because the overlay cannot add a route; everything it renders lives in
+ * the commercial package.
+ */
+export function CheckoutPage() {
+  return null;
+}

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -1489,6 +1489,32 @@
       "errorTitle": "Could not confirm this order",
       "missingOrder": "The link carries no order id, so the payment result cannot be looked up.",
       "backToDashboard": "Back to dashboard"
+    },
+    "checkout": {
+      "summaryHeading": "Purchase",
+      "planRow": "Plan",
+      "amountRow": "Plan price",
+      "feeRow": "Tax / fees",
+      "totalRow": "Total due",
+      "payHeading": "Payment details",
+      "detailsToggle": "Order details",
+      "accountRow": "Account",
+      "methodHeading": "Choose a payment method",
+      "payNow": "Pay now",
+      "paying": "Taking you to payment…",
+      "back": "Back",
+      "agree": "By continuing you confirm you have read and agree to our",
+      "and": "and",
+      "termsLabel": "Terms of Service",
+      "privacyLabel": "Privacy Policy",
+      "secure": "Payment happens on the channel’s own page — we never see your payment details",
+      "loading": "Loading your order",
+      "missingPlan": "The link carries no plan, so there is nothing to check out.",
+      "planNotFound": "We could not find that plan — it may have been withdrawn.",
+      "noMethod": "No payment method is available in this region yet.",
+      "notSoldHere": "This plan is not sold in this region.",
+      "notBuyable": "This plan cannot be purchased right now.",
+      "loadFailed": "Could not load the plan. Please try again."
     }
   },
   "aiLab": {

--- a/apps/web/src/locales/zh/translation.json
+++ b/apps/web/src/locales/zh/translation.json
@@ -1489,6 +1489,32 @@
       "errorTitle": "无法确认订单",
       "missingOrder": "链接里没有订单号，无法查询支付结果。",
       "backToDashboard": "返回工作台"
+    },
+    "checkout": {
+      "summaryHeading": "购买",
+      "planRow": "套餐类型",
+      "amountRow": "套餐费用",
+      "feeRow": "税费 / 手续费",
+      "totalRow": "应付总额",
+      "payHeading": "支付详情",
+      "detailsToggle": "订单详情",
+      "accountRow": "账户",
+      "methodHeading": "选择支付方式",
+      "payNow": "立即结账",
+      "paying": "正在前往支付…",
+      "back": "返回",
+      "agree": "点击「立即结账」即表示你已阅读并同意",
+      "and": "与",
+      "termsLabel": "用户协议",
+      "privacyLabel": "隐私政策",
+      "secure": "支付在支付渠道自己的页面完成，我们不接触你的付款信息",
+      "loading": "正在载入订单",
+      "missingPlan": "链接里没有套餐信息，无法结账。",
+      "planNotFound": "找不到这个套餐，它可能已经下架。",
+      "noMethod": "当前地区暂时没有可用的支付方式。",
+      "notSoldHere": "这个套餐在当前地区不出售。",
+      "notBuyable": "这个套餐当前无法购买。",
+      "loadFailed": "载入套餐失败，请稍后重试。"
     }
   },
   "aiLab": {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -20,6 +20,12 @@ const isProtectedRoute = createRouteMatcher([
   '/billing(.*)',
 ]);
 
+// The mirror of the rule above: these are the only routes that require *not*
+// being signed in. Catch-alls, because Clerk drives its own sub-routes under
+// both (`/sign-in/factor-one`, …) and a signed-in visitor has no business on
+// any of them.
+const isAuthRoute = createRouteMatcher(['/sign-in(.*)', '/sign-up(.*)']);
+
 /**
  * Where to send someone back after they sign in.
  *
@@ -43,11 +49,43 @@ function signInUrl(req: NextRequest): string {
   return url.toString();
 }
 
+/**
+ * Where a *signed-in* visitor to the sign-in page should land instead.
+ *
+ * `redirect_url` is honoured because `signInUrl` above put it there: someone
+ * whose session lapsed mid-checkout, signed in, and came back to `/sign-in`
+ * from history should still reach the order they were paying for rather than a
+ * generic dashboard.
+ *
+ * But unlike `signInUrl`, this value arrives from the query string, so it is
+ * attacker-controlled and an unchecked `NextResponse.redirect` on it is an open
+ * redirect — the classic phishing hop through a domain the victim trusts. Only
+ * a same-origin *path* is accepted: it must start with a single `/`, and may
+ * not contain a backslash, which some browsers normalise to `/` and would turn
+ * `/\evil.com` into a protocol-relative jump off-site.
+ */
+function afterAuthUrl(req: NextRequest): URL {
+  const target = req.nextUrl.searchParams.get('redirect_url');
+  const safe =
+    target &&
+    target.startsWith('/') &&
+    !target.startsWith('//') &&
+    !target.includes('\\');
+  return new URL(safe ? target : '/dashboard', req.url);
+}
+
 // cloud: unauthenticated users on protected routes go to the sign-in page
-// (unauthenticatedUrl avoids Clerk's default 404 on protect).
+// (unauthenticatedUrl avoids Clerk's default 404 on protect); signed-in users
+// are kept off the sign-in/sign-up pages, which otherwise render a login form
+// to somebody who is already logged in.
 const cloudHandler = clerkMiddleware(async (auth, req) => {
   if (isProtectedRoute(req)) {
     await auth.protect({ unauthenticatedUrl: signInUrl(req) });
+    return;
+  }
+  if (isAuthRoute(req)) {
+    const { userId } = await auth();
+    if (userId) return NextResponse.redirect(afterAuthUrl(req));
   }
 });
 


### PR DESCRIPTION
两条小改动。

## `/billing/checkout` 的路由外壳（#183）

OSS 侧只有一个 Suspense 包裹的空壳，实现在 Commercial 的 `CheckoutPage`。**这条必须先于 [Commercial #29](https://github.com/Magic-Resume/Magic-Resume-Commercial/pull/29) 合** —— overlay 加不了路由，而 `assertProvides` 读的是 `git show HEAD:` 的已提交桩，桩没落地这个槽位会静默渲染成 `null`。

## 已登录用户不该还能回到登录页（#182）

middleware 加了 `isAuthRoute`。`afterAuthUrl()` 只接受同源路径（单个前导 `/`、无反斜杠），否则回 `/dashboard` —— 不做开放重定向。

🤖 Generated with [Claude Code](https://claude.com/claude-code)