### PR TITLE
💄 style(web): 侧边栏导航文案加载时画骨架，不再留空

### DIFF
--- a/apps/web/src/app/dashboard/_components/DashboardSidebar.tsx
+++ b/apps/web/src/app/dashboard/_components/DashboardSidebar.tsx
@@ -250,7 +250,16 @@ function NavItem({
         )}
         style={labelStyle}
       >
-        {label}
+        {/* 文案要等挂载后才由 i18n 解析出来（见 `label()`）。这段空窗里画一条骨架，
+            而不是留空：留空得到的正是账号页脚特意避免的那个形态——一个没有标签的
+            孤零零图标，和右侧主区域的骨架屏并排时更像渲染坏了而不是在加载。
+            条子与 `AccountRowSkeleton` 同构，整条侧边栏因此说同一句话。 */}
+        {label ?? (
+          <span
+            aria-hidden
+            className="my-1 block h-3 w-16 animate-pulse rounded bg-white/[0.06]"
+          />
+        )}
       </span>
     </Link>
   );


### PR DESCRIPTION
## 现象

进入 dashboard 的头一小段时间，侧边栏只有三个裸图标、没有任何文字，而右侧主区域和左下角账号行都在正常显示骨架屏。整页看起来都在加载，唯独导航像是渲染坏了。

## 为什么会这样

`DashboardSidebar` 里：

```js
// i18n labels resolve client-side; keep them empty until mount so SSR and the
// first client render agree (icons are language-independent and render on both).
const label = (key: string) => (mounted ? t(key) : undefined);
```

导航项其实**不认为自己在加载**：图标与语言无关、服务端和客户端都能画，所以照常渲染；只有文案要等挂载后由 i18n 解析，否则服务端渲染的文字和首次客户端渲染对不上会 hydration 报错。这个取舍本身是对的。

问题在于同一条侧边栏对同一个视觉问题给了**相反**的答案。账号页脚等的是 `useAppUser` 的异步数据，它有 `AccountRowSkeleton`，注释还写明目的：

> show a skeleton row until it lands so the footer never flashes a lone, unlabelled avatar icon

而导航项呈现的恰恰就是那句话要避免的形态。

## 改动

`label` 缺席时画一条与 `AccountRowSkeleton` 同构的脉冲条（`h-3 w-16 animate-pulse rounded bg-white/[0.06]`），整条侧边栏因此说同一句话。

- **折叠态**无需额外分支：骨架在外层那个 `collapsed ? 'max-w-0 opacity-0'` 的 span 里，会被一起裁掉。
- **无障碍**：骨架标了 `aria-hidden`，不进无障碍树。
- **hydration**：服务端与首次客户端渲染的 `label` 同为 `undefined`，两边渲染同一条骨架，不引入差异。
- `NavNotifications` 内部就是 `NavItem`，所以改一处覆盖全部三项。

## 验证

`lint` / `tsc --noEmit` / `next build` 全绿（pre-commit 也跑了完整的 turbo lint + build）。

视觉验收留给人工——本地 `pnpm --filter @magic-resume/web dev`，进 `/dashboard` 后硬刷新（⌘⇧R）看那一小段空窗，以及把侧边栏折叠起来再刷新确认骨架不外溢。

🤖 Generated with [Claude Code](https://claude.com/claude-code)