### PR TITLE
:lipstick: style(web): 升级条随对话开始左滑退场，收放不再硬切

### DIFF
--- a/apps/web/src/app/dashboard/edit/_components/ai/AiChatShell.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ai/AiChatShell.tsx
@@ -1635,6 +1635,7 @@ export default function AiChatShell({
         onAttachPdf={handleAttachPdf}
         mode={agentMode}
         onModeChange={setAgentMode}
+        conversationStarted={started}
       />
     </>
   );

--- a/apps/web/src/app/dashboard/edit/_components/ai/conversation/Composer.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ai/conversation/Composer.tsx
@@ -58,6 +58,8 @@ type ComposerProps = {
   /** 当前模式 —— 提到会话层，因为真正的闸门在 AiChatShell 的运行逻辑里。 */
   mode: AgentMode;
   onModeChange: (mode: AgentMode) => void;
+  /** 对话已开始。升级条只属于欢迎态：一旦开聊，它就是压在输入框下面的一条广告。 */
+  conversationStarted?: boolean;
 };
 
 /**
@@ -104,6 +106,7 @@ export default function Composer({
   onStop,
   mode,
   onModeChange,
+  conversationStarted,
 }: ComposerProps) {
   const { t, i18n } = useTranslation();
   const [value, setValue] = useState('');
@@ -577,7 +580,7 @@ export default function Composer({
           </div>
         </div>
 
-        <ProUpgradeBanner />
+        <ProUpgradeBanner retired={conversationStarted} />
       </div>
     </div>
   );

--- a/apps/web/src/app/dashboard/edit/_components/ai/conversation/ProUpgradeBanner.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/ai/conversation/ProUpgradeBanner.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useEffect, useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useEntitlement } from '@/lib/extensions/billing-client';
@@ -21,8 +21,9 @@ const DISMISS_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
  * 关掉之后隔 7 天再出现：关一次就永不再见等于放弃了这个位置，但反复弹同一条广告
  * 与「让用户有掌控感」直接冲突。7 天是两者之间那个不讨嫌的间隔。
  */
-export default function ProUpgradeBanner() {
+export default function ProUpgradeBanner({ retired }: { retired?: boolean }) {
   const { t } = useTranslation();
+  const reduce = useReducedMotion() ?? false;
   const openPricing = useAccountUiStore((s) => s.openPricing);
   const { data } = useEntitlement(isCloudMode);
   // localStorage 只能在挂载后读:服务端没有它,首帧当作「已关闭」才不会 hydration 抖。
@@ -41,7 +42,10 @@ export default function ProUpgradeBanner() {
   const plan = data?.currentPlan;
   // 免费档 = 有计划行但不要钱。`isDefault` 兜住「运营把免费档改了名」的情况。
   const isFreePlan = !!plan && (plan.priceCents === 0 || plan.isDefault);
-  const visible = isCloudMode && isFreePlan && !dismissed;
+  const eligible = isCloudMode && isFreePlan;
+  // `retired`：对话一开始它就该走。欢迎态下方是空的，这条占得起；开聊之后输入框沉到
+  // 底部，它就成了压在输入框下面的一条广告，而那时用户正等着回答。
+  const visible = eligible && !dismissed && !retired;
 
   const dismiss = () => {
     setDismissed(true);
@@ -52,49 +56,68 @@ export default function ProUpgradeBanner() {
     }
   };
 
+  // 没资格看到它的构建（自部署 / 已付费）连壳子都不渲染。
+  if (!eligible) return null;
+
   return (
-    <AnimatePresence initial={false}>
-      {visible && (
-        <motion.aside
-          initial={{ opacity: 0, y: -6 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -6 }}
-          transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
-          aria-label={t('aiLab.pro.regionLabel')}
-          className="relative mt-2.5 flex min-h-[60px] items-center gap-3 overflow-hidden rounded-[30px] border border-sky-400/[0.14] bg-neutral-800/60 py-3 pl-5 pr-3.5"
-        >
-          {/* 辉光独立成层：渐变数学留在 CSS 里，浅色态在 globals.css 统一降透明 */}
-          <span aria-hidden className="composer-pro-glow absolute inset-0" />
-
-          <p className="relative min-w-0 flex-1 text-[15px] leading-snug text-neutral-100">
-            {t('aiLab.pro.title')}
-            <button
-              type="button"
-              onClick={openPricing}
-              className="ml-1.5 rounded text-sky-300 underline-offset-4 transition-colors hover:text-sky-200 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/50 cursor-pointer"
+    // 外层只管**让位**：0fr ↔ 1fr 把行高收放交给 grid 自己算，不去动 height。
+    // 缺了这一层，AnimatePresence 卸载的那一帧整条高度直接消失，输入框会硬生生
+    // 弹下去一截——这就是关掉横幅时那下「生硬」的来源。
+    // 收放与内容的滑出同时起步、同长同曲线，读作一个动作而不是两拍。
+    <div
+      className="grid"
+      style={{
+        gridTemplateRows: visible ? '1fr' : '0fr',
+        transition: reduce ? undefined : 'grid-template-rows 260ms cubic-bezier(0.22,1,0.36,1)',
+      }}
+    >
+      <div className="overflow-hidden">
+        <AnimatePresence initial={false}>
+          {visible && (
+            <motion.aside
+              initial={{ opacity: 0, y: -6 }}
+              animate={{ opacity: 1, x: 0, y: 0 }}
+              // 往左滑走，而不是原地淡掉：它是被**这次发送**推走的，方向上要读得出
+              // 「让开」而不是「消失」。入场仍是从上方落下——那是它自己出现的动作。
+              exit={{ opacity: 0, x: reduce ? 0 : -32 }}
+              transition={{ duration: reduce ? 0 : 0.26, ease: [0.22, 1, 0.36, 1] }}
+              aria-label={t('aiLab.pro.regionLabel')}
+              className="relative mt-2.5 flex min-h-[60px] items-center gap-3 overflow-hidden rounded-[30px] border border-sky-400/[0.14] bg-neutral-800/60 py-3 pl-5 pr-3.5"
             >
-              {t('aiLab.pro.benefits')}
-            </button>
-          </p>
+              {/* 辉光独立成层：渐变数学留在 CSS 里，浅色态在 globals.css 统一降透明 */}
+              <span aria-hidden className="composer-pro-glow absolute inset-0" />
 
-          <button
-            type="button"
-            onClick={openPricing}
-            className="relative inline-flex h-8 shrink-0 items-center rounded-full border border-sky-300/30 bg-sky-400/20 px-3.5 text-[14px] text-neutral-50 transition-colors hover:bg-sky-400/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/50 cursor-pointer"
-          >
-            {t('aiLab.pro.cta')}
-          </button>
+              <p className="relative min-w-0 flex-1 text-[15px] leading-snug text-neutral-100">
+                {t('aiLab.pro.title')}
+                <button
+                  type="button"
+                  onClick={openPricing}
+                  className="ml-1.5 rounded text-sky-300 underline-offset-4 transition-colors hover:text-sky-200 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/50 cursor-pointer"
+                >
+                  {t('aiLab.pro.benefits')}
+                </button>
+              </p>
 
-          <button
-            type="button"
-            onClick={dismiss}
-            aria-label={t('aiLab.pro.dismiss')}
-            className="relative grid h-8 w-8 shrink-0 place-items-center rounded-full text-neutral-400 transition-colors hover:bg-white/[0.07] hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/50 cursor-pointer"
-          >
-            <X size={16} />
-          </button>
-        </motion.aside>
-      )}
-    </AnimatePresence>
+              <button
+                type="button"
+                onClick={openPricing}
+                className="relative inline-flex h-8 shrink-0 items-center rounded-full border border-sky-300/30 bg-sky-400/20 px-3.5 text-[14px] text-neutral-50 transition-colors hover:bg-sky-400/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/50 cursor-pointer"
+              >
+                {t('aiLab.pro.cta')}
+              </button>
+
+              <button
+                type="button"
+                onClick={dismiss}
+                aria-label={t('aiLab.pro.dismiss')}
+                className="relative grid h-8 w-8 shrink-0 place-items-center rounded-full text-neutral-400 transition-colors hover:bg-white/[0.07] hover:text-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/50 cursor-pointer"
+              >
+                <X size={16} />
+              </button>
+            </motion.aside>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
输入框下方那条 Pro 升级条的两处生硬。

## 1. 发送后仍停在底部

升级条只属于欢迎态：那时输入框下方本就是空的，它占得起；开聊之后输入框沉到底部，它就成了压在输入框下面的一条广告，而那一刻用户正等着回答。

复用 `AiChatShell` 已有的 `started`，一路传成 `ProUpgradeBanner` 的 `retired`，对话一开始就走。退场**往左滑**而不是原地淡掉——它是被这次发送推走的，方向上要读得出「让开」而不是「消失」；入场保持从上方落下，那是它自己出现的动作，两者不该同形。

## 2. 关掉时输入框硬生生弹下去

根因是 `AnimatePresence` 卸载的那一帧**整条高度直接消失**：内容在淡出，布局却是硬切的。

外面套一层 grid，用 `0fr ↔ 1fr` 把行高收放交给 grid 自己算，不去动 `height`（符合「只动 transform/opacity，高度用 grid-template-rows」那条）。收放与滑出同时起步、同长同曲线（260ms），读作一个动作而不是两拍。

## 顺带

- `prefers-reduced-motion` 下位移与过渡都关掉
- 没资格看到它的构建（自部署 / 已付费）现在连外层壳子都不渲染，之前会留一个空 wrapper

## 验证

`tsc --noEmit` / `eslint` / `pnpm i18n:check` 全绿；pre-commit 全量 lint+build 通过。视觉验收已由作者完成。

> 配套的另一半在 Magic-Resume-Commercial：`PricingModal` 的 `z-50 → z-200`。此前点「升级到 Pro」没反应，不是弹窗没开，是被 AI Lab 的 `z-100/101` 整个盖住了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)