### PR TITLE
:sparkles: feat(web): 账户面板可设密码与 2FA · 导入格式分列 · 导出入口统一

### DIFF
--- a/apps/web/scripts/i18n-logs/scan.md
+++ b/apps/web/scripts/i18n-logs/scan.md
@@ -1,3 +1,3 @@
-# i18n Scan Report (8/10/2026, 7:22:33 PM)
+# i18n Scan Report (8/10/2026, 9:56:26 PM)
 
 ✅ All checks passed! No issues found.

--- a/apps/web/scripts/i18n-logs/scan.md
+++ b/apps/web/scripts/i18n-logs/scan.md
@@ -1,3 +1,3 @@
-# i18n Scan Report (8/10/2026, 9:56:26 PM)
+# i18n Scan Report (8/10/2026, 10:05:55 PM)
 
 ✅ All checks passed! No issues found.

--- a/apps/web/src/app/dashboard/_components/ImportResumeDialog.tsx
+++ b/apps/web/src/app/dashboard/_components/ImportResumeDialog.tsx
@@ -34,7 +34,43 @@ import {
   type PdfPhase,
 } from './PdfScanProgress';
 
-type FileType = 'json' | 'pdf' | null;
+/**
+ * 每一种格式单列一项，而不是合成「简历文件（PDF / Word / 图片 / Markdown）」。
+ *
+ * 合起来读着简洁，代价是**支持哪些格式变成了要读完一整行小字才知道的事**——而"原来
+ * Word 也能导"恰恰是最该被看见的信息。四项分开，一眼扫过去就知道自己那份能不能进。
+ *
+ * `'pdf'` 之外的三个值都是新增的：它们同时是埋点的 source 维度，只增不改，既有指标
+ * 不会从中间断掉。
+ */
+type FileType = 'json' | 'pdf' | 'image' | 'docx' | 'markdown' | null;
+
+/** 拖放区那枚小徽章上的扩展名提示。 */
+const ACCEPT_EXT_HINT: Record<string, string> = {
+  json: '.json',
+  pdf: '.pdf',
+  image: '.png · .jpg · .webp',
+  docx: '.docx',
+  markdown: '.md · .txt',
+};
+
+/** 走 LLM 解析的格式（与 json 相对——那条是直接读结构化数据，不花 AI 额度）。 */
+const AI_TYPES = ['pdf', 'image', 'docx', 'markdown'] as const;
+
+/** 每种格式接受的 MIME → 扩展名。后端按 mimetype 自己分发，这里只管把闸门开对。 */
+const ACCEPT_BY_TYPE: Record<string, Record<string, string[]>> = {
+  json: { 'application/json': ['.json'] },
+  pdf: { 'application/pdf': ['.pdf'] },
+  image: {
+    'image/png': ['.png'],
+    'image/jpeg': ['.jpg', '.jpeg'],
+    'image/webp': ['.webp'],
+  },
+  docx: {
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['.docx'],
+  },
+  markdown: { 'text/markdown': ['.md'], 'text/plain': ['.txt'] },
+};
 
 type ImportResumeDialogProps = {
   open: boolean;
@@ -204,7 +240,7 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
     setIsImporting(true);
 
     try {
-      const result = fileType === 'pdf'
+      const result = fileType !== 'json'
         ? await handlePdfFile(file)
         : await handleJsonFile(file);
 
@@ -241,7 +277,7 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
       });
 
       toast.success(
-        fileType === 'pdf'
+        fileType !== 'json'
           ? t('importDialog.pdf.success', { defaultValue: 'PDF resume imported successfully!' })
           : t('importDialog.success')
       );
@@ -265,21 +301,7 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
     }
   }, [fileType, importResume, handleClose, t, handleJsonFile, handlePdfFile, cloudSync]);
 
-  // 'pdf' 这个取值现在代表的是「走解析的简历文件」这一整条路，不再只是 PDF——
-  // 后端按 mimetype 自己分发（PDF 抽文字 / DOCX 走 mammoth / 图片交视觉模型 /
-  // Markdown 直读）。标识符没跟着改名，是因为它同时是埋点的 source 维度，
-  // 改了会把一条既有指标从中间截断。
-  const dropzoneAccept: Record<string, string[]> = fileType === 'pdf'
-    ? {
-        'application/pdf': ['.pdf'],
-        'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['.docx'],
-        'text/markdown': ['.md'],
-        'text/plain': ['.txt'],
-        'image/png': ['.png'],
-        'image/jpeg': ['.jpg', '.jpeg'],
-        'image/webp': ['.webp'],
-      }
-    : { 'application/json': ['.json'] };
+  const dropzoneAccept: Record<string, string[]> = ACCEPT_BY_TYPE[fileType ?? 'json'] ?? {};
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
@@ -347,18 +369,24 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
                         {'Magic Resume JSON'}
                       </span>
                     </SelectItem>
-                    <SelectItem
-                      value="pdf"
-                      className="text-neutral-200 focus:bg-neutral-800 focus:text-white rounded-lg cursor-pointer"
-                    >
-                      <span className="flex items-center gap-2">
-                        <FileText size={15} className="text-sky-400 shrink-0" />
-                        {t('importDialog.documentOption')}
-                        <span className="inline-flex items-center text-[10px] font-semibold text-sky-400 bg-sky-500/15 border border-sky-500/30 px-1.5 py-0.5 rounded-full leading-none">
-                          {'AI'}
+                    {AI_TYPES.map((type) => (
+                      <SelectItem
+                        key={type}
+                        value={type}
+                        className="text-neutral-200 focus:bg-neutral-800 focus:text-white rounded-lg cursor-pointer"
+                      >
+                        <span className="flex items-center gap-2">
+                          <FileText size={15} className="text-sky-400 shrink-0" />
+                          {t(`importDialog.types.${type}`)}
+                          {/* 每一项都标 AI：这四种都要花模型额度去解析，而 JSON 不用。
+                              标在每一行而不是标一次，是因为用户是逐项扫的，
+                              不会去推断"上面那个标签是不是也管我这一行"。 */}
+                          <span className="inline-flex items-center text-[10px] font-semibold text-sky-400 bg-sky-500/15 border border-sky-500/30 px-1.5 py-0.5 rounded-full leading-none">
+                            {'AI'}
+                          </span>
                         </span>
-                      </span>
-                    </SelectItem>
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>
@@ -411,7 +439,7 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
                       `}
                     >
                       <input {...getInputProps()} />
-                      {isImporting && fileType === 'pdf' ? (
+                      {isImporting && fileType !== 'json' ? (
                         <PdfScanProgress
                           phase={pdfPhase}
                           charCount={pdfCharCount}
@@ -435,10 +463,8 @@ export default function ImportResumeDialog({ open, onOpenChange }: ImportResumeD
                             <p className="text-neutral-300 font-medium text-sm">{t('importDialog.dropzone.default')}</p>
                           )}
                           <span className="inline-flex items-center gap-1 text-xs text-neutral-500 bg-neutral-800/60 px-2.5 py-1 rounded-full mt-2.5">
-                            {fileType === 'pdf' ? <FileText size={11} /> : <FileJson size={11} />}
-                            {fileType === 'pdf'
-                              ? '.pdf · .docx · .png · .jpg · .md'
-                              : '.json'}
+                            {fileType === 'json' ? <FileJson size={11} /> : <FileText size={11} />}
+                            {ACCEPT_EXT_HINT[fileType ?? 'json']}
                           </span>
                         </div>
                       )}

--- a/apps/web/src/app/dashboard/edit/_components/layout/EditorDock.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/layout/EditorDock.tsx
@@ -2,11 +2,11 @@ import { useMemo, useState, type ReactNode } from "react";
 import { motion } from "framer-motion";
 import { ZoomIn, ZoomOut, RotateCcw, Download, FileJson, Share2, Loader2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { toast } from "sonner";
 import { useSettingStore } from "@/store/useSettingStore";
-import { exportResumeToPdf, preloadResumePdfExport } from "@/lib/utils/pdf-export";
+import { preloadResumePdfExport } from "@/lib/utils/pdf-export";
+import ExportModal from "../modals/ExportModal";
+import { useResumeExport } from "../modals/useResumeExport";
 import { Resume } from "@/types/frontend/resume";
-import { appLifecycle } from "@/lib/extensions/app-lifecycle";
 
 type EditorDockProps = {
   zoomIn: (step?: number) => void;
@@ -28,11 +28,11 @@ type DockEntry =
  * `absolute … left-1/2` 自动避开右侧模板栏。
  */
 export function EditorDock({ zoomIn, zoomOut, resetTransform, resume, onShareClick, onJsonClick }: EditorDockProps) {
-  const { t, i18n } = useTranslation();
-  const [isExporting, setIsExporting] = useState(false);
+  const { t } = useTranslation();
+  const [exportOpen, setExportOpen] = useState(false);
+  const { isExporting, runExport } = useResumeExport(resume, 'dock');
   const cloudSync = useSettingStore((state) => state.cloudSync);
   // Match the locale the preview renders with so the export reuses its cached blob.
-  const pdfLocale = i18n.resolvedLanguage || i18n.language;
 
   const warmupPdfExport = () => {
     // Lightweight: only warms the template + fonts. The full blob is produced
@@ -40,36 +40,6 @@ export function EditorDock({ zoomIn, zoomOut, resetTransform, resume, onShareCli
     void preloadResumePdfExport(resume).catch(() => {
       // Best-effort warmup only; export handles real failures.
     });
-  };
-
-  const handleExportPdf = async () => {
-    // 客户端用 @react-pdf/renderer 生成矢量、文字可选中(ATS 友好)的 PDF。
-    // 产出是「一整页连续长页」而非分页 A4——见 resume-templates 的
-    // MagicResumePdfDocument 顶部说明。
-    if (isExporting) return;
-    setIsExporting(true);
-    const toastId = toast.loading(t("tools.exportingPDF"));
-    const startedAt = Date.now();
-    try {
-      await exportResumeToPdf(resume, pdfLocale);
-      toast.success(t("tools.exportPDFSuccess"), { id: toastId });
-      appLifecycle.resumeExported({
-        format: "pdf",
-        source: "dock",
-        durationMs: Date.now() - startedAt,
-      });
-    } catch (error) {
-      console.error("PDF export failed:", error);
-      toast.error(t("tools.exportPDFError"), { id: toastId });
-      appLifecycle.resumeExported({
-        format: "pdf",
-        source: "dock",
-        success: false,
-        durationMs: Date.now() - startedAt,
-      });
-    } finally {
-      setIsExporting(false);
-    }
   };
 
   const items: DockEntry[] = useMemo(() => {
@@ -82,7 +52,7 @@ export function EditorDock({ zoomIn, zoomOut, resetTransform, resume, onShareCli
         id: "export-pdf",
         title: isExporting ? t("tools.exportingPDF") : t("tools.exportPDF"),
         icon: isExporting ? <Loader2 size={16} className="animate-spin text-sky-300" /> : <Download size={16} />,
-        onClick: handleExportPdf,
+        onClick: () => setExportOpen(true),
         disabled: isExporting,
       },
       { id: "view-json", title: t("resumeContent.viewJson"), icon: <FileJson size={16} />, onClick: onJsonClick },
@@ -134,6 +104,13 @@ export function EditorDock({ zoomIn, zoomOut, resetTransform, resume, onShareCli
           )}
         </motion.div>
       </motion.div>
+
+      <ExportModal
+        isOpen={exportOpen}
+        onClose={() => setExportOpen(false)}
+        onExport={runExport}
+        resume={resume}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/dashboard/edit/_components/layout/EditorDock.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/layout/EditorDock.tsx
@@ -50,7 +50,7 @@ export function EditorDock({ zoomIn, zoomOut, resetTransform, resume, onShareCli
       { type: "divider", id: "divider-1" },
       {
         id: "export-pdf",
-        title: isExporting ? t("tools.exportingPDF") : t("tools.exportPDF"),
+        title: isExporting ? t("tools.exportingPDF") : t("modals.export.title"),
         icon: isExporting ? <Loader2 size={16} className="animate-spin text-sky-300" /> : <Download size={16} />,
         onClick: () => setExportOpen(true),
         disabled: isExporting,

--- a/apps/web/src/app/dashboard/edit/_components/layout/Tools.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/layout/Tools.tsx
@@ -5,17 +5,11 @@ import { Bot, History, Share2, MessageCircle, ChevronDown, ChevronUp, Loader2, Z
 import { useTranslation } from "react-i18next";
 import { type ReactNode, useState } from "react";
 import { useRouter, useParams } from "next/navigation";
-import { toast } from "sonner";
 import { useSettingStore } from "@/store/useSettingStore";
 import { isCloudMode } from "@/lib/config/app";
-import {
-  exportResumeToImage,
-  exportResumeToJson,
-  exportResumeToPdf,
-  preloadResumePdfExport,
-} from "@/lib/utils/pdf-export";
-import ExportModal, { type ExportFormat } from "../modals/ExportModal";
-import { appLifecycle } from "@/lib/extensions/app-lifecycle";
+import { preloadResumePdfExport } from "@/lib/utils/pdf-export";
+import ExportModal from "../modals/ExportModal";
+import { useResumeExport } from "../modals/useResumeExport";
 
 export type ToolsProps = {
   isMobile: boolean;
@@ -59,23 +53,21 @@ function ToolButton({ title, children, onClick, onFocus, onPointerEnter, disable
 }
 
 export function Tools({ isMobile, zoomIn, zoomOut, resetTransform, resume, onShowAI, onVersionClick, rightCollapsed = false, onShareClick, onFeedbackClick }: ToolsProps){
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const router = useRouter();
   const params = useParams();
   // We can fallback to 'default' or handle error if id is missing, but it should be present in this context
   const currentId = (params?.id as string) || resume.id;
 
   const [isCollapsed, setIsCollapsed] = useState(false);
-  const [isExporting, setIsExporting] = useState(false);
   const [exportOpen, setExportOpen] = useState(false);
+  const { isExporting, runExport } = useResumeExport(resume, 'tools');
   const cloudSync = useSettingStore((state) => state.cloudSync);
   
   // 计算桌面端工具栏的right位置，避免被模板栏遮挡
   const desktopRightPosition = rightCollapsed ? '76px' : '300px'; // 56px模板栏 + 20px间距 或 280px模板栏 + 20px间距
   
   const toggleCollapsed = () => setIsCollapsed((prev) => !prev);
-  // Match the locale the preview renders with so the export reuses its cached blob.
-  const pdfLocale = i18n.resolvedLanguage || i18n.language;
 
   const warmupPdfExport = () => {
     // Lightweight: only warms the template + fonts. The full blob is produced
@@ -85,48 +77,6 @@ export function Tools({ isMobile, zoomIn, zoomOut, resetTransform, resume, onSho
     });
   };
 
-  // PDF 走客户端 @react-pdf/renderer,矢量、文字可选中(ATS 友好),无打印框;
-  // 产出是「一整页连续长页」而非分页 A4——见 resume-templates 的
-  // MagicResumePdfDocument 顶部说明。
-  // 图片由同一份 PDF 光栅化而来,两者逐像素同源;JSON 是原始数据,不经渲染。
-  const COPY: Record<ExportFormat, { loading: string; ok: string; fail: string }> = {
-    pdf: { loading: 'tools.exportingPDF', ok: 'tools.exportPDFSuccess', fail: 'tools.exportPDFError' },
-    png: { loading: 'modals.export.imaging', ok: 'modals.export.imageSuccess', fail: 'modals.export.imageError' },
-    json: { loading: '', ok: 'modals.export.jsonSuccess', fail: '' },
-  };
-
-  const handleExport = async (format: ExportFormat) => {
-    if (isExporting) return;
-    setIsExporting(true);
-    const copy = COPY[format];
-    // JSON 是同步序列化,不该为它闪一下 loading——那会读成"在做很重的事"。
-    const toastId = copy.loading ? toast.loading(t(copy.loading)) : undefined;
-    const startedAt = Date.now();
-    try {
-      if (format === 'pdf') await exportResumeToPdf(resume, pdfLocale);
-      else if (format === 'png') await exportResumeToImage(resume, pdfLocale);
-      else exportResumeToJson(resume);
-      toast.success(t(copy.ok), toastId ? { id: toastId } : undefined);
-      appLifecycle.resumeExported({
-        format,
-        source: 'tools',
-        durationMs: Date.now() - startedAt,
-      });
-    } catch (error) {
-      console.error(`${format} export failed:`, error);
-      if (copy.fail) toast.error(t(copy.fail), toastId ? { id: toastId } : undefined);
-      // Failures matter as much as successes here: export is where the product
-      // delivers its value, so its success rate is the number worth watching.
-      appLifecycle.resumeExported({
-        format,
-        source: 'tools',
-        success: false,
-        durationMs: Date.now() - startedAt,
-      });
-    } finally {
-      setIsExporting(false);
-    }
-  };
 
   return (
     <div 
@@ -231,7 +181,7 @@ export function Tools({ isMobile, zoomIn, zoomOut, resetTransform, resume, onSho
       <ExportModal
         isOpen={exportOpen}
         onClose={() => setExportOpen(false)}
-        onExport={handleExport}
+        onExport={runExport}
         resume={resume}
       />
     </div>

--- a/apps/web/src/app/dashboard/edit/_components/modals/ExportModal.tsx
+++ b/apps/web/src/app/dashboard/edit/_components/modals/ExportModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Check, Download, FileJson, FileText, Image as ImageIcon, Loader2, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -43,6 +44,9 @@ export default function ExportModal({
   const { t } = useTranslation();
   const [format, setFormat] = useState<ExportFormat>('pdf');
   const [busy, setBusy] = useState(false);
+  // SSR 时没有 document，portal 只能在挂载后建。
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
 
   const run = async () => {
     if (busy) return;
@@ -55,7 +59,13 @@ export default function ExportModal({
     }
   };
 
-  return (
+  if (!mounted) return null;
+
+  // **必须 portal 到 body。** 两个调用方（Tools / EditorDock）都在带 transform 的
+  // 祖先里——EditorDock 外层就是 framer 的 motion.div——而祖先一旦有 transform，
+  // `position: fixed` 就不再相对视口，而是相对那个盒子：弹窗会被挤成一条窄缝，
+  // 还跟着一起被缩放。portal 出去之后，它挂在哪都不受调用方的布局影响。
+  return createPortal(
     <AnimatePresence>
       {isOpen && (
         <>
@@ -154,6 +164,7 @@ export default function ExportModal({
           </div>
         </>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body
   );
 }

--- a/apps/web/src/app/dashboard/edit/_components/modals/useResumeExport.ts
+++ b/apps/web/src/app/dashboard/edit/_components/modals/useResumeExport.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import {
+  exportResumeToImage,
+  exportResumeToJson,
+  exportResumeToPdf,
+} from '@/lib/utils/pdf-export';
+import { appLifecycle } from '@/lib/extensions/app-lifecycle';
+import type { Resume } from '@/types/frontend/resume';
+import type { ExportFormat } from './ExportModal';
+
+const COPY: Record<ExportFormat, { loading: string; ok: string; fail: string }> = {
+  pdf: {
+    loading: 'tools.exportingPDF',
+    ok: 'tools.exportPDFSuccess',
+    fail: 'tools.exportPDFError',
+  },
+  png: {
+    loading: 'modals.export.imaging',
+    ok: 'modals.export.imageSuccess',
+    fail: 'modals.export.imageError',
+  },
+  // JSON 是同步序列化，不该为它闪一下 loading——那会读成"在做很重的事"。
+  json: { loading: '', ok: 'modals.export.jsonSuccess', fail: '' },
+};
+
+/**
+ * 导出这件事的唯一实现。
+ *
+ * 编辑器有两个导出入口（右下工具栏 `Tools` 与底部 `EditorDock`），此前各写了一遍几乎
+ * 相同的 30 行——toast、埋点、错误处理全部重复，只差一个 `source` 字段。加格式选择时
+ * 若照旧复制一遍，就成了三份要同步维护的实现。
+ *
+ * `source` 保留为参数：两个入口的转化率本来就该分开看。
+ */
+export function useResumeExport(resume: Resume, source: 'tools' | 'dock') {
+  const { t, i18n } = useTranslation();
+  const [isExporting, setIsExporting] = useState(false);
+  // 与预览渲染用同一个 locale，导出才能命中预览已经算好的那份 blob 缓存。
+  const locale = i18n.resolvedLanguage || i18n.language;
+
+  const runExport = async (format: ExportFormat) => {
+    if (isExporting) return;
+    setIsExporting(true);
+    const copy = COPY[format];
+    const toastId = copy.loading ? toast.loading(t(copy.loading)) : undefined;
+    const startedAt = Date.now();
+    try {
+      if (format === 'pdf') await exportResumeToPdf(resume, locale);
+      else if (format === 'png') await exportResumeToImage(resume, locale);
+      else exportResumeToJson(resume);
+      toast.success(t(copy.ok), toastId ? { id: toastId } : undefined);
+      appLifecycle.resumeExported({ format, source, durationMs: Date.now() - startedAt });
+    } catch (error) {
+      console.error(`${format} export failed:`, error);
+      if (copy.fail) toast.error(t(copy.fail), toastId ? { id: toastId } : undefined);
+      // 失败和成功一样值得记：导出是这个产品交付价值的那一步，它的成功率是最该盯的数。
+      appLifecycle.resumeExported({
+        format,
+        source,
+        success: false,
+        durationMs: Date.now() - startedAt,
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return { isExporting, runExport };
+}

--- a/apps/web/src/components/account/billing/OrderHistoryTable.tsx
+++ b/apps/web/src/components/account/billing/OrderHistoryTable.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
 import type { OrderHistoryRow } from '@/lib/billing/types';
 
 /**
@@ -23,6 +25,43 @@ function formatAmount(amountCents: number, currency: string, locale: string) {
     // whole table.
     return `${(amountCents / 100).toFixed(2)} ${currency}`;
   }
+}
+
+/**
+ * 账单 ID。**屏幕上给短的，剪贴板里给全的。**
+ *
+ * 这两件事的受众不同：屏幕上要的是「能区分开同一天的六笔」，末 8 位就够；而发给客服
+ * 要的是「能粘贴的完整串」。cuid 有 25 位，整串塞进表格会把金额和状态挤出可视区。
+ */
+function OrderIdCell({ id }: { id: string }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard.writeText(id);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      title={id}
+      aria-label={t('account.billing.copyOrderId')}
+      className={cn(
+        'group inline-flex items-center gap-1.5 rounded font-mono text-[12px] transition-colors cursor-pointer',
+        copied ? 'text-emerald-400' : 'text-neutral-400 hover:text-neutral-100'
+      )}
+    >
+      {id.slice(-8)}
+      {copied ? (
+        <Check size={12} className="shrink-0" />
+      ) : (
+        <Copy size={12} className="shrink-0 opacity-0 transition-opacity group-hover:opacity-60" />
+      )}
+    </button>
+  );
 }
 
 function formatDate(value: string | null | undefined, locale: string) {
@@ -79,6 +118,7 @@ export function OrderHistoryTable({
         <thead>
           <tr className="border-b border-white/[0.06] text-left text-[11.5px] uppercase tracking-wide text-neutral-500">
             <th className="px-4 py-2.5 font-medium">{t('account.billing.colDate')}</th>
+            <th className="px-4 py-2.5 font-medium">{t('account.billing.colOrderId')}</th>
             <th className="px-4 py-2.5 font-medium">{t('account.billing.colItem')}</th>
             <th className="px-4 py-2.5 font-medium">
               {t('account.billing.colAmount')}
@@ -101,6 +141,9 @@ export function OrderHistoryTable({
                 {/* paidAt when it went through, createdAt when it did not —
                     an abandoned checkout still has a date worth showing. */}
                 {formatDate(order.paidAt ?? order.createdAt, locale)}
+              </td>
+              <td className="whitespace-nowrap px-4 py-2.5">
+                <OrderIdCell id={order.id} />
               </td>
               <td className="px-4 py-2.5 text-neutral-200">
                 {order.planName ?? t('account.billing.unknownItem')}

--- a/apps/web/src/components/account/security/PasswordSection.tsx
+++ b/apps/web/src/components/account/security/PasswordSection.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import React, { useState } from 'react';
+import { KeyRound, Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { clerkErrorMessage } from './clerkError';
+
+import type { useUser } from '@clerk/nextjs';
+
+/**
+ * 从 `useUser()` 的返回类型反推，而不是导 `@clerk/types`——后者已并入 `@clerk/shared`
+ * 且不是本包的直接依赖，导它是幻影依赖；这样写 Clerk 再搬一次类型也不会断。
+ */
+type ClerkUser = NonNullable<ReturnType<typeof useUser>['user']>;
+
+
+/**
+ * 密码：设置或修改。
+ *
+ * 直接调客户端 SDK 的 `user.updatePassword()`，不经我们自己的后端——不是图省事：
+ * Clerk 的 Backend API 用 `updateUser({ password })` 改密码时**不校验旧密码**，
+ * 那等于谁拿到一个被劫持的会话，谁就能静默改掉密码把机主锁在门外。客户端这条则强制
+ * 校验旧密码，还顺带给了 `signOutOfOtherSessions`。
+ *
+ * `currentPassword` 是可选参数，所以一套表单覆盖两种情形：OAuth 注册的用户从未设过
+ * 密码（`passwordEnabled === false`），此时不该问他"当前密码"。
+ */
+export default function PasswordSection({ user }: { user: ClerkUser }) {
+  const { t } = useTranslation();
+  const has = !!user.passwordEnabled;
+
+  const [open, setOpen] = useState(false);
+  const [current, setCurrent] = useState('');
+  const [next, setNext] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setOpen(false);
+    setCurrent('');
+    setNext('');
+    setConfirm('');
+    setError(null);
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (busy) return;
+    if (next !== confirm) {
+      setError(t('account.security.password.mismatch'));
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await user.updatePassword({
+        newPassword: next,
+        ...(has ? { currentPassword: current } : {}),
+        // 不给开关，默认踢掉其它会话：改密码这个动作的意义本来就是"把别人赶出去"。
+        // 留一个默认关闭的复选框，等于把一个安全决策推给不该承担它的人。
+        signOutOfOtherSessions: true,
+      });
+      reset();
+    } catch (err) {
+      setError(clerkErrorMessage(err, t));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg bg-white/[0.04] p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2 text-[13px] text-neutral-100">
+          <KeyRound size={16} className="shrink-0 text-neutral-500" />
+          <span className="truncate">{t('account.security.password.label')}</span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span
+            className={cn(
+              'rounded px-1.5 py-0.5 text-[11px]',
+              has ? 'bg-emerald-500/15 text-emerald-300' : 'bg-white/[0.06] text-neutral-500'
+            )}
+          >
+            {t(has ? 'account.security.on' : 'account.security.off')}
+          </span>
+          <button
+            type="button"
+            onClick={() => (open ? reset() : setOpen(true))}
+            className="rounded px-2 py-1 text-[12px] text-sky-300 transition-colors hover:bg-sky-400/10 hover:text-sky-200 cursor-pointer"
+          >
+            {t(open ? 'account.security.cancel' : has ? 'account.security.password.change' : 'account.security.password.set')}
+          </button>
+        </div>
+      </div>
+
+      {open && (
+        <form onSubmit={submit} className="mt-3 space-y-2 border-t border-white/[0.06] pt-3">
+          {has && (
+            <Field
+              label={t('account.security.password.current')}
+              value={current}
+              onChange={setCurrent}
+              autoComplete="current-password"
+            />
+          )}
+          <Field
+            label={t('account.security.password.new')}
+            value={next}
+            onChange={setNext}
+            autoComplete="new-password"
+          />
+          <Field
+            label={t('account.security.password.confirm')}
+            value={confirm}
+            onChange={setConfirm}
+            autoComplete="new-password"
+          />
+
+          {error && <p className="text-[12px] text-rose-300">{error}</p>}
+
+          {/* 先说清后果再让人点。「其它设备会被登出」不是副作用，是这个动作的一半意义。 */}
+          <p className="text-[11.5px] leading-relaxed text-neutral-500">
+            {t('account.security.password.signOutNotice')}
+          </p>
+
+          <button
+            type="submit"
+            disabled={busy || !next || !confirm || (has && !current)}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-sky-500 px-3.5 py-1.5 text-[12.5px] font-semibold text-[#fff] transition-colors hover:bg-sky-400 disabled:opacity-40 cursor-pointer"
+          >
+            {busy && <Loader2 size={13} className="animate-spin" />}
+            {t('account.security.save')}
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  autoComplete,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  autoComplete: string;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-[11.5px] text-neutral-500">{label}</span>
+      <input
+        type="password"
+        value={value}
+        autoComplete={autoComplete}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-lg border border-white/[0.08] bg-neutral-950/60 px-3 py-1.5 text-[13px] text-neutral-100 outline-none transition-colors focus:border-sky-400/40"
+      />
+    </label>
+  );
+}

--- a/apps/web/src/components/account/security/TotpSection.tsx
+++ b/apps/web/src/components/account/security/TotpSection.tsx
@@ -1,0 +1,285 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { Check, Copy, Download, Loader2, ShieldCheck } from 'lucide-react';
+import QRCode from 'qrcode';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { clerkErrorMessage } from './clerkError';
+
+import type { useUser } from '@clerk/nextjs';
+
+/**
+ * 从 `useUser()` 的返回类型反推，而不是导 `@clerk/types`——后者已并入 `@clerk/shared`
+ * 且不是本包的直接依赖，导它是幻影依赖；这样写 Clerk 再搬一次类型也不会断。
+ */
+type ClerkUser = NonNullable<ReturnType<typeof useUser>['user']>;
+
+
+type Step = 'idle' | 'scan' | 'codes' | 'confirmDisable';
+
+/**
+ * 两步验证（TOTP）+ 备用码。
+ *
+ * **只能在客户端做。** Clerk 的 Backend SDK 上只有 `deleteUserTOTP` / `disableUserMFA`
+ * ——能关不能开。绑定 TOTP 天然要把密钥展示给当前登录的这个人、并让他用验证器回证，
+ * 后端拿不到"这个人此刻在屏幕前"这个前提。
+ *
+ * 流程里唯一不可逆的伤害在最后一步：**验证通过后如果没拿到备用码就关掉，用户换手机时
+ * 就再也进不来了**。所以「已保存」不是一句提示，而是一道闸——没勾选就收不起这一节，
+ * 也不给关闭入口。宁可让人多点一下，也不能让人把自己锁在门外。
+ */
+export default function TotpSection({ user }: { user: ClerkUser }) {
+  const { t } = useTranslation();
+  const on = !!user.totpEnabled;
+
+  const [step, setStep] = useState<Step>('idle');
+  const [uri, setUri] = useState<string | null>(null);
+  const [secret, setSecret] = useState<string | null>(null);
+  const [code, setCode] = useState('');
+  const [codes, setCodes] = useState<string[]>([]);
+  const [saved, setSaved] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  // 二维码用已装的 `qrcode`（邀请海报刚引入），不为这一处再拉一个依赖。
+  useEffect(() => {
+    if (step !== 'scan' || !uri || !canvasRef.current) return;
+    void QRCode.toCanvas(canvasRef.current, uri, {
+      width: 168,
+      margin: 1,
+      color: { dark: '#0a0a0a', light: '#ffffff' },
+    });
+  }, [step, uri]);
+
+  const begin = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const totp = await user.createTOTP();
+      setUri(totp.uri ?? null);
+      setSecret(totp.secret ?? null);
+      setStep('scan');
+    } catch (err) {
+      setError(clerkErrorMessage(err, t));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const verify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (busy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await user.verifyTOTP({ code });
+      // 验证通过的下一件事必须是拿到备用码——中间不能有任何可退出的空档。
+      const backup = await user.createBackupCode();
+      setCodes(backup.codes ?? []);
+      setStep('codes');
+      setCode('');
+    } catch (err) {
+      setError(clerkErrorMessage(err, t));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const disable = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await user.disableTOTP();
+      setStep('idle');
+    } catch (err) {
+      setError(clerkErrorMessage(err, t));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const copyCodes = () => {
+    navigator.clipboard.writeText(codes.join('\n'));
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  };
+
+  const downloadCodes = () => {
+    const blob = new Blob([codes.join('\n')], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'magic-resume-backup-codes.txt';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const finish = () => {
+    setStep('idle');
+    setCodes([]);
+    setSaved(false);
+  };
+
+  return (
+    <div className="rounded-lg bg-white/[0.04] p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 items-center gap-2 text-[13px] text-neutral-100">
+          <ShieldCheck size={16} className="shrink-0 text-neutral-500" />
+          <span className="truncate">{t('account.security.totp.label')}</span>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span
+            className={cn(
+              'rounded px-1.5 py-0.5 text-[11px]',
+              on ? 'bg-emerald-500/15 text-emerald-300' : 'bg-white/[0.06] text-neutral-500'
+            )}
+          >
+            {t(on ? 'account.security.on' : 'account.security.off')}
+          </span>
+          {/* 展示备用码时不给任何退出口——这一步没有"取消"。 */}
+          {step !== 'codes' && (
+            <button
+              type="button"
+              onClick={() => {
+                if (step !== 'idle') return setStep('idle');
+                return on ? setStep('confirmDisable') : begin();
+              }}
+              disabled={busy}
+              className={cn(
+                'rounded px-2 py-1 text-[12px] transition-colors disabled:opacity-40 cursor-pointer',
+                on
+                  ? 'text-rose-300 hover:bg-rose-400/10'
+                  : 'text-sky-300 hover:bg-sky-400/10 hover:text-sky-200'
+              )}
+            >
+              {step !== 'idle'
+                ? t('account.security.cancel')
+                : t(on ? 'account.security.totp.disable' : 'account.security.totp.enable')}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {step === 'scan' && (
+        <form onSubmit={verify} className="mt-3 space-y-3 border-t border-white/[0.06] pt-3">
+          <p className="text-[12px] leading-relaxed text-neutral-400">
+            {t('account.security.totp.scanHint')}
+          </p>
+          <div className="flex items-start gap-3">
+            <canvas ref={canvasRef} className="shrink-0 rounded-lg bg-white p-1.5" />
+            <div className="min-w-0 flex-1 space-y-2">
+              {/* 相机不可用、或用桌面验证器的人需要手输，密钥必须给得出来。 */}
+              <div>
+                <span className="mb-1 block text-[11px] text-neutral-500">
+                  {t('account.security.totp.manualKey')}
+                </span>
+                <code className="block select-all break-all rounded bg-neutral-950/60 px-2 py-1 font-mono text-[11.5px] text-neutral-300">
+                  {secret}
+                </code>
+              </div>
+              <label className="block">
+                <span className="mb-1 block text-[11px] text-neutral-500">
+                  {t('account.security.totp.enterCode')}
+                </span>
+                <input
+                  value={code}
+                  onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  placeholder="000000"
+                  className="w-full rounded-lg border border-white/[0.08] bg-neutral-950/60 px-3 py-1.5 font-mono text-[14px] tracking-[0.3em] text-neutral-100 outline-none transition-colors focus:border-sky-400/40"
+                />
+              </label>
+            </div>
+          </div>
+          {error && <p className="text-[12px] text-rose-300">{error}</p>}
+          <button
+            type="submit"
+            disabled={busy || code.length !== 6}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-sky-500 px-3.5 py-1.5 text-[12.5px] font-semibold text-[#fff] transition-colors hover:bg-sky-400 disabled:opacity-40 cursor-pointer"
+          >
+            {busy && <Loader2 size={13} className="animate-spin" />}
+            {t('account.security.totp.verify')}
+          </button>
+        </form>
+      )}
+
+      {step === 'codes' && (
+        <div className="mt-3 space-y-3 border-t border-white/[0.06] pt-3">
+          <p className="text-[12px] font-medium leading-relaxed text-amber-200/90">
+            {t('account.security.totp.codesWarning')}
+          </p>
+          <div className="grid grid-cols-2 gap-1.5 rounded-lg bg-neutral-950/60 p-2.5 font-mono text-[12px] text-neutral-200">
+            {codes.map((c) => (
+              <span key={c} className="select-all">
+                {c}
+              </span>
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={copyCodes}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[12.5px] transition-colors cursor-pointer',
+                copied
+                  ? 'bg-emerald-500/15 text-emerald-300'
+                  : 'bg-white/[0.06] text-neutral-200 hover:bg-white/[0.1]'
+              )}
+            >
+              {copied ? <Check size={13} /> : <Copy size={13} />}
+              {t(copied ? 'account.security.totp.copied' : 'account.security.totp.copyAll')}
+            </button>
+            <button
+              type="button"
+              onClick={downloadCodes}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-white/[0.06] px-3 py-1.5 text-[12.5px] text-neutral-200 transition-colors hover:bg-white/[0.1] cursor-pointer"
+            >
+              <Download size={13} />
+              {t('account.security.totp.download')}
+            </button>
+          </div>
+          {/* 这道闸是硬的：没勾就没有出口。 */}
+          <label className="flex items-start gap-2 text-[12px] text-neutral-300">
+            <input
+              type="checkbox"
+              checked={saved}
+              onChange={(e) => setSaved(e.target.checked)}
+              className="mt-0.5 h-3.5 w-3.5 shrink-0 accent-sky-500"
+            />
+            {t('account.security.totp.confirmSaved')}
+          </label>
+          <button
+            type="button"
+            onClick={finish}
+            disabled={!saved}
+            className="inline-flex items-center rounded-lg bg-sky-500 px-3.5 py-1.5 text-[12.5px] font-semibold text-[#fff] transition-colors hover:bg-sky-400 disabled:opacity-40 cursor-pointer"
+          >
+            {t('account.security.done')}
+          </button>
+        </div>
+      )}
+
+      {step === 'confirmDisable' && (
+        <div className="mt-3 space-y-2 border-t border-white/[0.06] pt-3">
+          <p className="text-[12px] leading-relaxed text-neutral-400">
+            {t('account.security.totp.disableWarning')}
+          </p>
+          {error && <p className="text-[12px] text-rose-300">{error}</p>}
+          <button
+            type="button"
+            onClick={disable}
+            disabled={busy}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-rose-500/90 px-3.5 py-1.5 text-[12.5px] font-semibold text-[#fff] transition-colors hover:bg-rose-500 disabled:opacity-40 cursor-pointer"
+          >
+            {busy && <Loader2 size={13} className="animate-spin" />}
+            {t('account.security.totp.confirmDisable')}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/account/security/clerkError.ts
+++ b/apps/web/src/components/account/security/clerkError.ts
@@ -1,0 +1,36 @@
+/**
+ * Clerk 的报错 → 用户看得懂的话。
+ *
+ * Clerk 回的是英文 `ClerkAPIError`（`{ code, message, longMessage }`）。整段丢给中文
+ * 用户等于没报错——尤其"密码强度不够"和"旧密码不对"这两种，用户必须知道是哪一种才知道
+ * 下一步做什么。
+ *
+ * **只映射有把握的那几条，其余回退到 Clerk 自己的 longMessage。** 穷举错误码是做不完
+ * 的，而映射错比不映射更糟：把"验证码过期"说成"验证码错误"，用户会一直重输同一个码。
+ */
+type ClerkLikeError = {
+  errors?: { code?: string; message?: string; longMessage?: string }[];
+};
+
+const KNOWN: Record<string, string> = {
+  form_password_incorrect: 'account.security.errors.passwordIncorrect',
+  form_password_pwned: 'account.security.errors.passwordPwned',
+  form_password_length_too_short: 'account.security.errors.passwordTooShort',
+  form_password_validation_failed: 'account.security.errors.passwordWeak',
+  form_code_incorrect: 'account.security.errors.codeIncorrect',
+  verification_expired: 'account.security.errors.codeExpired',
+  form_param_format_invalid: 'account.security.errors.codeIncorrect',
+};
+
+export function clerkErrorMessage(
+  err: unknown,
+  t: (key: string) => string
+): string {
+  const first = (err as ClerkLikeError)?.errors?.[0];
+  if (!first) {
+    return err instanceof Error ? err.message : t('account.security.errors.unknown');
+  }
+  const key = first.code ? KNOWN[first.code] : undefined;
+  // 回退顺序：已知映射 → Clerk 的完整说明 → 简短消息 → 兜底。
+  return key ? t(key) : first.longMessage || first.message || t('account.security.errors.unknown');
+}

--- a/apps/web/src/components/llm/ProviderMark.tsx
+++ b/apps/web/src/components/llm/ProviderMark.tsx
@@ -21,7 +21,38 @@ export function ProviderMark({
   size?: number;
   className?: string;
 }) {
-  const mask = `url(/providers/${provider.id}.svg) center / contain no-repeat`;
+  return (
+    <BrandMark
+      file={provider.id}
+      // 单色品牌（OpenAI / xAI / Kimi / OpenRouter）的真实 logo 是纯黑或纯白，
+      // 钉死任何一个都会在另一个主题下消失。跟随 currentColor 让它自动翻面。
+      color={provider.monochrome ? 'currentColor' : provider.brandColor}
+      size={size}
+      className={className}
+    />
+  );
+}
+
+/**
+ * 渲染 `/public/providers/{file}.svg` 的那一层，不认识任何业务类型。
+ *
+ * 抽出来是因为社交账户（GitHub / Google）要用同一套渲染规则，而它拿到的是 Clerk 的
+ * provider 字符串，不是 `ModelProvider`。两处共用一个实现，图标与配色规则才不会分叉。
+ */
+export function BrandMark({
+  file,
+  color,
+  size = 16,
+  className,
+}: {
+  /** `/public/providers/{file}.svg` 里的文件名（不含扩展名） */
+  file: string;
+  /** 任意 CSS 颜色；`currentColor` 表示跟随文字色 */
+  color: string;
+  size?: number;
+  className?: string;
+}) {
+  const mask = `url(/providers/${file}.svg) center / contain no-repeat`;
   return (
     <span
       aria-hidden="true"
@@ -29,9 +60,7 @@ export function ProviderMark({
       style={{
         width: size,
         height: size,
-        // 单色品牌（OpenAI / xAI / Kimi / OpenRouter）的真实 logo 是纯黑或纯白，
-        // 钉死任何一个都会在另一个主题下消失。跟随 currentColor 让它自动翻面。
-        backgroundColor: provider.monochrome ? 'currentColor' : provider.brandColor,
+        backgroundColor: color,
         mask,
         WebkitMask: mask,
       }}

--- a/apps/web/src/lib/auth/AccountModal.tsx
+++ b/apps/web/src/lib/auth/AccountModal.tsx
@@ -1,9 +1,14 @@
 'use client';
 
-// Cloud-only. Our own dark, READ-ONLY account panel — modelled on the admin
-// UserDetailsModal (资料/安全/活动 + side rail) but rebuilt in our tokens and fed
-// purely from Clerk's client `useUser()` + the app's own resume store (no backend,
-// no embedded Clerk <UserProfile>). Clerk imports stay inside lib/auth.
+// Cloud-only. Our own dark account panel — modelled on the admin UserDetailsModal
+// (资料/安全/活动 + side rail) but rebuilt in our tokens and fed from Clerk's client
+// `useUser()` + the app's own resume store (no backend, no embedded Clerk
+// <UserProfile>). Clerk imports stay inside lib/auth.
+//
+// 除「安全」外全部只读。安全那一节可写是刻意的例外：用户看得见自己没开 2FA、却没有
+// 任何地方能开，等于把一个安全缺口摆着不给补。写操作直接调客户端 SDK 的方法——不经
+// 我们的后端，因为 Clerk Backend API 改密码时不校验旧密码（会话被劫持即可静默改密），
+// 而 TOTP 绑定后端根本做不了（它只能 disable，不能 create）。
 
 import React, { useMemo, useState } from 'react';
 import { useUser } from '@clerk/nextjs';
@@ -13,10 +18,6 @@ import {
   Check,
   Copy,
   FileText,
-  KeyRound,
-  Lock,
-  ShieldAlert,
-  ShieldCheck,
 } from 'lucide-react';
 import { isCloudMode } from '@/lib/config/app';
 import { ModalShell } from '@/components/ui/ModalShell';
@@ -27,10 +28,21 @@ import { BillingTab } from '@/components/account/billing/BillingTab';
 import InviteTab from '@/components/account/invite/InviteTab';
 import type { Entitlement } from '@/lib/billing/types';
 import { cn } from '@/lib/utils';
+import { BrandMark } from '@/components/llm/ProviderMark';
+import PasswordSection from '@/components/account/security/PasswordSection';
+import TotpSection from '@/components/account/security/TotpSection';
 
-const PROVIDERS: Record<string, { name: string; color: string }> = {
-  google: { name: 'Google', color: '#ea4335' },
-  github: { name: 'GitHub', color: '#8b949e' },
+/**
+ * `mark` = `/public/providers/{mark}-mono.svg` 的文件名前缀；没有 mark 的档位回退到
+ * 一颗品牌色圆点（即此前所有 provider 的样子）。
+ *
+ * 刻意**不给每家都补图标**：仓里现在只有 GitHub 与 Google 两个单色标，而 Clerk 还可能
+ * 回传 Apple、微信等。缺图时退回色点，是为了让这件事"锦上添花"而不是"全有或全无"——
+ * 硬指一个不存在的 SVG 只会得到一个看不见的方块，比色点更糟。
+ */
+const PROVIDERS: Record<string, { name: string; color: string; mark?: string }> = {
+  google: { name: 'Google', color: '#ea4335', mark: 'google-mono' },
+  github: { name: 'GitHub', color: '#8b949e', mark: 'github-mono' },
   gitlab: { name: 'GitLab', color: '#fc6d26' },
   discord: { name: 'Discord', color: '#5865f2' },
   apple: { name: 'Apple', color: '#a1a1aa' },
@@ -260,7 +272,14 @@ function CloudAccountModal() {
                               key={a.id}
                               className={cn('flex flex-wrap items-center gap-2 py-2', i > 0 && 'border-t border-white/[0.04]')}
                             >
-                              <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: p.color }} />
+                              {p.mark ? (
+                                <BrandMark file={p.mark} color={p.color} size={15} />
+                              ) : (
+                                <span
+                                  className="h-1.5 w-1.5 shrink-0 rounded-full"
+                                  style={{ backgroundColor: p.color }}
+                                />
+                              )}
                               <span className="text-[13px] font-medium text-neutral-100">{p.name}</span>
                               {a.label && <span className="truncate text-[12px] text-neutral-500">{a.label}</span>}
                               {a.verified && <Badge tone="emerald">{t('account.profile.verified')}</Badge>}
@@ -285,11 +304,12 @@ function CloudAccountModal() {
 
                 {accountTab === 'security' && (
                   <Section title={t('account.profile.security')}>
-                    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                      <SecurityItem icon={<KeyRound size={16} />} label={t('account.profile.password')} on={!!user.passwordEnabled} t={t} />
-                      <SecurityItem icon={<ShieldCheck size={16} />} label={t('account.profile.twoFactor')} on={!!user.twoFactorEnabled} t={t} />
-                      <SecurityItem icon={<Lock size={16} />} label={t('account.profile.totp')} on={!!user.totpEnabled} t={t} />
-                      <SecurityItem icon={<ShieldAlert size={16} />} label={t('account.profile.backupCodes')} on={!!user.backupCodeEnabled} t={t} />
+                    {/* 四张只读徽章换成两块可操作的：密码与两步验证。原来的 TOTP 与
+                        备用码不再单列——它们不是并列的第三、第四项开关，而是开启两步
+                        验证这一件事的两个环节，拆成四张卡只会让人以为要分别去开。 */}
+                    <div className="space-y-2.5">
+                      <PasswordSection user={user} />
+                      <TotpSection user={user} />
                     </div>
                   </Section>
                 )}
@@ -375,29 +395,6 @@ function Field({ label, value }: { label: string; value?: string | null }) {
   );
 }
 
-function SecurityItem({
-  icon,
-  label,
-  on,
-  t,
-}: {
-  icon: React.ReactNode;
-  label: string;
-  on: boolean;
-  t: (k: string) => string;
-}) {
-  return (
-    <div className="flex items-center justify-between rounded-md bg-white/[0.04] p-3">
-      <div className="flex items-center gap-2 text-[13px] text-neutral-100">
-        <span className="text-neutral-500">{icon}</span>
-        {label}
-      </div>
-      <Badge tone={on ? 'emerald' : 'neutral'}>
-        {on ? t('account.profile.enabled') : t('account.profile.disabled')}
-      </Badge>
-    </div>
-  );
-}
 
 function Stat({ label, value }: { label: string; value: React.ReactNode }) {
   return (

--- a/apps/web/src/lib/extensions/app-lifecycle.ts
+++ b/apps/web/src/lib/extensions/app-lifecycle.ts
@@ -1,6 +1,13 @@
 import type { FileSizeBucket } from '@/lib/utils/fileSize';
 
-export type ResumeImportSource = 'json' | 'pdf';
+/**
+ * 导入来源。四种走 LLM 解析的格式各占一个值，而不是并成一个 'document'——
+ * 「Word 用户占多少」和「有多少人是直接传截图的」是两个会导向不同产品决策的问题，
+ * 合并之后就再也分不出来了。
+ *
+ * 'pdf' 与 'json' 是既有值，语义未变：只增不改，历史指标不会从中间断掉。
+ */
+export type ResumeImportSource = 'json' | 'pdf' | 'image' | 'docx' | 'markdown';
 
 export type ResumeImportCompletedPayload = {
   source: ResumeImportSource;

--- a/apps/web/src/lib/utils/pdf-export.ts
+++ b/apps/web/src/lib/utils/pdf-export.ts
@@ -118,11 +118,32 @@ export const exportResumeToPdf = async (resume: Resume, locale?: string): Promis
 };
 
 /**
- * 图片导出的渲染倍率。2 倍够在高分屏与微信里都不糊，再往上文件体积涨得比清晰度快。
+ * 图片导出的渲染倍率——**按画布预算自适应，不是一个常数**。
+ *
+ * 渲染源是 PDF（矢量），所以"更清晰"的正确做法是用更高的倍率**重新渲染**，而不是把
+ * 已经栅格化的图再放大：插值加不出细节，只会更糊。
+ *
+ * 但倍率不能一味调高。简历导出的 PDF 是**一页连续长图**（见 resume-templates 的
+ * MagicResumePdfDocument），简历越长那一页越高，而浏览器对 canvas 有硬上限——撞上去
+ * 不会报错，会静默得到一张空白图。所以先按目标倍率算出尺寸，超预算就等比降档：
+ * 短简历吃满 3 倍，长简历自动退到还能安全渲染的那个值。
  */
-const IMAGE_SCALE = 2;
+const IMAGE_TARGET_SCALE = 3;
+/** 降档下限。低于这个宁可让它超限失败，也别交出一张糊到读不出字的图。 */
+const IMAGE_MIN_SCALE = 1.5;
+/** 单边上限：Chrome / Firefox 的 canvas 边长上限。 */
+const MAX_CANVAS_SIDE = 16384;
+/** 面积上限取 2^24 —— iOS Safari 的文档值，是各家里最紧的那个，按它兜底最安全。 */
+const MAX_CANVAS_AREA = 16_777_216;
 /** 多页拼接时页与页之间的分隔缝，画成纸张之间的留白。 */
 const IMAGE_PAGE_GAP = 24;
+
+/** 在画布预算内能取到的最大倍率。 */
+function fitScale(naturalWidth: number, naturalHeight: number): number {
+  const byArea = Math.sqrt(MAX_CANVAS_AREA / (naturalWidth * naturalHeight));
+  const bySide = Math.min(MAX_CANVAS_SIDE / naturalWidth, MAX_CANVAS_SIDE / naturalHeight);
+  return Math.max(IMAGE_MIN_SCALE, Math.min(IMAGE_TARGET_SCALE, byArea, bySide));
+}
 
 /**
  * 简历导出成一张长图。
@@ -149,11 +170,22 @@ export const exportResumeToImage = async (resume: Resume, locale?: string): Prom
   const doc = await loadingTask.promise;
   try {
     // 先量后画：拼接画布的尺寸要在渲染前定下来，否则得为每页各留一张离屏画布。
-    const viewports = [];
+    //
+    // 量两遍：第一遍取 1:1 的自然尺寸，算出这份文档能吃多大的倍率；第二遍才按那个
+    // 倍率取真正用于渲染的 viewport。
+    const pages = [];
     for (let i = 1; i <= doc.numPages; i += 1) {
-      const page = await doc.getPage(i);
-      viewports.push({ page, viewport: page.getViewport({ scale: IMAGE_SCALE }) });
+      pages.push(await doc.getPage(i));
     }
+    const natural = pages.map((page) => page.getViewport({ scale: 1 }));
+    const scale = fitScale(
+      Math.max(...natural.map((v) => v.width)),
+      natural.reduce((sum, v) => sum + v.height, 0) + IMAGE_PAGE_GAP * (pages.length - 1)
+    );
+    const viewports = pages.map((page) => ({
+      page,
+      viewport: page.getViewport({ scale }),
+    }));
     const width = Math.max(...viewports.map((v) => v.viewport.width));
     const height =
       viewports.reduce((sum, v) => sum + v.viewport.height, 0) +

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -1300,9 +1300,9 @@
     },
     "types": {
       "pdf": "PDF",
-      "image": "Image (screenshot / photo)",
-      "docx": "Word document",
-      "markdown": "Markdown / plain text"
+      "image": "Image",
+      "docx": "Word",
+      "markdown": "Markdown"
     }
   },
   "agentErrors": {

--- a/apps/web/src/locales/en/translation.json
+++ b/apps/web/src/locales/en/translation.json
@@ -205,7 +205,9 @@
         "wechat": "WeChat Pay",
         "stripe": "Stripe",
         "manual": "Manual"
-      }
+      },
+      "colOrderId": "Order ID",
+      "copyOrderId": "Copy full order ID"
     },
     "invite": {
       "copied": "Copied",
@@ -221,6 +223,48 @@
       "headerAction": "Invite friends",
       "emptyHint": "Send the poster or link to a friend who's job hunting — you both get extra AI allowance, and they get a head start.",
       "remaining": "{{count}} more rewards available"
+    },
+    "security": {
+      "on": "On",
+      "off": "Off",
+      "cancel": "Cancel",
+      "save": "Save",
+      "done": "Done",
+      "password": {
+        "label": "Password",
+        "set": "Set up",
+        "change": "Change",
+        "current": "Current password",
+        "new": "New password",
+        "confirm": "Confirm new password",
+        "mismatch": "The two new passwords do not match.",
+        "signOutNotice": "Changing it signs you out on your other devices."
+      },
+      "totp": {
+        "label": "Two-step verification",
+        "enable": "Enable",
+        "disable": "Disable",
+        "scanHint": "Scan the QR code with an authenticator app (Google Authenticator, 1Password…), or enter the key below manually.",
+        "manualKey": "Manual entry key",
+        "enterCode": "Enter the 6-digit code",
+        "verify": "Verify and enable",
+        "codesWarning": "Save these backup codes now. They are shown only once — if you lose your phone, this is your only way back in.",
+        "copyAll": "Copy all",
+        "copied": "Copied",
+        "download": "Download as file",
+        "confirmSaved": "I have saved these backup codes",
+        "disableWarning": "Once disabled, signing in needs only your password. Existing backup codes stop working.",
+        "confirmDisable": "Confirm disable"
+      },
+      "errors": {
+        "passwordIncorrect": "That current password is not correct.",
+        "passwordPwned": "This password has appeared in a data breach. Please choose another.",
+        "passwordTooShort": "That password is too short.",
+        "passwordWeak": "That password is too weak — mix upper and lower case, numbers and symbols.",
+        "codeIncorrect": "That code is not correct. Check the number currently shown in your authenticator.",
+        "codeExpired": "That code has expired. Enter the current one from your authenticator.",
+        "unknown": "Something went wrong. Please try again."
+      }
     }
   },
   "notificationsPage": {
@@ -1254,7 +1298,12 @@
       "pageUnit": "{{count}} page(s)",
       "warningsTitle": "A few things I wasn't sure about"
     },
-    "documentOption": "Resume file (PDF / Word / image / Markdown)"
+    "types": {
+      "pdf": "PDF",
+      "image": "Image (screenshot / photo)",
+      "docx": "Word document",
+      "markdown": "Markdown / plain text"
+    }
   },
   "agentErrors": {
     "agent_run_failed": "The parse did not finish. Try again; if it keeps failing, try another PDF or check your model settings.",

--- a/apps/web/src/locales/zh/translation.json
+++ b/apps/web/src/locales/zh/translation.json
@@ -205,7 +205,9 @@
         "wechat": "微信支付",
         "stripe": "Stripe",
         "manual": "人工"
-      }
+      },
+      "colOrderId": "账单 ID",
+      "copyOrderId": "复制完整账单 ID"
     },
     "invite": {
       "copied": "已复制",
@@ -221,6 +223,48 @@
       "headerAction": "邀请好友",
       "emptyHint": "把海报或链接发给正在找工作的朋友——你们都会多一份 AI 额度，他也少走点弯路。",
       "remaining": "本月还可获得 {{count}} 次奖励"
+    },
+    "security": {
+      "on": "已启用",
+      "off": "未启用",
+      "cancel": "取消",
+      "save": "保存",
+      "done": "完成",
+      "password": {
+        "label": "密码登录",
+        "set": "设置",
+        "change": "修改",
+        "current": "当前密码",
+        "new": "新密码",
+        "confirm": "确认新密码",
+        "mismatch": "两次输入的新密码不一致。",
+        "signOutNotice": "修改后，你在其它设备上的登录会被退出。"
+      },
+      "totp": {
+        "label": "两步验证",
+        "enable": "开启",
+        "disable": "关闭",
+        "scanHint": "用 Google Authenticator、1Password 等验证器扫描二维码，或手动输入下方密钥。",
+        "manualKey": "手动输入密钥",
+        "enterCode": "输入验证器上的 6 位数字",
+        "verify": "验证并开启",
+        "codesWarning": "请立即保存这些备用码。它们只显示这一次——手机丢失时，这是你唯一的登录方式。",
+        "copyAll": "复制全部",
+        "copied": "已复制",
+        "download": "下载为文件",
+        "confirmSaved": "我已保存好这些备用码",
+        "disableWarning": "关闭后，登录将只需要密码，安全性会下降。已有的备用码同时失效。",
+        "confirmDisable": "确认关闭"
+      },
+      "errors": {
+        "passwordIncorrect": "当前密码不正确。",
+        "passwordPwned": "这个密码曾在数据泄露中出现过，请换一个。",
+        "passwordTooShort": "密码太短了，请设置更长的密码。",
+        "passwordWeak": "密码强度不够，建议混合大小写字母、数字与符号。",
+        "codeIncorrect": "验证码不正确，请检查验证器上当前显示的数字。",
+        "codeExpired": "验证码已过期，请输入验证器上最新的数字。",
+        "unknown": "操作失败，请稍后重试。"
+      }
     }
   },
   "notificationsPage": {
@@ -1254,7 +1298,12 @@
       "pageUnit": "{{count}} 页",
       "warningsTitle": "有几处我拿不准"
     },
-    "documentOption": "简历文件（PDF / Word / 图片 / Markdown）"
+    "types": {
+      "pdf": "PDF",
+      "image": "图片（截图 / 照片）",
+      "docx": "Word 文档",
+      "markdown": "Markdown / 纯文本"
+    }
   },
   "agentErrors": {
     "agent_run_failed": "解析没能完成，请稍后重试；如果反复失败，换一份 PDF 或检查大模型配置。",

--- a/apps/web/src/locales/zh/translation.json
+++ b/apps/web/src/locales/zh/translation.json
@@ -1300,9 +1300,9 @@
     },
     "types": {
       "pdf": "PDF",
-      "image": "图片（截图 / 照片）",
-      "docx": "Word 文档",
-      "markdown": "Markdown / 纯文本"
+      "image": "图片",
+      "docx": "Word",
+      "markdown": "Markdown"
     }
   },
   "agentErrors": {


### PR DESCRIPTION
> **叠在 #192 上**（base 是 `feat/export-formats`，两者都改 `AccountModal.tsx` 与导出链路）。#192 合并后 GitHub 会自动把 base 改成 `release-2026-08-10`。

## 1. 安全设置从只读变成可写

这**推翻了一条既有决定**——`AccountModal.tsx` 文件头明写「Our own dark, **READ-ONLY** account panel … no embedded Clerk `<UserProfile>`」。但只推翻安全这一节，其余维持只读，文件头注释已同步改写并说明理由：用户看得见自己没开 2FA、却没有任何地方能开，等于把一个安全缺口摆着不给补。

**写操作直接调客户端 SDK，不经我们的后端。** 这不是图省事：

- Clerk Backend API 的 `updateUser({ password })` **不校验旧密码**——谁拿到一个被劫持的会话，谁就能静默改掉密码把机主锁在门外。客户端的 `updatePassword` 强制校验，还顺带给了 `signOutOfOtherSessions`。
- TOTP 绑定后端**根本做不了**：Backend SDK 上只有 `deleteUserTOTP` / `disableUserMFA`，没有 create。绑定天然要把密钥展示给当前登录的这个人再让他回证，后端拿不到"这个人此刻在屏幕前"这个前提。

四张只读徽章收成两块：密码、两步验证。TOTP 与备用码不再单列——它们不是并列的第三、第四个开关，而是开启两步验证这**一件事**的两个环节，拆成四张卡只会让人以为要分别去开。

### 备用码是硬闸，不是提示

验证通过后立刻 `createBackupCode()` 并展示，**未勾选「已保存」就不给任何出口**（连取消按钮都不渲染）。这是整个流程里唯一不可逆的伤害：没拿到备用码就关掉，换手机时就再也进不来。

Clerk 的英文报错单独一层映射（`clerkError.ts`），**只映射有把握的几条**，其余回退到它自己的 `longMessage`——把「验证码过期」错说成「验证码错误」会让用户一直重输同一个码，比不映射更糟。

## 2. 导入四种格式分列，各标 AI

合成一行读着简洁，代价是"支持哪些格式"变成要读完小字才知道的事，而"原来 Word 也能导"恰恰最该被看见。

埋点的 `ResumeImportSource` 相应扩成五个值：「Word 用户占多少」和「多少人直接传截图」会导向不同的产品决策，并成一个就再也分不出来了。**只增不改**，历史指标不断。

## 3. 导出入口统一

`EditorDock` 此前还在直接下 PDF，而 `Tools` 已经改成弹窗。两处接上同一个弹窗，并把两处几乎相同的 30 行（toast / 埋点 / 错误处理，只差一个 `source` 字段）抽成 `useResumeExport`——加格式选择时若照旧复制一遍，就成了三份要同步维护的实现。

## 4. 两个 bug

**弹窗被挤成窄缝还跟着缩放**：`ExportModal` 用 `position: fixed`，而 `EditorDock` 外层是 framer 的 `motion.div`——祖先一旦有 transform，`fixed` 就不再相对视口而是相对那个盒子。改用 `createPortal` 到 body，让它不管被谁挂载都成立。

**长简历导出空白图（既有 bug，此前未被发现）**：图片导出原本固定 2 倍，而简历 PDF 是一页连续长图，12 页 = 24.1MP、20 页 = 40.1MP，**都超过 iOS Safari 的 16.7MP canvas 上限**——撞上去不报错，静默返回空白图。

改成先按 1:1 量出自然尺寸、再算预算内能吃的最大倍率。顺带解决了"图片模糊"：

| 页数 | 旧 | 新 | 横向像素 |
|---|---|---|---|
| 1–3 页（绝大多数） | 2.00× | **3.00×** | 1191 → 1786 |
| 5 页 | 2.00× | 2.59× | |
| 12 页 | 2.00×（会空白） | 1.62× | |

> 顺带一提：「超分」这条路走不通——已栅格化的图再放大加不出细节。渲染源是矢量 PDF，用更高倍率**重新渲染**才是真的变清晰。

## 5. 账单 ID 与社交图标

付款记录加账单 ID 列：屏幕给末 8 位（等宽），点击复制完整串——这两件事受众不同，屏幕上要的是"区分开同一天的六笔"，发给客服要的是"能粘贴的完整串"。

社交账户用上仓里**已有的** `github-mono.svg` / `google-mono.svg`，从 `ProviderMark` 抽出与业务类型无关的 `BrandMark` 两处共用。缺图标的 provider（Apple、微信…）**回退到原来的品牌色圆点**而不是显示破图——让这件事是"锦上添花"而非"全有或全无"。

## 验证

`tsc --noEmit` / `eslint` / `pnpm i18n:check` 全绿；pre-commit 全量 lint+build 通过。

⚠️ **密码与 TOTP 无法在开发机上自动验证**，需要真实 Clerk 账号手测，建议先用测试号：

1. OAuth 注册的号（`passwordEnabled === false`）→ 表单应只要新密码 → 提交后其它设备被登出
2. 改密码时旧密码填错 → 应给出中文报错而非英文原文
3. TOTP：扫码 → 故意输错一次 → 输对 → **确认此时收不起面板** → 备用码可复制/下载 → 勾选后才能收起
4. 关 2FA → 两张卡回到未启用

🤖 Generated with [Claude Code](https://claude.com/claude-code)